### PR TITLE
feat(catalog-access): add Delta Sharing Catalog Integration

### DIFF
--- a/catalog-access/delta-common/pom.xml
+++ b/catalog-access/delta-common/pom.xml
@@ -16,7 +16,7 @@
     <relativePath>../..</relativePath>
   </parent>
 
-  <artifactId>floecat-catalog-access-unity</artifactId>
+  <artifactId>floecat-catalog-access-delta-common</artifactId>
 
   <dependencies>
     <dependency>
@@ -25,19 +25,8 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>ai.floedb.floecat</groupId>
-      <artifactId>floecat-http-endpoint-guards</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>ai.floedb.floecat</groupId>
-      <artifactId>floecat-unity-catalog-client</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>ai.floedb.floecat</groupId>
-      <artifactId>floecat-catalog-access-delta-common</artifactId>
-      <version>${project.version}</version>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>s3</artifactId>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/catalog-access/delta-common/src/main/java/ai/floedb/floecat/catalog/delta/DeltaLogStorageProbe.java
+++ b/catalog-access/delta-common/src/main/java/ai/floedb/floecat/catalog/delta/DeltaLogStorageProbe.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+package ai.floedb.floecat.catalog.delta;
+
+import ai.floedb.floecat.catalog.access.VendedStorageCredentials;
+import java.util.Locale;
+import java.util.Objects;
+
+@FunctionalInterface
+public interface DeltaLogStorageProbe {
+
+  void validate(String tableLocation, VendedStorageCredentials credentials);
+
+  /**
+   * Whether the S3 probe can address this location at all.
+   *
+   * <p>Part of the contract rather than an internal: a provider that vends AWS credentials needs to
+   * know before it reconciles a table whether the location it was given is one this can read. An
+   * {@code abfss://} or {@code gs://} table would otherwise load, reconcile, and fail at every
+   * scan.
+   */
+  static boolean s3Serves(String tableLocation) {
+    return S3DeltaLogProbe.s3Location(tableLocation) != null;
+  }
+
+  /**
+   * The form of a location a provider should publish, vend and compare.
+   *
+   * <p>An S3 object key may hold a space and {@code java.net.URI} may not. This probe encodes one
+   * before parsing, so it answers for {@code s3://bucket/db/my table} -- and a provider that then
+   * publishes the raw string reconciles a table the read path cannot open, because that path calls
+   * {@code URI.create} on the location at every site. Before the probe accepted such a location it
+   * was refused outright, which was at least a recorded failure; accepting it on one side without
+   * canonicalising on the other turns that into a table that validates clean and fails every scan.
+   *
+   * <p>Here rather than in either provider because both need the same answer, which is the reason
+   * this module exists. Encoded rather than refused because the read path derives its key with
+   * {@code URI.getPath}, which decodes, so S3 is asked for the key that was written. Idempotent,
+   * since only a literal space is replaced: a location that already carries {@code %20} is
+   * unchanged and nothing is double-encoded.
+   *
+   * <p>Other characters {@code URI} rejects and S3 permits are still refused by {@link #s3Serves}.
+   * A space is the one that occurs.
+   */
+  static String canonicalLocation(String tableLocation) {
+    if (tableLocation == null) {
+      return null;
+    }
+    // The scheme too, not only the space. s3Serves accepts s3, s3a and s3n in any case, while the
+    // reader's resolvePath matches a literal lowercase s3:// or s3a:// and throws on anything
+    // else -- so publishing the spelling the server used meant s3n://bucket/table and
+    // S3://bucket/table validated, reconciled, and failed every scan on an unsupported path.
+    // Servability and publication have to agree about what a location is, and the reader decides.
+    // No trim. An S3 object key may end in a space, and the probe does not trim either -- so
+    // trimming here published a different prefix from the one validation had just read, which is
+    // the divergence this method exists to prevent. Whatever the server sent is the key; the only
+    // changes made to it are the ones the reader requires.
+    return publishableScheme(tableLocation).replace(" ", "%20");
+  }
+
+  /**
+   * The scheme folded only where the reader cannot parse it.
+   *
+   * <p>{@code StorageLocations.normalizeScheme} folds s3, s3a and s3n alike, and folding everything
+   * to s3 put the stored location in a different scheme namespace from the prefix an operator
+   * registers: {@code StorageAuthorityResolver.matchesLocationPrefix} is a scheme-sensitive {@code
+   * startsWith}, and {@code S3Location.parse} explicitly accepts an {@code s3a://} authority prefix
+   * -- so a catalog reporting s3a, an authority registered as s3a, and a location stored as s3
+   * never match.
+   *
+   * <p>So only the spellings the reader genuinely cannot read are changed: {@code s3n} and any
+   * uppercase form, since {@code S3V2FileSystemClient.resolvePath} matches a literal lowercase
+   * {@code s3://} or {@code s3a://}. What the source reported is otherwise what gets stored.
+   */
+  private static String publishableScheme(String location) {
+    int schemeEnd = location.indexOf("://");
+    if (schemeEnd < 0) {
+      return location;
+    }
+    String scheme = location.substring(0, schemeEnd).toLowerCase(Locale.ROOT);
+    if ("s3a".equals(scheme)) {
+      return scheme + location.substring(schemeEnd);
+    }
+    return "s3".equals(scheme) || "s3n".equals(scheme)
+        ? "s3" + location.substring(schemeEnd)
+        : location;
+  }
+
+  /**
+   * A probe that lists and reads one object under the table's Delta log with the vended
+   * credentials.
+   *
+   * <p>Listing alone would pass on a grant that cannot read, so the probe reads a byte. What it
+   * proves is that the credential the provider vended actually reaches the storage it named, which
+   * is the question a validation run is asking on the operator's behalf.
+   *
+   * @param subject how the catalog is named in a refusal, such as {@code "Unity Catalog"}
+   */
+  static DeltaLogStorageProbe s3(String subject) {
+    Objects.requireNonNull(subject, "subject");
+    return (tableLocation, credentials) ->
+        S3DeltaLogProbe.validate(subject, tableLocation, credentials);
+  }
+}

--- a/catalog-access/delta-common/src/main/java/ai/floedb/floecat/catalog/delta/S3DeltaLogProbe.java
+++ b/catalog-access/delta-common/src/main/java/ai/floedb/floecat/catalog/delta/S3DeltaLogProbe.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  */
 
-package ai.floedb.floecat.catalog.unity;
+package ai.floedb.floecat.catalog.delta;
 
 import ai.floedb.floecat.catalog.access.CatalogAccessException;
 import ai.floedb.floecat.catalog.access.StorageLocations;
@@ -33,35 +33,30 @@ import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 
-@FunctionalInterface
-interface UnityStorageAccessValidator {
+final class S3DeltaLogProbe {
 
-  /** Implicitly public static final: this interface is package-private, so the constant is too. */
-  String DELTA_LOG_DIR = "_delta_log/";
+  private S3DeltaLogProbe() {}
 
-  void validate(String tableLocation, VendedStorageCredentials credentials);
+  private static final String DELTA_LOG_DIR = "_delta_log/";
 
-  static UnityStorageAccessValidator s3() {
-    return UnityStorageAccessValidator::validateS3;
-  }
-
-  private static void validateS3(String tableLocation, VendedStorageCredentials credentials) {
+  static void validate(String subject, String tableLocation, VendedStorageCredentials credentials) {
     // Parsed once, and inside the guard. Doing it here unguarded put an IllegalArgumentException
     // ahead of the check meant to catch it: an object key holding a character URI rejects -- a
-    // space is the common one -- threw before s3Location could answer, and UnityCatalogErrors
-    // mapped it to "storage access validation configuration is invalid", which describes neither
-    // the location nor anything an operator configured.
+    // space is the common one -- threw before s3Location could answer, and the caller mapped it
+    // to "storage access validation configuration is invalid", which describes neither the
+    // location nor anything an operator configured.
     URI location = s3Location(tableLocation);
     if (location == null) {
       throw new CatalogAccessException(
           CatalogAccessException.Code.UNSUPPORTED,
-          "Unity Catalog storage validation needs an addressable S3 location, and could not read"
-              + " a bucket from this one");
+          subject
+              + " storage validation needs an addressable S3 location, and could not read a"
+              + " bucket from this one");
     }
     String bucketName = bucketOf(location);
     Map<String, String> properties = credentials.properties();
-    String accessKey = required(properties, "s3.access-key-id");
-    String secretKey = required(properties, "s3.secret-access-key");
+    String accessKey = required(subject, properties, "s3.access-key-id");
+    String secretKey = required(subject, properties, "s3.secret-access-key");
     String sessionToken = nonBlank(properties.get("s3.session-token"));
     AwsCredentials awsCredentials =
         sessionToken == null
@@ -83,10 +78,10 @@ interface UnityStorageAccessValidator {
       builder.endpointOverride(URI.create(endpoint));
     }
 
-    // The bucket named in the object URI, never s3.access-point. SourceCatalogCredentialVendor
-    // strips that key before any reader sees it -- noteIgnoredAccessPoint records why -- so probing
-    // the access point would validate an endpoint no scan ever addresses, and a grant scoped to it
-    // alone would report success against reads that all get 403.
+    // The bucket named in the object URI, never s3.access-point. The vend strips that key before
+    // any reader sees it, so probing the access point would validate an endpoint no scan ever
+    // addresses, and a grant scoped to it alone would report success against reads that all get
+    // 403.
     String bucket = bucketName;
     String logPrefix = deltaLogPrefix(location.getPath());
     try (S3Client s3 = builder.build()) {
@@ -95,8 +90,8 @@ interface UnityStorageAccessValidator {
               ListObjectsV2Request.builder().bucket(bucket).prefix(logPrefix).maxKeys(1).build());
       if (listing.contents().isEmpty()) {
         throw new CatalogAccessException(
-            CatalogAccessException.Code.UNSUPPORTED,
-            "Unity Catalog table storage contains no Delta log object to validate");
+            CatalogAccessException.Code.INVALID_CONFIGURATION,
+            subject + " table storage contains no Delta log object to validate");
       }
       try {
         // Streamed and aborted, not buffered. Range is a request hint: an S3-compatible endpoint
@@ -136,29 +131,27 @@ interface UnityStorageAccessValidator {
           failure.awsErrorDetails() == null ? null : failure.awsErrorDetails().errorCode();
       throw new CatalogAccessException(
           storageFailureCode(errorCode, failure.statusCode()),
-          "Unity Catalog storage validation failed",
+          subject + " storage validation failed",
           failure);
     } catch (java.io.IOException failure) {
       // Reading or releasing the probe body: a fact about reaching the store, like the transport
       // failures below it, not about the credential.
       throw new CatalogAccessException(
           CatalogAccessException.Code.UNAVAILABLE,
-          "Unity Catalog storage validation could not read the probe object",
+          subject + " storage validation could not read the probe object",
           failure);
     } catch (RuntimeException failure) {
       throw new CatalogAccessException(
-          CatalogAccessException.Code.UNAVAILABLE,
-          "Unity Catalog storage validation failed",
-          failure);
+          CatalogAccessException.Code.UNAVAILABLE, subject + " storage validation failed", failure);
     }
   }
 
-  private static String required(Map<String, String> properties, String key) {
+  private static String required(String subject, Map<String, String> properties, String key) {
     String value = nonBlank(properties.get(key));
     if (value == null) {
       throw new CatalogAccessException(
           CatalogAccessException.Code.INVALID_CONFIGURATION,
-          "Unity Catalog storage credentials omitted " + key);
+          subject + " storage credentials omitted " + key);
     }
     return value;
   }
@@ -182,7 +175,7 @@ interface UnityStorageAccessValidator {
    * <p>Scoped to the listing on purpose. The ranged read streams a body of unknown size and aborts
    * after one byte, so capping that stream would constrain a path whose bound already holds.
    */
-  final class BoundedListingBody implements ExecutionInterceptor {
+  private static final class BoundedListingBody implements ExecutionInterceptor {
 
     @Override
     public Optional<InputStream> modifyHttpResponseContent(
@@ -299,11 +292,28 @@ interface UnityStorageAccessValidator {
     }
     URI normalized;
     try {
-      normalized = URI.create(StorageLocations.normalizeScheme(tableLocation));
+      // A space is percent-encoded before parsing. It is legal in an S3 object key and illegal in
+      // java.net.URI, so a valid table location answered null here and the caller refused it for
+      // having no addressable bucket -- a diagnosis pointing at the bucket when the key was the
+      // problem. getPath decodes it again, so the key the probe asks for is unchanged. Other
+      // characters URI rejects and S3 permits still answer null; a space is the one that occurs.
+      normalized = URI.create(StorageLocations.normalizeScheme(tableLocation).replace(" ", "%20"));
     } catch (IllegalArgumentException notAUri) {
       return null;
     }
     if (!"s3".equalsIgnoreCase(normalized.getScheme()) || bucketOf(normalized) == null) {
+      return null;
+    }
+    // Nothing that carries a secret. bucketOf refuses an authority holding userinfo, but only on
+    // its fallback branch: getHost() answers "bucket" for s3://user:password@bucket/table, so that
+    // check never ran and the location was servable. A provider then stores it as the reconciled
+    // table's storage_location, which puts a password or a signed query into catalog metadata --
+    // readable by every client that can read the table. None of these belong in an S3 object
+    // location anyway, and the endpoint gates already refuse the same four on a catalog URI.
+    if (normalized.getRawUserInfo() != null
+        || normalized.getRawQuery() != null
+        || normalized.getRawFragment() != null
+        || normalized.getPort() != -1) {
       return null;
     }
     return normalized;
@@ -338,8 +348,20 @@ interface UnityStorageAccessValidator {
     return authority;
   }
 
+  /**
+   * Exactly the URI separator, and no more.
+   *
+   * <p>An S3 object key may begin with a slash, so {@code s3://bucket//table} names the key {@code
+   * /table}. The read path removes one leading slash and addresses that key; this removed every one
+   * and probed {@code table/_delta_log/} instead -- a different prefix, so validation either
+   * rejected a readable table or, where something else sat at the stripped prefix, read that Delta
+   * log and reported success for a location no scan would reach.
+   */
   private static String stripLeadingSlash(String value) {
-    return value == null ? "" : value.replaceFirst("^/+", "");
+    if (value == null) {
+      return "";
+    }
+    return value.startsWith("/") ? value.substring(1) : value;
   }
 
   private static String nonBlank(String value) {

--- a/catalog-access/delta-common/src/test/java/ai/floedb/floecat/catalog/delta/DeltaLogStorageProbeTest.java
+++ b/catalog-access/delta-common/src/test/java/ai/floedb/floecat/catalog/delta/DeltaLogStorageProbeTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package ai.floedb.floecat.catalog.unity;
+package ai.floedb.floecat.catalog.delta;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -34,7 +34,10 @@ import org.junit.jupiter.api.Test;
  * smoke failure -- which key prefix the Delta log is looked for under, and what an S3 error means
  * about the credential -- are pure, and asserted here.
  */
-class UnityStorageAccessValidatorTest {
+class DeltaLogStorageProbeTest {
+
+  /** Every refusal names its caller, so the tests assert against one name. */
+  private static final String SUBJECT = "Test Catalog";
 
   /**
    * A table at the bucket root has an empty path, and a leading slash would make the prefix
@@ -52,9 +55,7 @@ class UnityStorageAccessValidatorTest {
             new Case("trailing slash", "/tpch/orders/", "tpch/orders/_delta_log/"),
             new Case("no leading slash", "tpch/orders", "tpch/orders/_delta_log/"),
             new Case("null path", null, "_delta_log/"))) {
-      assertThat(UnityStorageAccessValidator.deltaLogPrefix(c.path()))
-          .as(c.name())
-          .isEqualTo(c.expected());
+      assertThat(S3DeltaLogProbe.deltaLogPrefix(c.path())).as(c.name()).isEqualTo(c.expected());
     }
   }
 
@@ -85,7 +86,7 @@ class UnityStorageAccessValidatorTest {
                 "ExpiredToken",
                 400,
                 CatalogAccessException.Code.CREDENTIAL_EXPIRED))) {
-      assertThat(UnityStorageAccessValidator.storageFailureCode(c.errorCode(), c.status()))
+      assertThat(S3DeltaLogProbe.storageFailureCode(c.errorCode(), c.status()))
           .as(c.name())
           .isEqualTo(c.expected());
     }
@@ -109,7 +110,7 @@ class UnityStorageAccessValidatorTest {
             // Neither belongs in an S3 location, so an authority carrying one is not a bucket name.
             new Case("userinfo", "s3://user@my_bucket/x", null),
             new Case("port", "s3://my_bucket:9000/x", null))) {
-      assertThat(UnityStorageAccessValidator.bucketOf(java.net.URI.create(c.location())))
+      assertThat(S3DeltaLogProbe.bucketOf(java.net.URI.create(c.location())))
           .as(c.name())
           .isEqualTo(c.expected());
     }
@@ -136,25 +137,115 @@ class UnityStorageAccessValidatorTest {
             new Case("abfss", "abfss://c@a.dfs.core.windows.net/o", null),
             new Case("no scheme", "/warehouse/orders", null),
             new Case("blank", "  ", null))) {
-      assertThat(UnityStorageAccessValidator.s3Bucket(c.location()))
-          .as(c.name())
-          .isEqualTo(c.expected());
+      assertThat(S3DeltaLogProbe.s3Bucket(c.location())).as(c.name()).isEqualTo(c.expected());
     }
   }
 
   /**
    * A key holding a character URI rejects reads as "not addressable", not as a thrown parse error.
-   * The parse used to run ahead of the guard meant to report it, so an object key with a space --
-   * legal in S3 -- surfaced as "storage access validation configuration is invalid", describing
-   * neither the location nor anything an operator had configured.
+   * The parse runs inside the guard that reports it, so such a key is refused for what it is --
+   * rather than surfacing as "storage access validation configuration is invalid", which describes
+   * neither the location nor anything an operator set.
    */
   @Test
   void anUnparseableKeyIsRefusedRatherThanThrowingPastTheGuard() {
-    for (String location :
-        List.of("s3://warehouse/db/my table", "s3://warehouse/db/a|b", "s3://warehouse/db/x y/z")) {
-      assertThat(UnityStorageAccessValidator.s3Location(location)).as(location).isNull();
-      assertThat(UnityStorageAccessValidator.s3Bucket(location)).as(location).isNull();
+    for (String location : List.of("s3://warehouse/db/a|b", "s3://warehouse/db/a\"b")) {
+      assertThat(S3DeltaLogProbe.s3Location(location)).as(location).isNull();
+      assertThat(S3DeltaLogProbe.s3Bucket(location)).as(location).isNull();
     }
+  }
+
+  /**
+   * An S3 object key may end in a space, and the probe does not trim -- so trimming in the
+   * canonical form published a different prefix from the one validation had just probed. Both
+   * providers use this value for publication, scope comparison and validation, so such a table
+   * either failed to read or was pointed at the trimmed name when something else lived there.
+   */
+  @Test
+  void theCanonicalFormKeepsASignificantTrailingSpace() {
+    assertThat(DeltaLogStorageProbe.canonicalLocation("s3://warehouse/table "))
+        .isEqualTo("s3://warehouse/table%20");
+    // The same key the probe addresses, which is the agreement that matters.
+    assertThat(S3DeltaLogProbe.s3Location("s3://warehouse/table ").getPath()).isEqualTo("/table ");
+  }
+
+  /**
+   * A location carrying a secret is not one this will serve. bucketOf refuses an authority holding
+   * userinfo, but only on its fallback branch -- getHost() answers "bucket" here, so that check
+   * never ran and a provider stored the whole string as the table's storage_location, putting a
+   * password or a signed query into catalog metadata that every reader of the table can see.
+   */
+  @Test
+  void aLocationCarryingUserinfoQueryFragmentOrPortIsRefused() {
+    for (String location :
+        List.of(
+            "s3://user:password@warehouse/table",
+            "s3://warehouse/table?X-Amz-Signature=deadbeef",
+            "s3://warehouse/table#fragment",
+            "s3://warehouse:9000/table")) {
+      assertThat(S3DeltaLogProbe.s3Location(location)).as(location).isNull();
+      assertThat(DeltaLogStorageProbe.s3Serves(location)).as(location).isFalse();
+    }
+  }
+
+  /**
+   * The canonical form is the spelling the reader accepts. s3Serves folds s3, s3a and s3n in any
+   * case, while the reader matches a literal lowercase s3:// or s3a:// and throws on the rest -- so
+   * publishing the server's spelling let s3n:// and S3:// validate, reconcile, and fail every scan.
+   */
+  @Test
+  void theCanonicalFormNormalisesTheSchemeTheReaderAccepts() {
+    // Only the spellings the reader cannot parse are changed. resolvePath matches a literal
+    // lowercase s3:// or s3a://, so s3n and any uppercase form fold and s3a is left alone --
+    // folding it too would put the stored location in a different scheme namespace from the
+    // s3a:// prefix an operator may register, which matchesLocationPrefix compares literally.
+    assertThat(DeltaLogStorageProbe.canonicalLocation("s3n://warehouse/table"))
+        .isEqualTo("s3://warehouse/table");
+    assertThat(DeltaLogStorageProbe.canonicalLocation("S3://warehouse/table"))
+        .isEqualTo("s3://warehouse/table");
+    assertThat(DeltaLogStorageProbe.canonicalLocation("S3A://warehouse/table"))
+        .isEqualTo("s3a://warehouse/table");
+    assertThat(DeltaLogStorageProbe.canonicalLocation("s3a://warehouse/my table"))
+        .isEqualTo("s3a://warehouse/my%20table");
+    // Everything servable is publishable, in a spelling the reader accepts.
+    for (String location :
+        List.of("s3://w/t", "s3a://w/t", "s3n://w/t", "S3://w/t", "s3://w/my table")) {
+      assertThat(DeltaLogStorageProbe.s3Serves(location)).as(location).isTrue();
+      String canonical = DeltaLogStorageProbe.canonicalLocation(location);
+      assertThat(canonical.startsWith("s3://") || canonical.startsWith("s3a://"))
+          .as(location)
+          .isTrue();
+    }
+  }
+
+  /**
+   * A space is legal in an S3 object key and illegal in {@code java.net.URI}, so it is encoded
+   * before parsing rather than read as a location with no addressable bucket. The key has to
+   * survive the round trip: the probe asks S3 for the object it names, so an encoded space reaching
+   * the request would look for a key nothing wrote.
+   */
+  @Test
+  void aSpaceInAnObjectKeyIsAddressableAndKeepsItsKey() {
+    for (String location : List.of("s3://warehouse/db/my table", "s3://warehouse/db/x y/z")) {
+      assertThat(S3DeltaLogProbe.s3Location(location)).as(location).isNotNull();
+      assertThat(S3DeltaLogProbe.s3Bucket(location)).as(location).isEqualTo("warehouse");
+    }
+    assertThat(S3DeltaLogProbe.s3Location("s3://warehouse/db/my table").getPath())
+        .isEqualTo("/db/my table");
+  }
+
+  /**
+   * An S3 object key may begin with a slash, so {@code s3://bucket//table} names the key {@code
+   * /table}. The read path removes one leading slash and addresses that key; removing every one
+   * probed a different prefix, so validation either rejected a readable table or read whatever
+   * Delta log sat at the stripped prefix and reported success for a location no scan would reach.
+   */
+  @Test
+  void aKeyBeginningWithASlashKeepsIt() {
+    // The URI path, which is what the caller passes: getPath() on s3://warehouse//table is
+    // //table, and on s3://warehouse/table is /table.
+    assertThat(S3DeltaLogProbe.deltaLogPrefix("//table")).isEqualTo("/table/_delta_log/");
+    assertThat(S3DeltaLogProbe.deltaLogPrefix("/table")).isEqualTo("table/_delta_log/");
   }
 
   /** Only S3 is validated, and a location that is not one says so rather than failing obscurely. */
@@ -167,7 +258,7 @@ class UnityStorageAccessValidatorTest {
             Optional.empty());
     for (String location : List.of("gs://warehouse/orders", "abfss://c@a.dfs.core.windows.net/o")) {
       assertThatThrownBy(
-              () -> UnityStorageAccessValidator.s3().validate(location, credentials), location)
+              () -> DeltaLogStorageProbe.s3(SUBJECT).validate(location, credentials), location)
           .isInstanceOfSatisfying(
               CatalogAccessException.class,
               failure ->
@@ -192,7 +283,7 @@ class UnityStorageAccessValidatorTest {
       var credentials =
           new VendedStorageCredentials(c.properties(), "s3://warehouse/orders", Optional.empty());
       assertThatThrownBy(
-              () -> UnityStorageAccessValidator.s3().validate("s3://warehouse/orders", credentials),
+              () -> DeltaLogStorageProbe.s3(SUBJECT).validate("s3://warehouse/orders", credentials),
               c.name())
           .isInstanceOfSatisfying(
               CatalogAccessException.class,
@@ -213,11 +304,11 @@ class UnityStorageAccessValidatorTest {
    */
   @Test
   void aListingBodyIsRefusedOnceItPassesTheCap() throws Exception {
-    byte[] oversized = new byte[(int) UnityStorageAccessValidator.MAX_LISTING_RESPONSE_BYTES + 64];
+    byte[] oversized = new byte[(int) S3DeltaLogProbe.MAX_LISTING_RESPONSE_BYTES + 64];
     try (var bounded =
-        UnityStorageAccessValidator.limited(
+        S3DeltaLogProbe.limited(
             new java.io.ByteArrayInputStream(oversized),
-            UnityStorageAccessValidator.MAX_LISTING_RESPONSE_BYTES)) {
+            S3DeltaLogProbe.MAX_LISTING_RESPONSE_BYTES)) {
       assertThatThrownBy(() -> bounded.readAllBytes())
           .isInstanceOf(java.io.IOException.class)
           .hasMessageContaining("ignored max-keys");
@@ -229,13 +320,12 @@ class UnityStorageAccessValidatorTest {
         "<ListBucketResult><Contents><Key>a</Key></Contents></ListBucketResult>"
             .getBytes(java.nio.charset.StandardCharsets.UTF_8);
     try (var bounded =
-        UnityStorageAccessValidator.limited(
+        S3DeltaLogProbe.limited(
             new java.io.ByteArrayInputStream(ordinary),
-            UnityStorageAccessValidator.MAX_LISTING_RESPONSE_BYTES)) {
+            S3DeltaLogProbe.MAX_LISTING_RESPONSE_BYTES)) {
       assertThat(bounded.readAllBytes()).isEqualTo(ordinary);
     }
-    try (var bounded =
-        UnityStorageAccessValidator.limited(new java.io.ByteArrayInputStream(ordinary), 4L)) {
+    try (var bounded = S3DeltaLogProbe.limited(new java.io.ByteArrayInputStream(ordinary), 4L)) {
       assertThat(bounded.read()).isEqualTo(ordinary[0]);
       assertThatThrownBy(
               () -> {

--- a/catalog-access/delta-sharing/pom.xml
+++ b/catalog-access/delta-sharing/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright 2026 Yellowbrick Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>ai.floedb.floecat</groupId>
+    <artifactId>floecat</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <relativePath>../..</relativePath>
+  </parent>
+
+  <artifactId>floecat-catalog-access-delta-sharing</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>ai.floedb.floecat</groupId>
+      <artifactId>floecat-catalog-access-spi</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>ai.floedb.floecat</groupId>
+      <artifactId>floecat-catalog-access-delta-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>ai.floedb.floecat</groupId>
+      <artifactId>floecat-http-endpoint-guards</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>ai.floedb.floecat</groupId>
+      <artifactId>floecat-delta-sharing-client</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/catalog-access/delta-sharing/src/main/java/ai/floedb/floecat/catalog/sharing/DeltaSharingCatalogClient.java
+++ b/catalog-access/delta-sharing/src/main/java/ai/floedb/floecat/catalog/sharing/DeltaSharingCatalogClient.java
@@ -1,0 +1,856 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.catalog.sharing;
+
+import ai.floedb.floecat.catalog.access.CatalogAccessException;
+import ai.floedb.floecat.catalog.access.CatalogCapabilities;
+import ai.floedb.floecat.catalog.access.CatalogCapability;
+import ai.floedb.floecat.catalog.access.CatalogClient;
+import ai.floedb.floecat.catalog.access.CatalogObjectName;
+import ai.floedb.floecat.catalog.access.CatalogTable;
+import ai.floedb.floecat.catalog.access.CatalogView;
+import ai.floedb.floecat.catalog.access.ExternalObjectIdentity;
+import ai.floedb.floecat.catalog.access.NamespacePath;
+import ai.floedb.floecat.catalog.access.StorageLocations;
+import ai.floedb.floecat.catalog.access.VendedStorageCredentials;
+import ai.floedb.floecat.catalog.delta.DeltaLogStorageProbe;
+import ai.floedb.floecat.client.sharing.DeltaSharingClient;
+import ai.floedb.floecat.client.sharing.DeltaSharingException;
+import ai.floedb.floecat.client.sharing.DeltaSharingModel.AccessMode;
+import ai.floedb.floecat.client.sharing.DeltaSharingModel.Schema;
+import ai.floedb.floecat.client.sharing.DeltaSharingModel.Share;
+import ai.floedb.floecat.client.sharing.DeltaSharingModel.Table;
+import ai.floedb.floecat.client.sharing.DeltaSharingModel.TableDescription;
+import ai.floedb.floecat.client.sharing.DeltaSharingModel.TemporaryCredentials;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * A Delta Sharing recipient behind the catalog-access SPI.
+ *
+ * <p>The sharing hierarchy is share, then schema, then table, which maps onto {@link NamespacePath}
+ * without translation: an empty parent lists shares as one-segment paths and a one-segment parent
+ * lists schemas as two.
+ *
+ * <p>Directory access only. A table advertising url alone is discoverable and describable, and
+ * refused at the vend by name rather than returning nothing, because a caller that got an empty
+ * answer would report a missing storage authority for a table whose provider simply does not
+ * delegate storage.
+ */
+public final class DeltaSharingCatalogClient implements CatalogClient {
+
+  private static final CatalogCapabilities CAPABILITIES =
+      CatalogCapabilities.of(
+          CatalogCapability.VALIDATE,
+          CatalogCapability.LIST_NAMESPACES,
+          CatalogCapability.LIST_TABLES,
+          CatalogCapability.LOAD_TABLE,
+          CatalogCapability.VEND_STORAGE_CREDENTIALS,
+          CatalogCapability.VALIDATE_STORAGE_ACCESS,
+          CatalogCapability.STABLE_OBJECT_IDS);
+
+  /** Names the property in the refusal it produces, so an operator can find what caused it. */
+  static final String STRICT_ACCESS_MODES = "delta.sharing.strict-access-modes";
+
+  /**
+   * What {@code delta.sharing.access-modes} reads when the server stated nothing.
+   *
+   * <p>Not {@code url}. That is the protocol's reading of an absent field, and it is the reading
+   * this client deliberately does not apply before vending, so writing it onto the reconciled table
+   * would report a fact the share never communicated.
+   */
+  static final String UNSTATED_ACCESS_MODES = "unstated";
+
+  private final DeltaSharingClient client;
+  private final Map<String, String> storageProperties;
+  private final boolean strictAccessModes;
+  private final DeltaLogStorageProbe storageProbe;
+  private final Map<Schema, List<Table>> listedTables =
+      new java.util.concurrent.ConcurrentHashMap<>();
+
+  public DeltaSharingCatalogClient(
+      DeltaSharingClient client, Map<String, String> storageProperties) {
+    this(client, storageProperties, false);
+  }
+
+  /**
+   * @param strictAccessModes whether a table that states no access modes is read as url only. The
+   *     protocol says it is, and the reference server implements the credential endpoint while
+   *     stating nothing, so the default asks and lets the server answer.
+   */
+  public DeltaSharingCatalogClient(
+      DeltaSharingClient client, Map<String, String> storageProperties, boolean strictAccessModes) {
+    this(client, storageProperties, strictAccessModes, DeltaLogStorageProbe.s3("Delta Sharing"));
+  }
+
+  DeltaSharingCatalogClient(
+      DeltaSharingClient client,
+      Map<String, String> storageProperties,
+      boolean strictAccessModes,
+      DeltaLogStorageProbe storageProbe) {
+    this.client = Objects.requireNonNull(client, "client");
+    this.storageProperties = storageProperties == null ? Map.of() : Map.copyOf(storageProperties);
+    this.strictAccessModes = strictAccessModes;
+    this.storageProbe = Objects.requireNonNull(storageProbe, "storageProbe");
+  }
+
+  /** Whether a table stating no access modes is read as url only rather than asked about. */
+  boolean strictAccessModes() {
+    return strictAccessModes;
+  }
+
+  /** The storage properties published alongside every vended credential. */
+  Map<String, String> storageProperties() {
+    return storageProperties;
+  }
+
+  @Override
+  public CatalogCapabilities capabilities() {
+    return CAPABILITIES;
+  }
+
+  @Override
+  public void validate() {
+    // Listing shares is the smallest call that proves the endpoint is a sharing server and that the
+    // recipient token is accepted. It answers with an empty list for a recipient granted nothing,
+    // which is a valid configuration rather than a failure.
+    translate("validation", client::listShares);
+  }
+
+  @Override
+  public List<NamespacePath> listNamespaces(NamespacePath parent) {
+    List<String> segments = parent == null ? List.of() : parent.segments();
+    if (segments.isEmpty()) {
+      List<NamespacePath> shares = new ArrayList<>();
+      for (Share share : translate("listing shares", client::listShares)) {
+        shares.add(new NamespacePath(List.of(share.name())));
+      }
+      return List.copyOf(shares);
+    }
+    if (segments.size() == 1) {
+      String share = segments.get(0);
+      List<NamespacePath> schemas = new ArrayList<>();
+      for (Schema schema :
+          translate("listing schemas of " + share, () -> client.listSchemas(share))) {
+        schemas.add(new NamespacePath(List.of(share, schema.name())));
+      }
+      return List.copyOf(schemas);
+    }
+    // Share and schema are the only levels the protocol defines. Deeper is not an error, it is
+    // simply empty, which is what a caller walking a tree expects at a leaf.
+    return List.of();
+  }
+
+  @Override
+  public List<CatalogObjectName> listTables(NamespacePath namespace) {
+    // Tables live at share.schema and nowhere else. The root and a share are real levels of the
+    // hierarchy that simply hold none, and the reconciler lists tables at every selected namespace
+    // before descending, so raising here abandoned any overlay whose include named a whole share.
+    List<String> segments = namespace == null ? List.of() : namespace.segments();
+    if (segments.size() != 2) {
+      return List.of();
+    }
+    Schema addressed = requireSchema(namespace);
+    List<CatalogObjectName> tables = new ArrayList<>();
+    // Through the memo the load path reads. The reconciler lists a schema and then loads every
+    // table in it, so without this the schema is paged twice per pass: once here and once by the
+    // first findTable.
+    for (Table table : listing(addressed)) {
+      tables.add(new CatalogObjectName(namespace, table.name()));
+    }
+    return List.copyOf(tables);
+  }
+
+  @Override
+  public CatalogTable loadTable(CatalogObjectName name) {
+    Schema addressed = requireSchema(name.namespace());
+    Table listed = findTable(addressed, name.name());
+    TableDescription described =
+        translate(
+            "describing " + listed.fullName(),
+            () -> client.describeTable(addressed.share(), addressed.name(), name.name()));
+
+    ExternalObjectIdentity identity = identityOf(listed);
+
+    Map<String, String> properties = new HashMap<>(described.metadata().configuration());
+    described.version().ifPresent(v -> properties.put("delta.sharing.version", Long.toString(v)));
+    properties.put("delta.sharing.file-format", described.metadata().format());
+    List<AccessMode> modes = statedModes(listed, described);
+    properties.put(
+        "delta.sharing.access-modes",
+        modes.isEmpty()
+            ? UNSTATED_ACCESS_MODES
+            : modes.stream()
+                .map(mode -> mode.name().toLowerCase(java.util.Locale.ROOT))
+                .reduce((a, b) -> a + "," + b)
+                .orElse(UNSTATED_ACCESS_MODES));
+
+    // Either surface, because the protocol states auxiliary locations on the listing and on the
+    // metadata action and a server may use either. Refused here rather than at the vend, because
+    // this is where both are known and because a table refused here never reconciles. The protocol
+    // requires a client to
+    // ask for credentials once per location, root and auxiliary alike, and tells a client that
+    // cannot read from several to fall back to url access or raise. The storage contract carries
+    // one credential over one scope prefix, so there is nothing here to carry the rest.
+    if (listed.hasAuxiliaryLocations() || described.metadata().hasAuxiliaryLocations()) {
+      throw new CatalogAccessException(
+          CatalogAccessException.Code.UNSUPPORTED,
+          "Delta Sharing table "
+              + listed.fullName()
+              + " reports auxiliary storage locations, which need a credential each and cannot be"
+              + " published as one scoped credential");
+    }
+
+    return new CatalogTable(
+        name,
+        identity,
+        // Always DELTA. A shared table is a Delta table; the metaData action's format.provider
+        // names
+        // the data file format underneath it -- parquet -- which is a different question, and
+        // reporting it here is a table format the reconciler does not recognise.
+        "DELTA",
+        described.metadata().schemaJson(),
+        described.metadata().partitionColumns(),
+        Optional.empty(),
+        // Present for directory access and absent otherwise, which is the protocol being explicit
+        // that a url-only recipient is never told where the table lives.
+        Optional.of(requireStorageLocation(addressed, name, listed, described, modes)),
+        Map.copyOf(properties));
+  }
+
+  @Override
+  public List<CatalogObjectName> listViews(NamespacePath namespace) {
+    // Delta Sharing shares tables. There is no view concept to enumerate.
+    return List.of();
+  }
+
+  @Override
+  public CatalogView loadView(CatalogObjectName view) {
+    throw new CatalogAccessException(
+        CatalogAccessException.Code.UNSUPPORTED, "Delta Sharing does not share views");
+  }
+
+  @Override
+  public Optional<VendedStorageCredentials> vendStorageCredentials(CatalogObjectName name) {
+    Schema addressed = requireSchema(name.namespace());
+    // The metadata endpoint, not the table listing. This is the per-read path -- a credential is
+    // vended on every storage-authority resolve -- and listing the schema to find one table paged
+    // the whole schema before every credential POST, which is unbounded in the schema's table
+    // count and made a reconcile quadratic. The delta response format this client asks for carries
+    // the access modes and auxiliary locations here, which is all the listing was consulted for.
+    String qualified = addressed.share() + "." + addressed.name() + "." + name.name();
+    TableDescription described =
+        translate(
+            "describing " + qualified,
+            () -> client.describeTable(addressed.share(), addressed.name(), name.name()));
+    List<AccessMode> modes = described.metadata().accessModes();
+    if (modes.isEmpty() && strictAccessModes) {
+      // The listing is the other place the protocol lets a server state modes, and a server may
+      // use either. Strict mode refuses without asking the server, so it must not refuse a table
+      // the share marked directory-accessible somewhere this path had not looked. The extra
+      // listing is confined to the path an operator opted into.
+      modes = findTable(addressed, name.name()).accessModes();
+    }
+
+    if (described.metadata().hasAuxiliaryLocations()) {
+      throw new CatalogAccessException(
+          CatalogAccessException.Code.UNSUPPORTED,
+          "Delta Sharing table "
+              + qualified
+              + " reports auxiliary storage locations, which need a credential each and cannot be"
+              + " published as one scoped credential");
+    }
+
+    // A table that states its modes is believed. One that states none is ambiguous: the protocol
+    // reads that as url only, and the reference server implements the credential endpoint while
+    // stating nothing at all, so the default is to ask and let the server answer.
+    boolean unstated = modes.isEmpty();
+    if (!modes.contains(AccessMode.DIR) && (strictAccessModes || !unstated)) {
+      throw new CatalogAccessException(
+          CatalogAccessException.Code.UNSUPPORTED,
+          unstated
+              ? "Delta Sharing table "
+                  + qualified
+                  + " states no access modes, which "
+                  + STRICT_ACCESS_MODES
+                  + " reads as url only"
+              // The same distinction the load draws. Validation's sampler sends names straight from
+              // listTables to this method without loading them, so for a table stating only modes
+              // this client does not know, "offers url access only" is the message an operator
+              // running a validation actually sees -- about a url mode the table never mentioned.
+              : onlyUnrecognised(modes)
+                  ? "Delta Sharing table "
+                      + qualified
+                      + " states only access modes this provider does not recognise"
+                  : "Delta Sharing table "
+                      + qualified
+                      + " offers url access only, which cannot be vended as storage credentials");
+    }
+
+    TemporaryCredentials credentials =
+        askForCredentials(addressed, name, qualified, "vending credentials for " + qualified);
+
+    if (!credentials.hasAwsSession()) {
+      // Named by cloud. A recipient on Azure or GCP is a supported configuration of the protocol
+      // and an unsupported one here, and the difference between those is what an operator needs.
+      throw new CatalogAccessException(
+          CatalogAccessException.Code.UNSUPPORTED,
+          "Delta Sharing vended "
+              + credentials.cloud()
+              + " credentials for "
+              + qualified
+              + ", and only AWS session credentials can be published");
+    }
+
+    // Checked on the path that actually runs per read. validateStorageAccess makes the same check
+    // and is only ever called from validation, so without this a server returning a credential
+    // scoped somewhere unrelated or far broader than the table would go unchallenged on every
+    // storage-authority resolve. The Unity provider checks it in its own vend for this reason.
+    // The metadata action only. Paging the schema to look for a location was waste on exactly the
+    // servers that need this path: one that omits it from its metadata omits it from its listing
+    // too, and this runs on every storage-authority resolve with a fresh client, so the memo never
+    // absorbs it.
+    //
+    // That leaves one shape unchecked, and it is a narrower claim than "loadTable already refused
+    // a table without a location". loadTable resolves the listing first, so a server stating the
+    // location only there reconciles, and here there is nothing to compare the scope against. The
+    // check is skipped rather than failed, because the alternative is a schema listing per read --
+    // the cost this path exists to avoid. validateStorageAccess does consult both surfaces, so an
+    // operator sees a mis-scoped credential at validation; what is not caught is a server that
+    // starts mis-scoping after that. Closing it means carrying the load's location to the vend,
+    // which the vendor's fresh-client-per-resolve shape gives nowhere to put.
+    // Canonical on both sides. covers() is a prefix test on strings, so encoding one side and not
+    // the other makes every table whose key holds a space look scoped elsewhere.
+    Optional<String> tableLocation =
+        described.metadata().location().map(DeltaSharingCatalogClient::canonical);
+    if (tableLocation.isPresent()) {
+      // One direction only: the credential has to reach the table. A scope broader than the table
+      // -- a share root, a bucket, an external-location prefix -- is left alone deliberately.
+      // StorageLocations states the rule this sits under: never be stricter than the component
+      // that will actually use the credential, because this path is reached only once no storage
+      // authority matched, so refusing here fails a read that the catalog's own client would have
+      // attempted and that S3 would have answered on the real grant.
+      if (!StorageLocations.covers(canonical(credentials.location()), tableLocation.get())) {
+        throw new CatalogAccessException(
+            CatalogAccessException.Code.CREDENTIAL_SCOPE_INVALID,
+            "Delta Sharing vended credentials that do not reach " + qualified);
+      }
+    }
+
+    Map<String, String> properties = new HashMap<>(storageProperties);
+    properties.put("s3.access-key-id", credentials.accessKeyId().orElseThrow());
+    properties.put("s3.secret-access-key", credentials.secretAccessKey().orElseThrow());
+    properties.put("s3.session-token", credentials.sessionToken().orElseThrow());
+
+    // Servable, checked here too. requireServable ran only at the load, so on the reference-server
+    // shape -- where the metaData action names no location and the coverage check above is skipped
+    // -- whatever the credential endpoint returned was canonicalised and published unexamined. A
+    // table reconciled from an earlier good credential could then start receiving an AWS tuple
+    // scoped to a gs:// location, or one carrying userinfo, and the read failed at query time
+    // instead of the provider refusing it. This needs no listing, so the shape the vend was changed
+    // to avoid is unaffected.
+    String scope = requireServable(credentials.location(), qualified);
+
+    return Optional.of(
+        new VendedStorageCredentials(Map.copyOf(properties), scope, credentials.expiresAt()));
+  }
+
+  @Override
+  public void validateStorageAccess(
+      CatalogObjectName name, VendedStorageCredentials vendedStorageCredentials) {
+    Objects.requireNonNull(vendedStorageCredentials, "vendedStorageCredentials");
+    Schema addressed = requireSchema(name.namespace());
+    // The metadata endpoint rather than the listing, for the reason the vend uses it: one request
+    // for one table instead of paging the schema to find it.
+    String qualified = addressed.share() + "." + addressed.name() + "." + name.name();
+    // Every surface the protocol lets a server state a location on, in the order all three paths
+    // use: the metaData action, then the listing, then the scope the credential itself named. That
+    // last one matters for the reference server, which states a location on neither of the first
+    // two -- without it this refused every table on exactly the servers the ask-rather-than-refuse
+    // default exists to support, before attempting any read.
+    Optional<String> stated =
+        translate(
+                "describing " + qualified,
+                () -> client.describeTable(addressed.share(), addressed.name(), name.name()))
+            .metadata()
+            .location()
+            .or(() -> findTable(addressed, name.name()).location());
+    String location =
+        canonical(
+            stated.orElseGet(
+                () ->
+                    Optional.of(vendedStorageCredentials.scopePrefix())
+                        .filter(prefix -> !prefix.isBlank())
+                        .orElseThrow(
+                            () ->
+                                new CatalogAccessException(
+                                    CatalogAccessException.Code.UNSUPPORTED,
+                                    "Delta Sharing table "
+                                        + qualified
+                                        + " reports no location to validate access against"))));
+    // Scope first, because it answers without a network call and a credential scoped elsewhere is
+    // a provider bug rather than a permission the operator can grant. Skipped where the credential
+    // supplied the location, since checking a scope against itself asserts nothing; the probe below
+    // still reads the store, which is what this validation is for.
+    if (stated.isPresent() && !vendedStorageCredentials.covers(location)) {
+      throw new CatalogAccessException(
+          CatalogAccessException.Code.CREDENTIAL_SCOPE_INVALID,
+          "Delta Sharing credentials do not cover " + qualified);
+    }
+    // Then the store itself. A shared table is a Delta table, so this is the same probe the Unity
+    // provider runs: list one object under the Delta log and read a byte of it. Scope alone would
+    // pass on a grant that cannot read, which is the failure an operator finds at query time.
+    storageProbe.validate(location, vendedStorageCredentials);
+  }
+
+  @Override
+  public void close() {
+    client.close();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  /** Whether a surface stated modes and none of them are ones this client knows. */
+  private static boolean onlyUnrecognised(List<AccessMode> modes) {
+    return !modes.isEmpty() && modes.stream().allMatch(mode -> mode == AccessMode.OTHER);
+  }
+
+  /** Whether a surface stated its modes and directory access was not among them. */
+  private static boolean refusesDir(List<AccessMode> modes) {
+    return !modes.isEmpty() && !modes.contains(AccessMode.DIR);
+  }
+
+  /**
+   * What the server actually stated about how this table may be read.
+   *
+   * <p>Two places carry it. The listing states it in either response format; the metaData action
+   * states it only in the delta format, which is what this client asks for. Neither is required to,
+   * so an empty answer means the server said nothing rather than that it said url.
+   *
+   * <p>Which surface this prefers decides nothing about whether a table may be read that way --
+   * {@link #refusesDir} is asked of both surfaces separately, because the vend sees only one of
+   * them. This answers the narrower question of whether anything was stated at all.
+   */
+  private static List<AccessMode> statedModes(Table listed, TableDescription described) {
+    return listed.accessModes().isEmpty()
+        ? described.metadata().accessModes()
+        : listed.accessModes();
+  }
+
+  /**
+   * Two components joined so that the pair can be recovered from the result.
+   *
+   * <p>The protocol treats a share id and a table id as opaque strings, so a bare delimiter makes
+   * {@code a:b} plus {@code c} indistinguishable from {@code a} plus {@code b:c}. The reconciler
+   * checks stable identities for duplicates and abandons the whole overlay on a collision, which is
+   * the failure this identity exists to prevent rather than cause. Percent-encoding the delimiter
+   * inside each component is enough to keep the join unambiguous.
+   */
+  private static String joined(String first, String second) {
+    return escape(first) + ":" + escape(second);
+  }
+
+  private static String escape(String component) {
+    return component.replace("%", "%25").replace(":", "%3A");
+  }
+
+  /**
+   * An identity that names the share as well as the table.
+   *
+   * <p>The protocol scopes a table id to its share and makes {@code shareId} unique across the
+   * server, so a bare table id is not unique across an Integration: two shares may carry the same
+   * id, including for the same underlying table shared twice. The reconciler requires stable
+   * identities to be unique across every selected table and abandons the overlay on a duplicate.
+   *
+   * <p>Stable only when both components are the server's own ids. Falling back to the share name,
+   * or to the qualified name where the listing states no table id, keeps the identity unambiguous
+   * but promises nothing about a rename surviving, so those forms are reported unstable rather than
+   * claiming more than the server offered.
+   */
+  private static ExternalObjectIdentity identityOf(Table listed) {
+    // The listing's id only. The metaData action's id identifies the underlying Delta table, which
+    // the protocol calls the unique identifier for the table itself -- a different namespace from
+    // the share-scoped id here. A share exposing one physical table under two names, which is a
+    // legitimate configuration, reports the same value for both entries, and the reconciler
+    // abandons the whole overlay on a duplicate stable identity. Falling back to it looked like it
+    // recovered stability and instead risked dropping the share.
+    Optional<String> tableId = listed.id();
+    if (tableId.isEmpty()) {
+      return new ExternalObjectIdentity(listed.fullName(), false);
+    }
+    return listed
+        .shareId()
+        .map(shareId -> new ExternalObjectIdentity(joined(shareId, tableId.get()), true))
+        .orElseGet(() -> new ExternalObjectIdentity(joined(listed.share(), tableId.get()), false));
+  }
+
+  /**
+   * The schema's tables, listed once for the client's lifetime.
+   *
+   * <p>Which is one reconcile pass: the reconciler lists a schema and then loads every table in it,
+   * and each load looked the table up by paging the listing again. A table appearing mid-pass is
+   * not something the pass would have seen anyway.
+   */
+  private List<Table> listing(Schema schema) {
+    return listedTables.computeIfAbsent(
+        schema,
+        key ->
+            translate(
+                "listing tables of " + key.share() + "." + key.name(),
+                () -> client.listTables(key.share(), key.name())));
+  }
+
+  /**
+   * Where the table's data lives, or a refusal.
+   *
+   * <p>Three surfaces, because a server need not use the first two. The reference implementation
+   * states a location in neither its listing nor its metadata action -- both predate directory
+   * access, as its absent {@code accessModes} shows -- and names it only on the credential
+   * response. Reconciling without one is not harmless: the reconciler stores no storage location
+   * and leaves the Integration's own HTTPS catalog URI as the table's upstream reference, so the
+   * table materializes and cannot be opened by anything that reads object storage.
+   *
+   * <p>So every path here ends in a location or a refusal, and nothing reconciles unreadable. A
+   * table this Integration cannot read is refused at the load and counted in {@code
+   * objects_skipped} rather than materialized and left to fail at query time:
+   *
+   * <ul>
+   *   <li>url access alone, which the storage contract cannot express at all.
+   *   <li>no stated modes under {@code delta.sharing.strict-access-modes}, which is the reading
+   *       that knob exists to apply -- refused here without a request, since asking is exactly what
+   *       it turns off.
+   *   <li>no location on any surface, including the credential response.
+   * </ul>
+   */
+  private String requireStorageLocation(
+      Schema addressed,
+      CatalogObjectName name,
+      Table listed,
+      TableDescription described,
+      List<AccessMode> modes) {
+    String qualified = addressed.share() + "." + addressed.name() + "." + name.name();
+    // Both surfaces, not whichever one spoke first. statedModes prefers the listing, and the vend
+    // reads the metaData action alone, so a server saying dir on its listing and url on its
+    // metaData would otherwise load here and be refused there -- on every read, for the life of
+    // the table. The load must not be more permissive than the vend, and the vend sees only the
+    // metaData action, so a stated refusal on either surface is decisive. A table whose listing
+    // says url and whose metaData says dir is refused too: that direction only costs a table
+    // nothing could read through this path anyway, and no reading of two contradictory answers is
+    // worth a vend that fails later.
+    if (refusesDir(listed.accessModes()) || refusesDir(described.metadata().accessModes())) {
+      // Named for what was actually stated. A table stating only modes this client does not know
+      // is not a table offering url access, and saying so sent an operator looking for a url-mode
+      // problem that does not exist.
+      boolean unrecognised =
+          onlyUnrecognised(listed.accessModes())
+              || onlyUnrecognised(described.metadata().accessModes());
+      throw new CatalogAccessException(
+          CatalogAccessException.Code.UNSUPPORTED,
+          unrecognised
+              ? "Delta Sharing table "
+                  + qualified
+                  + " states only access modes this provider does not recognise"
+              : "Delta Sharing table "
+                  + qualified
+                  + " offers url access only, which cannot be vended as storage credentials");
+    }
+    // Only where the modes were genuinely absent. A table stating dir is not the ambiguous case
+    // this knob governs, and refusing it here said "states no access modes" about a table that had
+    // stated them.
+    //
+    // Ahead of the location, not after it. This sat below the early return, so a table with no
+    // stated modes and a location on its listing was loaded and then refused by the vend, which
+    // applies the same rule with no such exemption -- it reconciled and every read of it failed.
+    // Knowing where a table lives says nothing about whether it may be read that way, which is the
+    // only question this knob answers.
+    if (modes.isEmpty() && strictAccessModes) {
+      throw new CatalogAccessException(
+          CatalogAccessException.Code.UNSUPPORTED,
+          "Delta Sharing table "
+              + qualified
+              + " states no access modes, which "
+              + STRICT_ACCESS_MODES
+              + " reads as url only");
+    }
+    // The metaData action first, then the listing, which is the order all three paths use. A
+    // server may state a location on both surfaces and state them differently, so the paths have
+    // to agree on which one wins: otherwise the table reconciles at one location, validation
+    // probes another, and the vend compares the credential's scope against a third, and a passing
+    // storage-access check says nothing about where a read will go. The metaData action is the
+    // surface they can all reach -- the vend cannot see a listing without paging the schema on
+    // every read.
+    Optional<String> stated = described.metadata().location().or(listed::location);
+    // Whether to ask is decided on the metaData action alone, which is the surface the vend reads.
+    // statedModes prefers the listing, so a table stating dir only there took this early return
+    // while the vend saw nothing stated, treated the table as ambiguous and asked -- and a server
+    // that states dir on its listing and then refuses the credential endpoint reconciled here and
+    // failed every read. Same regression as the unstated case, reached by the other surface.
+    //
+    // What both paths still share is trusting a dir the metaData action does state: neither probes
+    // that, so a server contradicting its own metaData is believed. That is a policy rather than an
+    // oversight -- a stated dir followed by a refusal is a server disagreeing with itself, where an
+    // unstated table refusing is the ordinary shape the ask exists for -- and it costs no request
+    // on the common shape. The two paths agree on it, which is what matters here.
+    // Under the strict setting the vend falls back to the listing when the metaData action states
+    // nothing, so the load consults it too and the two still agree. Both surfaces are already in
+    // hand here, so this costs no request -- it only stops the strict setting from spending a
+    // credential POST per table on a server that states its modes where the protocol defines them.
+    List<AccessMode> decidedOn = strictAccessModes ? modes : described.metadata().accessModes();
+    if (!decidedOn.isEmpty() && stated.isPresent()) {
+      return requireServable(stated.get(), qualified);
+    }
+    // No blank check on what comes back. The transport refuses a credentials response that names
+    // no location, as INVALID_RESPONSE, before it reaches here -- so a guard here was unreachable
+    // and, by naming a per-table refusal, implied a graceful skip that does not exist. A server
+    // whose credential endpoint answers 200 without a location ends the pass instead, which is the
+    // rule every unreadable response follows: a response shape this client cannot read is not a
+    // property of one table, and absorbing it per table leaves a broken share looking partly
+    // healthy.
+    // Reached two ways: dir was stated and no surface named a location, or no surface stated
+    // modes at all. In the second case the credential endpoint is the only thing that can answer
+    // whether directory access exists, and a stated location does not answer it -- the protocol
+    // lets a url-only server name one. So a server that omits its access modes, names a location
+    // and refuses this endpoint has to be asked, not assumed: asking is what the default setting
+    // is. askForCredentials classifies the answer, so a refusal arrives as UNSUPPORTED and skips
+    // this table rather than reconciling one whose every read fails.
+    TemporaryCredentials answered =
+        askForCredentials(addressed, name, qualified, "asking where " + qualified + " lives");
+    String vended = answered.location();
+    // The location the credential names is the table's root, whatever shape its path has. The
+    // protocol answers a request naming no location with the table's main location, and a Delta
+    // table may sit directly at a bucket root -- deltaLogPrefix("") answers _delta_log/ for that
+    // case on purpose.
+    //
+    // Whether a credential is scoped where the table actually lives is settled by reading the
+    // Delta log under it, which validateStorageAccess does. The shape of a path cannot settle it,
+    // and a check here that guessed from the shape would refuse tables validation reads happily.
+    // A location a surface stated outranks the credential's scope, which only stands in for one --
+    // but it has to be reachable with the credential the server just answered with. Where both are
+    // known and disjoint, reconciling the stated one materialises a table every read of which is
+    // scoped elsewhere, and validation is optional so nothing else need catch it. The vend makes
+    // this comparison for a location the metaData action states; making it here covers the surface
+    // the vend cannot see.
+    if (stated.isPresent()
+        && !StorageLocations.covers(canonical(vended), canonical(stated.get()))) {
+      throw new CatalogAccessException(
+          CatalogAccessException.Code.CREDENTIAL_SCOPE_INVALID,
+          "Delta Sharing answered for " + qualified + " with credentials that do not reach it");
+    }
+    return requireServable(stated.orElse(vended), qualified);
+  }
+
+  /**
+   * A location this provider can actually read, or a refusal.
+   *
+   * <p>The storage probe addresses S3 and the vend publishes an AWS session, so an {@code abfss://}
+   * or {@code gs://} table would load, reconcile, and then fail at every scan when the vend refused
+   * its cloud -- the unreadable materialized table the other refusals here exist to prevent,
+   * reached by a different route and not counted in {@code objects_skipped} either.
+   */
+  private static String requireServable(String location, String qualified) {
+    if (!DeltaLogStorageProbe.s3Serves(location)) {
+      // The scheme, never the location. This message reaches operator logs through the throwable
+      // the reconciler records, and the location is the server's: a query or fragment on one is a
+      // signature or a SAS token, userinfo is a password, and a control character in it forges a
+      // log line. The scheme is the whole answer to which cloud, and cannot carry any of those.
+      String scheme = schemeOf(location);
+      throw new CatalogAccessException(
+          CatalogAccessException.Code.UNSUPPORTED,
+          "s3".equals(scheme)
+              // Same answer from s3Serves, two different problems. Reporting the cloud for an s3
+              // location whose bucket would not parse told an operator the opposite of what was
+              // wrong, and sent them to look at a provider that reads S3 perfectly well.
+              ? "Delta Sharing table "
+                  + qualified
+                  + " names an s3 location this provider could not read a bucket from"
+              : "Delta Sharing table "
+                  + qualified
+                  + " lives on "
+                  + scheme
+                  + ", which this provider cannot read: it vends AWS session credentials for S3");
+    }
+    // The canonical form, not the one the server sent. This is the value that reaches
+    // CatalogTable.storageLocation and then UpstreamRef, so it has to be one the read path can
+    // parse; see canonical().
+    return canonical(location);
+  }
+
+  /**
+   * The form of a location this provider publishes, vends and compares.
+   *
+   * <p>The rule lives in {@link DeltaLogStorageProbe#canonicalLocation}, beside the probe whose
+   * space encoding created the need for it, because the Unity provider needs the same answer and
+   * had received the probe half of this without the publish half.
+   */
+  private static String canonical(String location) {
+    return DeltaLogStorageProbe.canonicalLocation(location);
+  }
+
+  /** A location's scheme alone, which names the cloud and can hold nothing else. */
+  private static String schemeOf(String location) {
+    try {
+      // Spaces encoded first. An S3 object key may hold one and java.net.URI may not, so a legal
+      // location threw here and was reported as having no readable scheme at all. Other characters
+      // URI rejects and S3 permits are still refused; a space is the one that occurs.
+      String scheme = java.net.URI.create(canonical(location)).getScheme();
+      return scheme == null ? "no addressable scheme" : scheme.toLowerCase(java.util.Locale.ROOT);
+    } catch (IllegalArgumentException notAUri) {
+      return "no addressable scheme";
+    }
+  }
+
+  /**
+   * The credential call, classified as the capability boundary it answers.
+   *
+   * <p>A server without the endpoint answers NOT_FOUND, and the refusal the protocol defines for a
+   * table not offering directory access is INVALID_REQUEST. Both mean the same thing to a caller --
+   * directory access is not available for this table -- so both are reported as unsupported rather
+   * than as a missing table or a bad request.
+   *
+   * <p>Not gated on whether the table stated its modes, so that one HTTP 400 means the same thing
+   * on the load path and the vend path. The server's answer settles it either way: a table whose
+   * listing claims dir and whose credential endpoint refuses does not have directory access,
+   * whatever the listing said.
+   */
+  private TemporaryCredentials askForCredentials(
+      Schema addressed, CatalogObjectName name, String qualified, String action) {
+    try {
+      return client.temporaryTableCredentials(
+          addressed.share(), addressed.name(), name.name(), null);
+    } catch (DeltaSharingException failure) {
+      // A 3xx is excluded. The transport folds a refused redirect into INVALID_REQUEST, and its
+      // own comment says what that means: the base URI names something other than a sharing
+      // server. Read here as the protocol's per-table refusal, an auth proxy or a trailing-slash
+      // redirect in front of the server reported every table as offering no directory access --
+      // a configuration error arriving as a per-table capability limit, table by table, with the
+      // integration looking partly healthy rather than misconfigured.
+      // 400 exactly, not every INVALID_REQUEST. The transport folds 400, 405 and 422 into that
+      // one failure, and only 400 is the protocol's own statement that a table does not offer
+      // directory access. A 405 is a GET-only proxy or a gateway rule and a 422 is neither -- both
+      // are configuration in front of the server, and reading them as a capability limit reported
+      // every table as lacking dir access while the real fault went unnamed. They stay a per-table
+      // skip either way, since INVALID_CONFIGURATION also describes one branch; what changes is
+      // the issue an operator is shown and the message that comes with it.
+      boolean protocolRefusal =
+          failure.failure() == DeltaSharingException.Failure.NOT_FOUND
+              || (failure.failure() == DeltaSharingException.Failure.INVALID_REQUEST
+                  && failure.statusCode() == 400);
+      if (protocolRefusal) {
+        throw new CatalogAccessException(
+            CatalogAccessException.Code.UNSUPPORTED,
+            "Delta Sharing did not offer directory access for " + qualified,
+            failure);
+      }
+      throw new CatalogAccessException(
+          codeFor(failure.failure()), messageFor(action, failure), failure);
+    }
+  }
+
+  private Schema requireSchema(NamespacePath namespace) {
+    List<String> segments = namespace == null ? List.of() : namespace.segments();
+    if (segments.size() != 2) {
+      throw new CatalogAccessException(
+          CatalogAccessException.Code.INVALID_CONFIGURATION,
+          "Delta Sharing addresses a table as share.schema.table, so its namespace has two"
+              + " segments, not "
+              + segments.size());
+    }
+    return new Schema(segments.get(0), segments.get(1));
+  }
+
+  /**
+   * The listed table, which carries the share id that describing it does not.
+   *
+   * <p>Only the load needs this. The vend and the storage probe read one table's metadata instead,
+   * because paging a whole schema to find one table is not something a per-read path should do.
+   */
+  private Table findTable(Schema schema, String name) {
+    // Memoised for the client's lifetime, which is one reconcile pass: the reconciler lists a
+    // schema once and then loads every table in it, and each load looked the table up by paging
+    // the whole listing again. Only loadTable reaches here -- the vend and the storage probe read
+    // one table's metadata instead -- so the window is a single traversal of a schema it has just
+    // listed, and a table appearing mid-pass is not something the pass would have seen anyway.
+    for (Table table : listing(schema)) {
+      if (table.name().equals(name)) {
+        return table;
+      }
+    }
+    throw new CatalogAccessException(
+        CatalogAccessException.Code.NOT_FOUND,
+        "Delta Sharing share " + schema.share() + "." + schema.name() + " does not share " + name);
+  }
+
+  private <T> T translate(String action, java.util.function.Supplier<T> call) {
+    try {
+      return call.get();
+    } catch (DeltaSharingException e) {
+      throw new CatalogAccessException(codeFor(e.failure()), messageFor(action, e), e);
+    }
+  }
+
+  private void translate(String action, Runnable call) {
+    translate(
+        action,
+        () -> {
+          call.run();
+          return null;
+        });
+  }
+
+  private static String messageFor(String action, DeltaSharingException e) {
+    return "Delta Sharing failed while " + action + ": " + e.getMessage();
+  }
+
+  /**
+   * The recipient's classification, mapped to the SPI's.
+   *
+   * <p>The distinction that matters is terminal against retryable. A rejected token and a share not
+   * granted will answer the same way on every attempt; a rate limit, a server error and a transport
+   * failure will not.
+   */
+  private static CatalogAccessException.Code codeFor(DeltaSharingException.Failure failure) {
+    return switch (failure) {
+      case UNAUTHENTICATED -> CatalogAccessException.Code.UNAUTHENTICATED;
+      case PERMISSION_DENIED -> CatalogAccessException.Code.PERMISSION_DENIED;
+      case NOT_FOUND -> CatalogAccessException.Code.NOT_FOUND;
+      case RATE_LIMITED, SERVER_ERROR, TRANSPORT, TRANSIENT ->
+          CatalogAccessException.Code.UNAVAILABLE;
+      case INTERRUPTED -> CatalogAccessException.Code.TIMEOUT;
+      // Split, because they describe different scopes. INVALID_REQUEST is the protocol's own
+      // per-table refusal, and INVALID_CONFIGURATION is per-branch, so the walk steps over it.
+      // INVALID_RESPONSE is a body this client cannot read -- a proxy error page, a version
+      // mismatch reshaping every table -- which describes the catalog. INTERNAL is outside
+      // describesOneBranch, so a reconcile fails on it rather than recording every table as
+      // unobserved and leaving a broken share looking partially healthy. Unity splits them the
+      // same way and for the same reason.
+      case INVALID_REQUEST -> CatalogAccessException.Code.INVALID_CONFIGURATION;
+      case INVALID_RESPONSE -> CatalogAccessException.Code.INTERNAL;
+      // Not UNSUPPORTED. That code now means the provider will never do this: the service skips
+      // the table and reports CIVI_..._UNSUPPORTED, and the vendor reports a deterministic refusal.
+      // OTHER is the catch-all for a status this client does not classify -- 402, 407, 409, 423,
+      // 451 -- which is a real upstream or configuration problem, and naming it unsupported tells
+      // an operator there is nothing to fix. UNAVAILABLE keeps the status in the message and
+      // treats an unknown condition as one a later attempt might not meet.
+      case OTHER -> CatalogAccessException.Code.UNAVAILABLE;
+    };
+  }
+}

--- a/catalog-access/delta-sharing/src/main/java/ai/floedb/floecat/catalog/sharing/DeltaSharingClientProvider.java
+++ b/catalog-access/delta-sharing/src/main/java/ai/floedb/floecat/catalog/sharing/DeltaSharingClientProvider.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.catalog.sharing;
+
+import ai.floedb.floecat.catalog.access.CatalogAccessException;
+import ai.floedb.floecat.catalog.access.CatalogAuthenticationScheme;
+import ai.floedb.floecat.catalog.access.CatalogClient;
+import ai.floedb.floecat.catalog.access.CatalogClientProvider;
+import ai.floedb.floecat.catalog.access.CatalogConnectionConfig;
+import ai.floedb.floecat.catalog.access.CatalogProtocol;
+import ai.floedb.floecat.catalog.access.ResolvedCatalogCredentials;
+import ai.floedb.floecat.client.sharing.DeltaSharingClient;
+import ai.floedb.floecat.client.sharing.HttpDeltaSharingClient;
+import ai.floedb.floecat.http.guards.HttpEndpointGuards;
+import java.net.URI;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/** Opens Delta Sharing recipients for the catalog-access SPI. */
+public final class DeltaSharingClientProvider implements CatalogClientProvider {
+
+  private static final Duration DEFAULT_CONNECT_TIMEOUT = Duration.ofSeconds(10);
+  private static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofSeconds(30);
+
+  /**
+   * Storage properties carried through to a vended credential.
+   *
+   * <p>The temporary-table-credentials response names the location and the key material and nothing
+   * else, so a non-standard object store still has to be told where it is and how to address it.
+   * Against real AWS these are inferable and an operator sets none of them.
+   */
+  private static final List<String> STORAGE_PROPERTY_KEYS =
+      List.of("s3.endpoint", "s3.region", "client.region", "s3.path-style-access");
+
+  static final String READER_FEATURES = "delta.sharing.reader-features";
+
+  /** Seam for tests: builds the recipient without opening a connection. */
+  interface ClientFactory {
+    DeltaSharingClient create(
+        URI endpoint,
+        String bearerToken,
+        Duration connectTimeout,
+        Duration requestTimeout,
+        List<String> readerFeatures);
+  }
+
+  private final ClientFactory clientFactory;
+
+  public DeltaSharingClientProvider() {
+    this(HttpDeltaSharingClient::new);
+  }
+
+  DeltaSharingClientProvider(ClientFactory clientFactory) {
+    this.clientFactory = Objects.requireNonNull(clientFactory, "clientFactory");
+  }
+
+  @Override
+  public CatalogProtocol protocol() {
+    return CatalogProtocol.DELTA_SHARING;
+  }
+
+  @Override
+  public CatalogClient open(
+      CatalogConnectionConfig config, ResolvedCatalogCredentials resolvedCredentials) {
+    Objects.requireNonNull(config, "config");
+    Objects.requireNonNull(resolvedCredentials, "resolvedCredentials");
+    // Cheap defence against a registry mis-dispatch, as the Unity provider makes at its entry.
+    if (config.protocol() != CatalogProtocol.DELTA_SHARING) {
+      throw new CatalogAccessException(
+          CatalogAccessException.Code.INVALID_CONFIGURATION,
+          "Delta Sharing provider was asked for " + config.protocol());
+    }
+
+    // A recipient token, and nothing else. The protocol defines bearer authorization and no other
+    // scheme, so anything else here is a configuration error rather than an unused field. A bearer
+    // token reaches a provider as OAUTH2 carrying a token property, which is how the service
+    // resolves one.
+    if (config.authentication().scheme() != CatalogAuthenticationScheme.OAUTH2) {
+      throw new CatalogAccessException(
+          CatalogAccessException.Code.INVALID_CONFIGURATION,
+          "Delta Sharing authenticates with a recipient bearer token, not "
+              + config.authentication().scheme());
+    }
+    String token = resolvedCredentials.properties().get("token");
+    if (token == null || token.isBlank()) {
+      throw new CatalogAccessException(
+          CatalogAccessException.Code.INVALID_CONFIGURATION,
+          "Delta Sharing requires a resolved recipient token");
+    }
+
+    Map<String, String> properties = config.properties();
+    Map<String, String> storage = new HashMap<>();
+    for (String key : STORAGE_PROPERTY_KEYS) {
+      String value = properties.get(key);
+      if (value != null && !value.isBlank()) {
+        storage.put(key, value.trim());
+      }
+    }
+    // The same gate the Unity provider holds its own s3.endpoint to, for the same reason: this
+    // vend publishes an AWS session token, and the endpoint travels on to query workers.
+    try {
+      HttpEndpointGuards.requireUsableStorageEndpoint(
+          storage.get("s3.endpoint"), "Delta Sharing s3.endpoint");
+    } catch (IllegalArgumentException refused) {
+      throw new CatalogAccessException(
+          CatalogAccessException.Code.INVALID_CONFIGURATION, refused.getMessage(), refused);
+    }
+
+    // Before the client exists. Arguments evaluate left to right, so resolving this inside the
+    // constructor call built the transport first and leaked it when the property was malformed --
+    // once per open, which is once per vend and once per validation.
+    boolean strict = strictAccessModes(properties);
+
+    // The transport is open by the time the wrapper's constructor runs, so anything it raises
+    // leaks it -- once per vend and once per validation, the same window the flag above is
+    // resolved early to avoid.
+    DeltaSharingClient recipient;
+    try {
+      recipient =
+          clientFactory.create(
+              config.endpoint(),
+              token,
+              durationProperty(properties, "http.connect.ms", DEFAULT_CONNECT_TIMEOUT),
+              durationProperty(properties, "http.read.ms", DEFAULT_REQUEST_TIMEOUT),
+              readerFeatures(properties));
+    } catch (IllegalArgumentException refused) {
+      // The message as the transport wrote it. Naming a property here was wrong: the constructor
+      // raises this for the endpoint gates, the two floecat.delta-sharing.* limits and a blank
+      // token as well as for a reader feature, so an operator pointing at an http:// endpoint was
+      // told about delta.sharing.reader-features, which they had never set.
+      throw new CatalogAccessException(
+          CatalogAccessException.Code.INVALID_CONFIGURATION, refused.getMessage(), refused);
+    }
+    try {
+      return new DeltaSharingCatalogClient(recipient, storage, strict);
+    } catch (RuntimeException | Error failure) {
+      closeQuietly(recipient);
+      throw failure;
+    }
+  }
+
+  private static void closeQuietly(DeltaSharingClient recipient) {
+    try {
+      recipient.close();
+    } catch (RuntimeException ignored) {
+      // Closing is what releases the transport; a failure to close adds nothing to report.
+    }
+  }
+
+  /**
+   * Whether a table stating no access modes is read as url only, off by default.
+   *
+   * <p>The protocol reads an absent field as url only, and the reference server implements the
+   * credential endpoint while stating nothing at all, so holding to that reading refuses every
+   * table on a server that would have vended. The default asks and lets the server answer; an
+   * operator who wants the protocol reading enforced without a round trip sets this.
+   */
+  private static boolean strictAccessModes(Map<String, String> properties) {
+    String value = properties.get(DeltaSharingCatalogClient.STRICT_ACCESS_MODES);
+    if (value == null || value.isBlank()) {
+      return false;
+    }
+    String trimmed = value.trim();
+    if (trimmed.equalsIgnoreCase("true")) {
+      return true;
+    }
+    if (trimmed.equalsIgnoreCase("false")) {
+      return false;
+    }
+    throw new CatalogAccessException(
+        CatalogAccessException.Code.INVALID_CONFIGURATION,
+        DeltaSharingCatalogClient.STRICT_ACCESS_MODES + " must be true or false, not " + value);
+  }
+
+  /**
+   * Delta reader features this deployment can process, empty by default.
+   *
+   * <p>Empty rather than everything the protocol names. The capability header tells the server what
+   * the client can handle, and claiming a feature the read path cannot process turns a refusal the
+   * server would have made into a failure partway through a scan. An operator opts in per feature
+   * once the read path is known to support it.
+   *
+   * <p>Enforcement is the server's. This list reaches it in {@code delta-sharing-capabilities} on
+   * the metadata call, and nothing here compares it against the {@code readerFeatures} the protocol
+   * action reports back. Under directory access the data read goes straight to object storage with
+   * the vended credential, so there is no later point at which the server could refuse -- which
+   * means a server that ignores the header is not caught, and a table needing more than the opt-in
+   * would be read rather than rejected. Checking it locally is a policy this does not yet take.
+   */
+  private static List<String> readerFeatures(Map<String, String> properties) {
+    String configured = properties.get(READER_FEATURES);
+    if (configured == null || configured.isBlank()) {
+      return List.of();
+    }
+    List<String> features = new ArrayList<>();
+    for (String feature : configured.split(",")) {
+      String trimmed = feature.trim();
+      if (trimmed.isEmpty()) {
+        continue;
+      }
+      // Not checked here. The transport validates each token where it interpolates it into the
+      // capability header, which is the only place the shape matters and the one place every
+      // construction path goes through; open() turns that refusal into this property's name.
+      features.add(trimmed);
+    }
+    return List.copyOf(features);
+  }
+
+  private static Duration durationProperty(
+      Map<String, String> properties, String key, Duration fallback) {
+    String value = properties.get(key);
+    if (value == null || value.isBlank()) {
+      return fallback;
+    }
+    long millis;
+    try {
+      millis = Long.parseLong(value.trim());
+    } catch (NumberFormatException notANumber) {
+      throw new CatalogAccessException(
+          CatalogAccessException.Code.INVALID_CONFIGURATION,
+          key + " must be a number of milliseconds, not " + value);
+    }
+    if (millis <= 0) {
+      throw new CatalogAccessException(
+          CatalogAccessException.Code.INVALID_CONFIGURATION, key + " must be above zero");
+    }
+    return Duration.ofMillis(millis);
+  }
+}

--- a/catalog-access/delta-sharing/src/main/resources/META-INF/services/ai.floedb.floecat.catalog.access.CatalogClientProvider
+++ b/catalog-access/delta-sharing/src/main/resources/META-INF/services/ai.floedb.floecat.catalog.access.CatalogClientProvider
@@ -1,0 +1,6 @@
+# Copyright 2026 Yellowbrick Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+ai.floedb.floecat.catalog.sharing.DeltaSharingClientProvider

--- a/catalog-access/delta-sharing/src/test/java/ai/floedb/floecat/catalog/sharing/DeltaSharingCatalogClientTest.java
+++ b/catalog-access/delta-sharing/src/test/java/ai/floedb/floecat/catalog/sharing/DeltaSharingCatalogClientTest.java
@@ -1,0 +1,1560 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.catalog.sharing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import ai.floedb.floecat.catalog.access.CatalogAccessException;
+import ai.floedb.floecat.catalog.access.CatalogCapability;
+import ai.floedb.floecat.catalog.access.CatalogObjectName;
+import ai.floedb.floecat.catalog.access.CatalogTable;
+import ai.floedb.floecat.catalog.access.CatalogTraversalFailures;
+import ai.floedb.floecat.catalog.access.NamespacePath;
+import ai.floedb.floecat.catalog.access.VendedStorageCredentials;
+import ai.floedb.floecat.catalog.delta.DeltaLogStorageProbe;
+import ai.floedb.floecat.client.sharing.DeltaSharingClient;
+import ai.floedb.floecat.client.sharing.DeltaSharingException;
+import ai.floedb.floecat.client.sharing.DeltaSharingModel.AccessMode;
+import ai.floedb.floecat.client.sharing.DeltaSharingModel.CredentialCloud;
+import ai.floedb.floecat.client.sharing.DeltaSharingModel.Protocol;
+import ai.floedb.floecat.client.sharing.DeltaSharingModel.Schema;
+import ai.floedb.floecat.client.sharing.DeltaSharingModel.Share;
+import ai.floedb.floecat.client.sharing.DeltaSharingModel.Table;
+import ai.floedb.floecat.client.sharing.DeltaSharingModel.TableDescription;
+import ai.floedb.floecat.client.sharing.DeltaSharingModel.TableMetadata;
+import ai.floedb.floecat.client.sharing.DeltaSharingModel.TemporaryCredentials;
+import java.net.URI;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class DeltaSharingCatalogClientTest {
+
+  private static final String LOCATION = "s3://sharing/gold/events";
+
+  @Test
+  void capabilitiesCoverDiscoveryAndVending() {
+    try (DeltaSharingCatalogClient client = client(new FakeSharingClient())) {
+      assertThat(client.capabilities().supports(CatalogCapability.LIST_NAMESPACES)).isTrue();
+      assertThat(client.capabilities().supports(CatalogCapability.VEND_STORAGE_CREDENTIALS))
+          .isTrue();
+      assertThat(client.capabilities().supports(CatalogCapability.STABLE_OBJECT_IDS)).isTrue();
+    }
+  }
+
+  @Test
+  void rootListsSharesAndOneSegmentListsSchemas() {
+    FakeSharingClient fake = new FakeSharingClient();
+    try (DeltaSharingCatalogClient client = client(fake)) {
+      assertThat(client.listNamespaces(new NamespacePath(List.of())))
+          .containsExactly(new NamespacePath(List.of("prod")));
+      assertThat(client.listNamespaces(new NamespacePath(List.of("prod"))))
+          .containsExactly(new NamespacePath(List.of("prod", "gold")));
+    }
+  }
+
+  @Test
+  void belowSchemaIsEmptyRatherThanAnError() {
+    try (DeltaSharingCatalogClient client = client(new FakeSharingClient())) {
+      assertThat(client.listNamespaces(new NamespacePath(List.of("prod", "gold", "events"))))
+          .isEmpty();
+    }
+  }
+
+  /**
+   * A share holds schemas, not tables. The reconciler lists tables at every selected namespace
+   * before descending into it, so raising here abandoned any overlay whose include named a whole
+   * share rather than a schema within it.
+   */
+  @Test
+  void listingTablesAtAShareIsEmptyRatherThanAnError() {
+    FakeSharingClient fake = new FakeSharingClient();
+    try (DeltaSharingCatalogClient client = client(fake)) {
+      assertThat(client.listTables(new NamespacePath(List.of("prod")))).isEmpty();
+      assertThat(client.listTables(NamespacePath.root())).isEmpty();
+      assertThat(client.listTables(new NamespacePath(List.of("prod", "gold", "deeper")))).isEmpty();
+    }
+    // Empty because the level holds none, not because the upstream was asked and said so.
+    assertThat(fake.listTablesCalls).isZero();
+  }
+
+  /** Addressing a table still has to name one, so the load path keeps its shape check. */
+  @Test
+  void loadingATableOutsideShareDotSchemaIsAConfigurationError() {
+    try (DeltaSharingCatalogClient client = client(new FakeSharingClient())) {
+      assertThatThrownBy(
+              () ->
+                  client.loadTable(new CatalogObjectName(new NamespacePath(List.of("prod")), "t")))
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure ->
+                  assertThat(failure.code())
+                      .isEqualTo(CatalogAccessException.Code.INVALID_CONFIGURATION));
+    }
+  }
+
+  /**
+   * A table id is unique within its share, not across the server, so an identity built from it
+   * alone would collide between two shares carrying the same id -- which the reconciler treats as a
+   * duplicate and abandons the overlay over.
+   */
+  @Test
+  void loadTableScopesTheStableIdentityToItsShare() {
+    try (DeltaSharingCatalogClient client = client(new FakeSharingClient())) {
+      CatalogTable table = client.loadTable(events());
+      assertThat(table.identity().value()).isEqualTo("share-uuid:tbl-1");
+      assertThat(table.identity().stable()).isTrue();
+      assertThat(table.storageLocation()).contains(LOCATION);
+      assertThat(table.properties()).containsEntry("delta.sharing.access-modes", "url,dir");
+      assertThat(table.properties()).containsEntry("delta.sharing.version", "12");
+      // The reconciler accepts ICEBERG or DELTA and nothing else. The metaData action's
+      // format.provider names the data file format underneath the table, which is a different
+      // question, and is kept as a property rather than reported as the table's format.
+      assertThat(table.format()).isEqualTo("DELTA");
+      assertThat(table.properties()).containsEntry("delta.sharing.file-format", "parquet");
+    }
+  }
+
+  @Test
+  void aShareWithoutAServerIdIsNamedButNotClaimedStable() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.shareId = Optional.empty();
+    try (DeltaSharingCatalogClient client = client(fake)) {
+      CatalogTable table = client.loadTable(events());
+      // Unambiguous, because the share name still separates two shares. Not stable, because the
+      // protocol promises nothing about a share name surviving.
+      assertThat(table.identity().value()).isEqualTo("prod:tbl-1");
+      assertThat(table.identity().stable()).isFalse();
+    }
+  }
+
+  /**
+   * The metaData action's id is the underlying Delta table's, not the share entry's. A share
+   * exposing one physical table under two names reports the same value for both, and the reconciler
+   * abandons the whole overlay on a duplicate stable identity -- so the listing's id or nothing.
+   */
+  @Test
+  void aListingWithoutATableIdDoesNotBorrowThePhysicalTableId() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.tableId = Optional.empty();
+    fake.metadataId = Optional.of("physical-table-uuid");
+    try (DeltaSharingCatalogClient client = client(fake)) {
+      CatalogTable table = client.loadTable(events());
+      assertThat(table.identity().value()).isEqualTo("prod.gold.events");
+      assertThat(table.identity().stable()).isFalse();
+    }
+  }
+
+  /** Two entries on one physical table must not collide, which is what dropped the overlay. */
+  @Test
+  void twoEntriesSharingOnePhysicalTableGetDistinctIdentities() {
+    FakeSharingClient first = new FakeSharingClient();
+    first.tableId = Optional.empty();
+    first.metadataId = Optional.of("physical-table-uuid");
+    FakeSharingClient second = new FakeSharingClient();
+    second.tableId = Optional.empty();
+    second.metadataId = Optional.of("physical-table-uuid");
+    second.schemaName = "silver";
+    try (DeltaSharingCatalogClient one = client(first);
+        DeltaSharingCatalogClient two = client(second)) {
+      assertThat(one.loadTable(events()).identity().value())
+          .isNotEqualTo(
+              two.loadTable(
+                      new CatalogObjectName(new NamespacePath(List.of("prod", "silver")), "events"))
+                  .identity()
+                  .value());
+    }
+  }
+
+  @Test
+  void aTableWithNoIdAnywhereFallsBackToItsNameAndReportsThatAsUnstable() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.tableId = Optional.empty();
+    fake.metadataId = Optional.empty();
+    try (DeltaSharingCatalogClient client = client(fake)) {
+      CatalogTable table = client.loadTable(events());
+      assertThat(table.identity().value()).isEqualTo("prod.gold.events");
+      assertThat(table.identity().stable()).isFalse();
+    }
+  }
+
+  /**
+   * The property is a report of what the share said, so it must not say url when the share said
+   * nothing -- that is the reading the vend deliberately declines to apply.
+   */
+  @Test
+  void aServerStatingNoModesIsReportedAsUnstatedRatherThanUrl() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.accessModes = List.of();
+    try (DeltaSharingCatalogClient client = client(fake)) {
+      assertThat(client.loadTable(events()).properties())
+          .containsEntry("delta.sharing.access-modes", "unstated");
+    }
+  }
+
+  /** In the delta response format the metaData action states the modes, not only the listing. */
+  @Test
+  void modesStatedOnlyByTheMetadataActionAreStillReported() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.accessModes = List.of();
+    fake.metadataAccessModes = List.of(AccessMode.DIR);
+    try (DeltaSharingCatalogClient client = client(fake)) {
+      assertThat(client.loadTable(events()).properties())
+          .containsEntry("delta.sharing.access-modes", "dir");
+    }
+  }
+
+  /**
+   * The protocol wants a credential per location, root and auxiliary alike, and tells a client that
+   * cannot read from several to fall back to url access or raise. One scoped credential cannot
+   * carry the rest, so the table is refused before it can reconcile.
+   */
+  @Test
+  void aTableWithAuxiliaryLocationsIsRefusedBeforeItCanReconcile() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.auxiliaryLocations = List.of("s3://sharing/gold/events-aux");
+    try (DeltaSharingCatalogClient client = client(fake)) {
+      assertThatThrownBy(() -> client.loadTable(events()))
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure -> {
+                assertThat(failure.code()).isEqualTo(CatalogAccessException.Code.UNSUPPORTED);
+                assertThat(failure.getMessage())
+                    .contains("prod.gold.events", "auxiliary storage locations");
+              });
+    }
+  }
+
+  @Test
+  void aTableTheShareDoesNotCarryIsNotFound() {
+    try (DeltaSharingCatalogClient client = client(new FakeSharingClient())) {
+      assertThatThrownBy(() -> client.loadTable(new CatalogObjectName(schemaPath(), "not_shared")))
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure ->
+                  assertThat(failure.code()).isEqualTo(CatalogAccessException.Code.NOT_FOUND));
+    }
+  }
+
+  @Test
+  void vendingPublishesTheSessionTriadScopedToTheServersLocation() {
+    try (DeltaSharingCatalogClient client =
+        new DeltaSharingCatalogClient(new FakeSharingClient(), Map.of("s3.region", "us-east-1"))) {
+      VendedStorageCredentials vended = client.vendStorageCredentials(events()).orElseThrow();
+      assertThat(vended.properties())
+          .containsEntry("s3.access-key-id", "AKIA")
+          .containsEntry("s3.secret-access-key", "secret")
+          .containsEntry("s3.session-token", "session")
+          .containsEntry("s3.region", "us-east-1");
+      assertThat(vended.scopePrefix()).isEqualTo(LOCATION);
+      assertThat(vended.expiresAt()).isPresent();
+    }
+  }
+
+  @Test
+  void aUrlOnlyTableIsRefusedByNameRatherThanVendingNothing() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.accessModes = List.of(AccessMode.URL);
+    try (DeltaSharingCatalogClient client = client(fake)) {
+      assertThatThrownBy(() -> client.vendStorageCredentials(events()))
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure -> {
+                assertThat(failure.code()).isEqualTo(CatalogAccessException.Code.UNSUPPORTED);
+                assertThat(failure.getMessage()).contains("prod.gold.events", "url access only");
+              });
+    }
+  }
+
+  /**
+   * A server that states nothing is asked rather than refused.
+   *
+   * <p>The protocol reads an absent field as url only. The reference implementation vends through
+   * {@code temporary-table-credentials} while never sending the field at all, so holding to that
+   * reading refuses every table on a server that would have answered.
+   */
+  @Test
+  void aServerThatStatesNoAccessModesIsAskedRatherThanRefused() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.accessModes = List.of();
+    try (DeltaSharingCatalogClient client = client(fake)) {
+      VendedStorageCredentials vended = client.vendStorageCredentials(events()).orElseThrow();
+      assertThat(vended.scopePrefix()).isEqualTo(LOCATION);
+    }
+  }
+
+  @Test
+  void theStrictSettingReadsAnUnstatedTableAsUrlOnlyWithoutAsking() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.accessModes = List.of();
+    fake.credentialFailure = DeltaSharingException.Failure.SERVER_ERROR;
+    try (DeltaSharingCatalogClient client = new DeltaSharingCatalogClient(fake, Map.of(), true)) {
+      assertThatThrownBy(() -> client.vendStorageCredentials(events()))
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure -> {
+                assertThat(failure.code()).isEqualTo(CatalogAccessException.Code.UNSUPPORTED);
+                assertThat(failure.getMessage())
+                    .contains("delta.sharing.strict-access-modes", "prod.gold.events");
+              });
+    }
+  }
+
+  @Test
+  void theStrictSettingStillVendsForATableThatStatesDirectoryAccess() {
+    FakeSharingClient fake = new FakeSharingClient();
+    try (DeltaSharingCatalogClient client = new DeltaSharingCatalogClient(fake, Map.of(), true)) {
+      assertThat(client.vendStorageCredentials(events())).isPresent();
+    }
+  }
+
+  @Test
+  void aServerWithoutTheCredentialEndpointIsReportedAsUnsupportedNotMissing() {
+    for (DeltaSharingException.Failure refusal :
+        List.of(
+            DeltaSharingException.Failure.NOT_FOUND,
+            DeltaSharingException.Failure.INVALID_REQUEST)) {
+      FakeSharingClient fake = new FakeSharingClient();
+      fake.accessModes = List.of();
+      fake.credentialFailure = refusal;
+      // The status the protocol defines for each: 404 for a server without the endpoint, 400 for
+      // its refusal of a table that does not offer directory access.
+      fake.credentialStatus = refusal == DeltaSharingException.Failure.NOT_FOUND ? 404 : 400;
+      try (DeltaSharingCatalogClient client = client(fake)) {
+        assertThatThrownBy(() -> client.vendStorageCredentials(events()))
+            .describedAs("%s", refusal)
+            .isInstanceOfSatisfying(
+                CatalogAccessException.class,
+                failure -> {
+                  assertThat(failure.code()).isEqualTo(CatalogAccessException.Code.UNSUPPORTED);
+                  assertThat(failure.getMessage()).contains("prod.gold.events");
+                });
+      }
+    }
+  }
+
+  @Test
+  void askingDoesNotTurnARejectedTokenIntoAnUnsupportedTable() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.accessModes = List.of();
+    fake.credentialFailure = DeltaSharingException.Failure.UNAUTHENTICATED;
+    try (DeltaSharingCatalogClient client = client(fake)) {
+      assertThatThrownBy(() -> client.vendStorageCredentials(events()))
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure ->
+                  assertThat(failure.code())
+                      .isEqualTo(CatalogAccessException.Code.UNAUTHENTICATED));
+    }
+  }
+
+  @Test
+  void aTableThatStatesUrlOnlyIsRefusedEvenWithoutTheStrictSetting() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.accessModes = List.of(AccessMode.URL);
+    fake.credentialFailure = DeltaSharingException.Failure.SERVER_ERROR;
+    try (DeltaSharingCatalogClient client = client(fake)) {
+      assertThatThrownBy(() -> client.vendStorageCredentials(events()))
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure ->
+                  assertThat(failure.code()).isEqualTo(CatalogAccessException.Code.UNSUPPORTED));
+    }
+  }
+
+  @Test
+  void aListingWithoutALocationFallsBackToTheMetadataEndpoint() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.listedLocation = Optional.empty();
+    RecordingProbe probe = new RecordingProbe();
+    try (DeltaSharingCatalogClient client =
+        new DeltaSharingCatalogClient(fake, Map.of(), false, probe)) {
+      client.validateStorageAccess(
+          events(),
+          new VendedStorageCredentials(
+              Map.of("s3.access-key-id", "AKIA"), "s3://sharing/gold", Optional.empty()));
+    }
+    assertThat(probe.location).isEqualTo(LOCATION);
+  }
+
+  @Test
+  void aNonAwsCredentialIsRefusedByCloud() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.credentials =
+        new TemporaryCredentials(
+            CredentialCloud.AZURE,
+            LOCATION,
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty());
+    try (DeltaSharingCatalogClient client = client(fake)) {
+      assertThatThrownBy(() -> client.vendStorageCredentials(events()))
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure -> {
+                assertThat(failure.code()).isEqualTo(CatalogAccessException.Code.UNSUPPORTED);
+                assertThat(failure.getMessage()).contains("AZURE");
+              });
+    }
+  }
+
+  @Test
+  void validateStorageAccessProbesTheTableItWasAskedAbout() {
+    RecordingProbe probe = new RecordingProbe();
+    VendedStorageCredentials credentials =
+        new VendedStorageCredentials(
+            Map.of("s3.access-key-id", "AKIA"), "s3://sharing/gold", Optional.empty());
+    try (DeltaSharingCatalogClient client =
+        new DeltaSharingCatalogClient(new FakeSharingClient(), Map.of(), false, probe)) {
+      client.validateStorageAccess(events(), credentials);
+    }
+    assertThat(probe.location).isEqualTo(LOCATION);
+    assertThat(probe.credentials).isSameAs(credentials);
+  }
+
+  /** Scope answers without a network call, so a credential scoped elsewhere never reaches it. */
+  @Test
+  void aCredentialScopedElsewhereIsRefusedBeforeTheProbeRuns() {
+    RecordingProbe probe = new RecordingProbe();
+    try (DeltaSharingCatalogClient client =
+        new DeltaSharingCatalogClient(new FakeSharingClient(), Map.of(), false, probe)) {
+      assertThatThrownBy(
+              () ->
+                  client.validateStorageAccess(
+                      events(),
+                      new VendedStorageCredentials(
+                          Map.of("s3.access-key-id", "AKIA"), "s3://other/gold", Optional.empty())))
+          .isInstanceOf(CatalogAccessException.class);
+    }
+    assertThat(probe.location).isNull();
+  }
+
+  @Test
+  void validateStorageAccessRejectsACredentialScopedElsewhere() {
+    try (DeltaSharingCatalogClient client = client(new FakeSharingClient())) {
+      assertThatThrownBy(
+              () ->
+                  client.validateStorageAccess(
+                      events(),
+                      new VendedStorageCredentials(
+                          Map.of("s3.access-key-id", "AKIA"), "s3://other/gold", Optional.empty())))
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure ->
+                  assertThat(failure.code())
+                      .isEqualTo(CatalogAccessException.Code.CREDENTIAL_SCOPE_INVALID));
+    }
+  }
+
+  @Test
+  void validateProvesTheEndpointAndTokenByListingShares() {
+    FakeSharingClient fake = new FakeSharingClient();
+    try (DeltaSharingCatalogClient client = client(fake)) {
+      client.validate();
+      assertThat(fake.listSharesCalls).isEqualTo(1);
+    }
+  }
+
+  @Test
+  void aRejectedTokenStaysTerminalAndAServerErrorStaysRetryable() {
+    FakeSharingClient rejected = new FakeSharingClient();
+    rejected.failure = DeltaSharingException.Failure.UNAUTHENTICATED;
+    try (DeltaSharingCatalogClient client = client(rejected)) {
+      assertThatThrownBy(client::validate)
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure ->
+                  assertThat(failure.code())
+                      .isEqualTo(CatalogAccessException.Code.UNAUTHENTICATED));
+    }
+
+    FakeSharingClient down = new FakeSharingClient();
+    down.failure = DeltaSharingException.Failure.SERVER_ERROR;
+    try (DeltaSharingCatalogClient client = client(down)) {
+      assertThatThrownBy(client::validate)
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure ->
+                  assertThat(failure.code()).isEqualTo(CatalogAccessException.Code.UNAVAILABLE));
+    }
+  }
+
+  @Test
+  void viewsAreEmptyAndLoadingOneIsUnsupported() {
+    try (DeltaSharingCatalogClient client = client(new FakeSharingClient())) {
+      assertThat(client.listViews(schemaPath())).isEmpty();
+      assertThatThrownBy(() -> client.loadView(events()))
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure ->
+                  assertThat(failure.code()).isEqualTo(CatalogAccessException.Code.UNSUPPORTED));
+    }
+  }
+
+  @Test
+  void closingTheCatalogClientClosesTheRecipient() {
+    FakeSharingClient fake = new FakeSharingClient();
+    client(fake).close();
+    assertThat(fake.closed).isTrue();
+  }
+
+  private static DeltaSharingCatalogClient client(DeltaSharingClient sharing) {
+    return new DeltaSharingCatalogClient(sharing, Map.of());
+  }
+
+  private static NamespacePath schemaPath() {
+    return new NamespacePath(List.of("prod", "gold"));
+  }
+
+  private static CatalogObjectName events() {
+    return new CatalogObjectName(schemaPath(), "events");
+  }
+
+  /** Records what the storage probe was asked, instead of reaching an object store. */
+  private static final class RecordingProbe implements DeltaLogStorageProbe {
+    private String location;
+    private VendedStorageCredentials credentials;
+
+    @Override
+    public void validate(String tableLocation, VendedStorageCredentials vended) {
+      this.location = tableLocation;
+      this.credentials = vended;
+    }
+  }
+
+  /**
+   * A credential is vended on every storage-authority resolve, so listing the schema to find one
+   * table paged the whole schema before every credential POST -- unbounded in the schema's table
+   * count, and quadratic across a reconcile.
+   */
+  @Test
+  void vendingDoesNotListTheSchema() {
+    FakeSharingClient fake = new FakeSharingClient();
+    try (DeltaSharingCatalogClient client = client(fake)) {
+      client.vendStorageCredentials(events());
+    }
+    assertThat(fake.listTablesCalls).isZero();
+  }
+
+  @Test
+  void validatingStorageAccessDoesNotListTheSchema() {
+    FakeSharingClient fake = new FakeSharingClient();
+    try (DeltaSharingCatalogClient client =
+        new DeltaSharingCatalogClient(fake, Map.of(), false, new RecordingProbe())) {
+      client.validateStorageAccess(
+          events(),
+          new VendedStorageCredentials(
+              Map.of("s3.access-key-id", "AKIA"), "s3://sharing/gold", Optional.empty()));
+    }
+    assertThat(fake.listTablesCalls).isZero();
+  }
+
+  /**
+   * UNSUPPORTED now means the provider will never do this, which the service acts on by skipping
+   * the table and reporting a vending-unsupported issue. An unclassified upstream status is a real
+   * problem instead, and must not be reported as a capability boundary.
+   */
+  @Test
+  void anUnclassifiedUpstreamStatusIsNotReportedAsUnsupported() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.credentialFailure = DeltaSharingException.Failure.OTHER;
+    try (DeltaSharingCatalogClient client = client(fake)) {
+      assertThatThrownBy(() -> client.vendStorageCredentials(events()))
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure ->
+                  assertThat(failure.code()).isEqualTo(CatalogAccessException.Code.UNAVAILABLE));
+    }
+  }
+
+  /**
+   * The reconciler lists a schema once and then loads every table in it. Looking each one up by
+   * paging the listing again made that pass quadratic in the schema's table count.
+   */
+  @Test
+  void loadingSeveralTablesListsTheSchemaOnce() {
+    FakeSharingClient fake = new FakeSharingClient();
+    try (DeltaSharingCatalogClient client = client(fake)) {
+      client.loadTable(events());
+      client.loadTable(events());
+      client.loadTable(events());
+    }
+    assertThat(fake.listTablesCalls).isEqualTo(1);
+  }
+
+  /**
+   * Either place may state the modes and neither is required to. Strict mode refuses without asking
+   * the server, so refusing on the metadata action alone would reject a table the share had marked
+   * directory-accessible in its listing.
+   */
+  @Test
+  void theStrictSettingConsultsTheListingBeforeRefusing() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.accessModes = List.of(AccessMode.DIR);
+    fake.metadataAccessModes = List.of();
+    try (DeltaSharingCatalogClient client =
+        new DeltaSharingCatalogClient(fake, Map.of(), true, new RecordingProbe())) {
+      assertThat(client.vendStorageCredentials(events())).isPresent();
+    }
+  }
+
+  /**
+   * The runtime path never reaches validateStorageAccess, so a credential scoped somewhere
+   * unrelated would otherwise be published on every storage-authority resolve.
+   */
+  @Test
+  void aCredentialScopedOutsideTheTableIsRefusedByTheVend() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.credentials =
+        new TemporaryCredentials(
+            CredentialCloud.AWS,
+            "s3://somewhere-else/entirely",
+            Optional.of("AKIA"),
+            Optional.of("secret"),
+            Optional.of("session"),
+            Optional.of(Instant.parse("2026-01-01T00:00:00Z")));
+    try (DeltaSharingCatalogClient client = client(fake)) {
+      assertThatThrownBy(() -> client.vendStorageCredentials(events()))
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure ->
+                  assertThat(failure.code())
+                      .isEqualTo(CatalogAccessException.Code.CREDENTIAL_SCOPE_INVALID));
+    }
+  }
+
+  /** The listing states a location too, so a share using only that is not unvalidatable. */
+  @Test
+  void storageValidationFallsBackToTheListingLocation() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.metadataLocation = Optional.empty();
+    RecordingProbe probe = new RecordingProbe();
+    try (DeltaSharingCatalogClient client =
+        new DeltaSharingCatalogClient(fake, Map.of(), false, probe)) {
+      client.validateStorageAccess(
+          events(),
+          new VendedStorageCredentials(
+              Map.of("s3.access-key-id", "AKIA"), "s3://sharing/gold", Optional.empty()));
+    }
+    assertThat(probe.location).isEqualTo(LOCATION);
+  }
+
+  /**
+   * A body this client cannot read describes the catalog, not one table in it.
+   * INVALID_CONFIGURATION is per-branch, so a reconcile would record every table as unobserved and
+   * leave a broken share looking partially healthy.
+   */
+  @Test
+  void anUnreadableResponseIsNotAPerBranchFailure() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.failure = DeltaSharingException.Failure.INVALID_RESPONSE;
+    try (DeltaSharingCatalogClient client = client(fake)) {
+      assertThatThrownBy(client::validate)
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure -> {
+                assertThat(failure.code()).isEqualTo(CatalogAccessException.Code.INTERNAL);
+                assertThat(CatalogTraversalFailures.describesOneBranch(failure)).isFalse();
+              });
+    }
+  }
+
+  /**
+   * A share root, a bucket, an external-location prefix: broader than the table and left alone.
+   * StorageLocations states the rule -- never be stricter than the component that will use the
+   * credential, because this path is reached only once no storage authority matched, so refusing
+   * fails a read the catalog's own client would have attempted.
+   */
+  @Test
+  void aCredentialScopedAboveTheTableIsPublished() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.credentials =
+        new TemporaryCredentials(
+            CredentialCloud.AWS,
+            "s3://sharing",
+            Optional.of("AKIA"),
+            Optional.of("secret"),
+            Optional.of("session"),
+            Optional.of(Instant.parse("2026-01-01T00:00:00Z")));
+    try (DeltaSharingCatalogClient client = client(fake)) {
+      assertThat(client.vendStorageCredentials(events()).orElseThrow().scopePrefix())
+          .isEqualTo("s3://sharing");
+    }
+  }
+
+  /** An id carrying the delimiter must not collide with a different pair of components. */
+  @Test
+  void identityComponentsAreEscapedSoThePairCannotCollide() {
+    FakeSharingClient first = new FakeSharingClient();
+    first.shareId = Optional.of("a:b");
+    first.tableId = Optional.of("c");
+    first.metadataId = Optional.of("c");
+    FakeSharingClient second = new FakeSharingClient();
+    second.shareId = Optional.of("a");
+    second.tableId = Optional.of("b:c");
+    second.metadataId = Optional.of("b:c");
+    try (DeltaSharingCatalogClient one = client(first);
+        DeltaSharingCatalogClient two = client(second)) {
+      assertThat(one.loadTable(events()).identity().value())
+          .isNotEqualTo(two.loadTable(events()).identity().value());
+    }
+  }
+
+  /**
+   * The reconciler lists a schema and then loads every table in it; that is one listing, not two.
+   */
+  @Test
+  void listingThenLoadingPagesTheSchemaOnce() {
+    FakeSharingClient fake = new FakeSharingClient();
+    try (DeltaSharingCatalogClient client = client(fake)) {
+      client.listTables(schemaPath());
+      client.loadTable(events());
+    }
+    assertThat(fake.listTablesCalls).isEqualTo(1);
+  }
+
+  /**
+   * The protocol states auxiliary locations on the listing as well as the metadata action, and says
+   * a client that cannot read one should fall back to url access or fail the request.
+   */
+  @Test
+  void auxiliaryLocationsStatedOnlyByTheListingAlsoRefuseTheLoad() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.listedAuxiliaryLocations = List.of("s3://sharing/gold/events-aux");
+    try (DeltaSharingCatalogClient client = client(fake)) {
+      assertThatThrownBy(() -> client.loadTable(events()))
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure -> {
+                assertThat(failure.code()).isEqualTo(CatalogAccessException.Code.UNSUPPORTED);
+                assertThat(failure.getMessage()).contains("auxiliary storage locations");
+              });
+    }
+  }
+
+  /**
+   * The reference implementation names a location on neither its listing nor its metadata action,
+   * only on the credential response. Reconciling without one stores no storage location and falls
+   * back to the Integration's HTTPS catalog URI, so the table materializes and cannot be opened.
+   */
+  @Test
+  void aLocationStatedOnlyByTheCredentialResponseStillReachesTheTable() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.listedLocation = Optional.empty();
+    fake.metadataLocation = Optional.empty();
+    fake.accessModes = List.of();
+    try (DeltaSharingCatalogClient client = client(fake)) {
+      assertThat(client.loadTable(events()).storageLocation()).contains(LOCATION);
+    }
+  }
+
+  /**
+   * A url-only table is refused at the load, not left to fail at read time. Materializing it stores
+   * no storage location and leaves the share's own HTTPS endpoint as the upstream reference, which
+   * is the unreadable shape the location work exists to prevent -- so the two cases are refused the
+   * same way rather than one of each.
+   */
+  @Test
+  void aUrlOnlyTableIsRefusedAtTheLoadWithoutBeingAsked() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.accessModes = List.of(AccessMode.URL);
+    try (DeltaSharingCatalogClient client = client(fake)) {
+      assertThatThrownBy(() -> client.loadTable(events()))
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure -> {
+                assertThat(failure.code()).isEqualTo(CatalogAccessException.Code.UNSUPPORTED);
+                assertThat(failure.getMessage()).contains("url access only");
+              });
+    }
+    assertThat(fake.credentialCalls).isZero();
+  }
+
+  /**
+   * The load and the vend answer the same question the same way. The strict refusal sat below the
+   * early return on a stated location, so a table with no stated modes whose listing named a
+   * location loaded, and then the vend refused it on the rule the load had skipped: it reconciled
+   * and every read of it failed. Knowing where a table lives says nothing about whether it may be
+   * read that way.
+   */
+  @Test
+  void strictModeRefusesAnUnstatedTableAtBothPathsEvenWhenTheListingNamesALocation() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.accessModes = List.of();
+    fake.listedLocation = Optional.of(LOCATION);
+    fake.metadataLocation = Optional.empty();
+    try (DeltaSharingCatalogClient client =
+        new DeltaSharingCatalogClient(fake, Map.of(), true, new RecordingProbe())) {
+      assertThatThrownBy(() -> client.loadTable(events()))
+          .as("load")
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure -> {
+                assertThat(failure.code()).isEqualTo(CatalogAccessException.Code.UNSUPPORTED);
+                assertThat(failure.getMessage())
+                    .contains(DeltaSharingCatalogClient.STRICT_ACCESS_MODES);
+              });
+      assertThatThrownBy(() -> client.vendStorageCredentials(events()))
+          .as("vend")
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure ->
+                  assertThat(failure.code()).isEqualTo(CatalogAccessException.Code.UNSUPPORTED));
+    }
+    assertThat(fake.credentialCalls).isZero();
+  }
+
+  /**
+   * One location, whichever path asks. The load preferred the listing while validation and the vend
+   * read the metaData action, so a server stating a location on both surfaces that differ had the
+   * table reconciling at one, being probed at another, and having the credential's scope compared
+   * against that other -- a passing storage-access check saying nothing about where a read would
+   * go. All three agree on the metaData action, because the vend cannot see a listing without
+   * paging the schema on every read.
+   */
+  @Test
+  void allThreePathsResolveTheSameLocationWhenTheSurfacesDisagree() {
+    String listingLocation = "s3://sharing/gold/from-listing";
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.accessModes = List.of(AccessMode.DIR);
+    fake.listedLocation = Optional.of(listingLocation);
+    fake.metadataLocation = Optional.of(LOCATION);
+    RecordingProbe probe = new RecordingProbe();
+    try (DeltaSharingCatalogClient client =
+        new DeltaSharingCatalogClient(fake, Map.of(), false, probe)) {
+      assertThat(client.loadTable(events()).storageLocation()).as("load").contains(LOCATION);
+      assertThat(client.vendStorageCredentials(events()))
+          .as("vend")
+          .get()
+          .extracting(VendedStorageCredentials::scopePrefix)
+          .isEqualTo(LOCATION);
+      client.validateStorageAccess(
+          events(),
+          new VendedStorageCredentials(
+              Map.of("s3.access-key-id", "AKIA"), LOCATION, Optional.empty()));
+    }
+    assertThat(probe.location).as("probed").isEqualTo(LOCATION);
+  }
+
+  /**
+   * The last surface pairing where the two paths disagreed, and it ran the wrong way. statedModes
+   * prefers the listing, so a table stating dir only there took the load's early return without
+   * asking, while the vend -- which reads the metaData action alone -- saw nothing stated, treated
+   * the table as ambiguous and asked. A server advertising dir on its listing and then refusing the
+   * credential endpoint reconciled and failed every read.
+   */
+  @Test
+  void aDirStatedOnlyOnTheListingIsStillAskedAboutAtTheLoad() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.accessModes = List.of(AccessMode.DIR);
+    fake.metadataAccessModes = List.of();
+    fake.listedLocation = Optional.of(LOCATION);
+    fake.metadataLocation = Optional.of(LOCATION);
+    fake.credentialFailure = DeltaSharingException.Failure.INVALID_REQUEST;
+    fake.credentialStatus = 400;
+    try (DeltaSharingCatalogClient client =
+        new DeltaSharingCatalogClient(fake, Map.of(), false, new RecordingProbe())) {
+      assertThatThrownBy(() -> client.loadTable(events()))
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure ->
+                  assertThat(failure.code()).isEqualTo(CatalogAccessException.Code.UNSUPPORTED));
+    }
+    assertThat(fake.credentialCalls).isPositive();
+  }
+
+  /**
+   * A dir the metaData action does state is trusted, and no request is spent on it. Both paths
+   * agree on that, which is the property that matters; a server contradicting its own metaData is a
+   * different problem from one that left the question open.
+   */
+  @Test
+  void aDirStatedOnTheMetadataActionCostsNoCredentialCallAtTheLoad() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.accessModes = List.of(AccessMode.DIR);
+    fake.metadataAccessModes = List.of(AccessMode.DIR);
+    try (DeltaSharingCatalogClient client =
+        new DeltaSharingCatalogClient(fake, Map.of(), false, new RecordingProbe())) {
+      assertThat(client.loadTable(events()).storageLocation()).contains(LOCATION);
+    }
+    assertThat(fake.credentialCalls).isZero();
+  }
+
+  /**
+   * The location that reconciles has to be one the read path can parse. Encoding the space only
+   * inside the probe was half a fix: the raw string was still what got published, so the table
+   * materialised as {@code s3://.../my table} and every scan threw on {@code URI.create} after
+   * validation had passed. The read path derives its key with {@code URI.getPath}, which decodes,
+   * so the encoded form asks S3 for the key that was written.
+   */
+  @Test
+  void aLocationWithASpaceIsPublishedInAFormTheReadPathCanParse() {
+    String raw = "s3://sharing/gold/my table";
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.accessModes = List.of(AccessMode.DIR);
+    fake.listedLocation = Optional.of(raw);
+    fake.metadataLocation = Optional.of(raw);
+    fake.credentials =
+        new TemporaryCredentials(
+            CredentialCloud.AWS,
+            raw,
+            Optional.of("AKIA"),
+            Optional.of("secret"),
+            Optional.of("session"),
+            Optional.of(Instant.parse("2026-01-01T00:00:00Z")));
+    RecordingProbe probe = new RecordingProbe();
+    try (DeltaSharingCatalogClient client =
+        new DeltaSharingCatalogClient(fake, Map.of(), false, probe)) {
+      String published = client.loadTable(events()).storageLocation().orElseThrow();
+      assertThat(published).isEqualTo("s3://sharing/gold/my%20table");
+      assertThatCode(() -> URI.create(published)).doesNotThrowAnyException();
+      assertThat(URI.create(published).getPath()).isEqualTo("/gold/my table");
+
+      // And the vend publishes the same form, so covers() compares like with like.
+      assertThat(client.vendStorageCredentials(events()))
+          .get()
+          .extracting(VendedStorageCredentials::scopePrefix)
+          .isEqualTo("s3://sharing/gold/my%20table");
+    }
+  }
+
+  /**
+   * Only 400 is the protocol's own refusal. The transport folds 400, 405 and 422 into one failure,
+   * so a GET-only proxy answering 405 was read as every table lacking directory access while the
+   * real fault went unnamed. Both stay a per-table skip; what changes is what the operator is told.
+   */
+  @Test
+  void aMethodNotAllowedIsNotReadAsMissingDirectoryAccess() {
+    for (int status : List.of(405, 422)) {
+      FakeSharingClient fake = new FakeSharingClient();
+      fake.accessModes = List.of(AccessMode.DIR);
+      fake.credentialFailure = DeltaSharingException.Failure.INVALID_REQUEST;
+      fake.credentialStatus = status;
+      try (DeltaSharingCatalogClient client =
+          new DeltaSharingCatalogClient(fake, Map.of(), false, new RecordingProbe())) {
+        assertThatThrownBy(() -> client.vendStorageCredentials(events()))
+            .describedAs("%s", status)
+            .isInstanceOfSatisfying(
+                CatalogAccessException.class,
+                failure ->
+                    assertThat(failure.code())
+                        .isNotEqualTo(CatalogAccessException.Code.UNSUPPORTED));
+      }
+    }
+  }
+
+  /**
+   * Under the strict setting the vend falls back to the listing, so the load consults it too. Both
+   * surfaces are already in hand, so this costs no request -- it stops the knob from spending a
+   * credential POST per table against a server stating its modes where the protocol defines them.
+   */
+  @Test
+  void strictModeTrustsADirStatedOnTheListingWithoutAsking() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.accessModes = List.of(AccessMode.DIR);
+    fake.metadataAccessModes = List.of();
+    fake.listedLocation = Optional.of(LOCATION);
+    try (DeltaSharingCatalogClient client =
+        new DeltaSharingCatalogClient(fake, Map.of(), true, new RecordingProbe())) {
+      assertThat(client.loadTable(events()).storageLocation()).contains(LOCATION);
+    }
+    assertThat(fake.credentialCalls).isZero();
+  }
+
+  /**
+   * The scope the vend publishes is checked the way the load checks a location. requireServable ran
+   * only at the load, so on the reference-server shape -- no location on the metaData action, so
+   * the coverage check is skipped -- whatever the credential endpoint returned was published
+   * unexamined, and a table reconciled from an earlier good credential could start receiving a
+   * tuple scoped somewhere this provider cannot read.
+   */
+  @Test
+  void theVendRefusesACredentialScopedSomewhereItCannotRead() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.accessModes = List.of(AccessMode.DIR);
+    fake.metadataLocation = Optional.empty();
+    fake.listedLocation = Optional.empty();
+    fake.credentials =
+        new TemporaryCredentials(
+            CredentialCloud.AWS,
+            "gs://elsewhere/table",
+            Optional.of("AKIA"),
+            Optional.of("secret"),
+            Optional.of("session"),
+            Optional.of(Instant.parse("2026-01-01T00:00:00Z")));
+    try (DeltaSharingCatalogClient client =
+        new DeltaSharingCatalogClient(fake, Map.of(), false, new RecordingProbe())) {
+      assertThatThrownBy(() -> client.vendStorageCredentials(events()))
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure -> {
+                assertThat(failure.code()).isEqualTo(CatalogAccessException.Code.UNSUPPORTED);
+                assertThat(failure.getMessage()).contains("gs");
+              });
+    }
+  }
+
+  /**
+   * The vend says the same thing the load does. Validation's sampler sends names straight from
+   * listTables to vendStorageCredentials without loading them, so for a table stating only modes
+   * this client does not know, this is the message an operator running a validation actually sees.
+   */
+  @Test
+  void theVendAlsoNamesUnrecognisedModesRatherThanClaimingUrlAccess() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.accessModes = List.of(AccessMode.OTHER);
+    fake.metadataAccessModes = List.of(AccessMode.OTHER);
+    try (DeltaSharingCatalogClient client =
+        new DeltaSharingCatalogClient(fake, Map.of(), false, new RecordingProbe())) {
+      assertThatThrownBy(() -> client.vendStorageCredentials(events()))
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure -> {
+                assertThat(failure.code()).isEqualTo(CatalogAccessException.Code.UNSUPPORTED);
+                assertThat(failure.getMessage()).contains("does not recognise");
+                assertThat(failure.getMessage()).doesNotContain("url access only");
+              });
+    }
+  }
+
+  /**
+   * And a table stating only modes this client does not recognise is refused for that, not told it
+   * offers url access.
+   */
+  @Test
+  void aTableStatingOnlyUnrecognisedModesSaysSo() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.accessModes = List.of(AccessMode.OTHER);
+    fake.metadataAccessModes = List.of(AccessMode.OTHER);
+    try (DeltaSharingCatalogClient client =
+        new DeltaSharingCatalogClient(fake, Map.of(), false, new RecordingProbe())) {
+      assertThatThrownBy(() -> client.loadTable(events()))
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure -> {
+                assertThat(failure.code()).isEqualTo(CatalogAccessException.Code.UNSUPPORTED);
+                assertThat(failure.getMessage()).contains("does not recognise");
+              });
+    }
+  }
+
+  /**
+   * A redirect is a wrong base URI, not a table without directory access. The transport folds a
+   * refused 3xx into INVALID_REQUEST, which this path read as the protocol's per-table refusal, so
+   * an auth proxy in front of the server reported every table as offering no directory access -- a
+   * configuration error arriving table by table as a capability limit, leaving the integration
+   * looking partly healthy instead of misconfigured.
+   */
+  @Test
+  void aRedirectOnTheCredentialEndpointIsNotReadAsMissingDirectoryAccess() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.accessModes = List.of(AccessMode.DIR);
+    fake.credentialFailure = DeltaSharingException.Failure.INVALID_REQUEST;
+    fake.credentialStatus = 302;
+    try (DeltaSharingCatalogClient client =
+        new DeltaSharingCatalogClient(fake, Map.of(), false, new RecordingProbe())) {
+      assertThatThrownBy(() -> client.vendStorageCredentials(events()))
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure ->
+                  assertThat(failure.code()).isNotEqualTo(CatalogAccessException.Code.UNSUPPORTED));
+    }
+  }
+
+  /** A 400 is still the protocol's own per-table refusal, which is what UNSUPPORTED is for. */
+  @Test
+  void aBadRequestOnTheCredentialEndpointIsStillATableRefusal() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.accessModes = List.of(AccessMode.DIR);
+    fake.credentialFailure = DeltaSharingException.Failure.INVALID_REQUEST;
+    fake.credentialStatus = 400;
+    try (DeltaSharingCatalogClient client =
+        new DeltaSharingCatalogClient(fake, Map.of(), false, new RecordingProbe())) {
+      assertThatThrownBy(() -> client.vendStorageCredentials(events()))
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure ->
+                  assertThat(failure.code()).isEqualTo(CatalogAccessException.Code.UNSUPPORTED));
+    }
+  }
+
+  /**
+   * The two surfaces disagreeing is refused, not resolved in the load's favour. statedModes prefers
+   * the listing and the vend reads the metaData action alone, so a server saying dir on one and url
+   * on the other reconciled here and was refused on every read for the life of the table. Whichever
+   * surface refuses, the load has to be no more permissive than the vend.
+   */
+  @Test
+  void surfacesDisagreeingAboutAccessModesAreRefusedAtBothPaths() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.accessModes = List.of(AccessMode.DIR);
+    fake.metadataAccessModes = List.of(AccessMode.URL);
+    try (DeltaSharingCatalogClient client =
+        new DeltaSharingCatalogClient(fake, Map.of(), false, new RecordingProbe())) {
+      assertThatThrownBy(() -> client.loadTable(events()))
+          .as("load")
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure -> {
+                assertThat(failure.code()).isEqualTo(CatalogAccessException.Code.UNSUPPORTED);
+                assertThat(failure.getMessage()).contains("url access only");
+              });
+      assertThatThrownBy(() -> client.vendStorageCredentials(events()))
+          .as("vend")
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure ->
+                  assertThat(failure.code()).isEqualTo(CatalogAccessException.Code.UNSUPPORTED));
+    }
+  }
+
+  /**
+   * A location does not establish directory access. The protocol lets a url-only server state one,
+   * so a legacy server that omits its access modes, names a location and refuses the credential
+   * endpoint has to be refused at the load -- the early return on a stated location was skipping
+   * the request the default setting exists to make, and the table reconciled with every read of it
+   * failing.
+   */
+  @Test
+  void anUnstatedTableIsAskedAboutEvenWhenTheListingNamesALocation() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.accessModes = List.of();
+    fake.metadataAccessModes = List.of();
+    fake.listedLocation = Optional.of(LOCATION);
+    fake.credentialFailure = DeltaSharingException.Failure.INVALID_REQUEST;
+    fake.credentialStatus = 400;
+    try (DeltaSharingCatalogClient client =
+        new DeltaSharingCatalogClient(fake, Map.of(), false, new RecordingProbe())) {
+      assertThatThrownBy(() -> client.loadTable(events()))
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure ->
+                  assertThat(failure.code()).isEqualTo(CatalogAccessException.Code.UNSUPPORTED));
+    }
+    assertThat(fake.credentialCalls).isPositive();
+  }
+
+  /**
+   * The same shape with a server that does vend: the ask is what establishes directory access, and
+   * the location a surface stated is still what the table reconciles with rather than the scope the
+   * credential happened to name.
+   */
+  @Test
+  void anUnstatedTableThatVendsKeepsTheLocationItsListingStated() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.accessModes = List.of();
+    fake.metadataAccessModes = List.of();
+    fake.listedLocation = Optional.of(LOCATION);
+    fake.metadataLocation = Optional.empty();
+    try (DeltaSharingCatalogClient client =
+        new DeltaSharingCatalogClient(fake, Map.of(), false, new RecordingProbe())) {
+      assertThat(client.loadTable(events()).storageLocation()).contains(LOCATION);
+    }
+    assertThat(fake.credentialCalls).isPositive();
+  }
+
+  /**
+   * Strict mode refuses without asking, which is the point of it. Asking for a location would be
+   * the round trip the knob turns off, and answering would reconcile a table whose every vend then
+   * fails -- a configuration choice turned into a runtime failure.
+   */
+  @Test
+  void strictModeRefusesAnUnstatedTableAtTheLoadWithoutAsking() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.accessModes = List.of();
+    fake.listedLocation = Optional.empty();
+    fake.metadataLocation = Optional.empty();
+    try (DeltaSharingCatalogClient client =
+        new DeltaSharingCatalogClient(fake, Map.of(), true, new RecordingProbe())) {
+      assertThatThrownBy(() -> client.loadTable(events()))
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure -> {
+                assertThat(failure.code()).isEqualTo(CatalogAccessException.Code.UNSUPPORTED);
+                assertThat(failure.getMessage())
+                    .contains(DeltaSharingCatalogClient.STRICT_ACCESS_MODES);
+              });
+    }
+    assertThat(fake.credentialCalls).isZero();
+  }
+
+  /**
+   * The reference-server shape again: neither surface states a location, so validation has only the
+   * scope the credential itself named. Without that it refused every table before attempting a
+   * read, on exactly the servers the ask default exists to support.
+   */
+  @Test
+  void storageValidationFallsBackToTheVendedScopeWhenNoSurfaceStatesALocation() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.listedLocation = Optional.empty();
+    fake.metadataLocation = Optional.empty();
+    RecordingProbe probe = new RecordingProbe();
+    try (DeltaSharingCatalogClient client =
+        new DeltaSharingCatalogClient(fake, Map.of(), false, probe)) {
+      client.validateStorageAccess(
+          events(),
+          new VendedStorageCredentials(
+              Map.of("s3.access-key-id", "AKIA"), LOCATION, Optional.empty()));
+    }
+    assertThat(probe.location).isEqualTo(LOCATION);
+  }
+
+  /** Better a named refusal than a table that materializes and cannot be opened. */
+  @Test
+  void aTableWhoseLocationNoSurfaceStatesIsRefused() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.listedLocation = Optional.empty();
+    fake.metadataLocation = Optional.empty();
+    fake.accessModes = List.of();
+    fake.credentialNamesNoLocation = true;
+    try (DeltaSharingCatalogClient client = client(fake)) {
+      assertThatThrownBy(() -> client.loadTable(events()))
+          .isInstanceOf(CatalogAccessException.class);
+    }
+  }
+
+  /** The vend runs per resolve with a fresh client, so it must not page a schema to find one. */
+  @Test
+  void vendingDoesNotPageTheSchemaLookingForALocation() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.metadataLocation = Optional.empty();
+    try (DeltaSharingCatalogClient client = client(fake)) {
+      client.vendStorageCredentials(events());
+    }
+    assertThat(fake.listTablesCalls).isZero();
+  }
+
+  /** The knob governs the ambiguous case; a table stating dir is not ambiguous. */
+  @Test
+  void strictModeStillLoadsATableThatStatesDirectoryAccess() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.accessModes = List.of(AccessMode.DIR);
+    fake.listedLocation = Optional.empty();
+    fake.metadataLocation = Optional.empty();
+    try (DeltaSharingCatalogClient client =
+        new DeltaSharingCatalogClient(fake, Map.of(), true, new RecordingProbe())) {
+      assertThat(client.loadTable(events()).storageLocation()).contains(LOCATION);
+    }
+  }
+
+  /**
+   * The probe addresses S3 and the vend publishes an AWS session, so a table elsewhere would load,
+   * reconcile, and fail at every scan -- the unreadable materialized table by another route.
+   */
+  @Test
+  void aTableOnACloudThisProviderCannotReadIsRefused() {
+    for (String elsewhere :
+        List.of("abfss://c@a.dfs.core.windows.net/gold/events", "gs://sharing/gold/events")) {
+      FakeSharingClient fake = new FakeSharingClient();
+      fake.listedLocation = Optional.of(elsewhere);
+      fake.metadataLocation = Optional.of(elsewhere);
+      try (DeltaSharingCatalogClient client = client(fake)) {
+        assertThatThrownBy(() -> client.loadTable(events()))
+            .describedAs("%s", elsewhere)
+            .isInstanceOfSatisfying(
+                CatalogAccessException.class,
+                failure -> {
+                  assertThat(failure.code()).isEqualTo(CatalogAccessException.Code.UNSUPPORTED);
+                  assertThat(failure.getMessage()).contains("cannot read");
+                });
+      }
+    }
+  }
+
+  /**
+   * The refusal reaches operator logs through the throwable the reconciler records, and the
+   * location is the server's: a query is a signature or a SAS token, userinfo is a password, and a
+   * newline forges a log line. The scheme answers which cloud and can hold none of them.
+   */
+  @Test
+  void refusingACloudNamesTheSchemeAndNotTheLocation() {
+    String withSecrets = "abfss://user:pa55word@a.dfs.core.windows.net/gold/events?sig=SECRET-SAS";
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.listedLocation = Optional.of(withSecrets);
+    fake.metadataLocation = Optional.of(withSecrets);
+    try (DeltaSharingCatalogClient client = client(fake)) {
+      assertThatThrownBy(() -> client.loadTable(events()))
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure -> {
+                assertThat(failure.getMessage()).contains("abfss");
+                assertThat(failure.getMessage())
+                    .doesNotContain("SECRET-SAS", "pa55word", "a.dfs.core.windows.net");
+              });
+    }
+  }
+
+  /**
+   * The load's speculative ask is the same question the vend asks, so it is classified the same
+   * way: a server with no credential endpoint is an unsupported capability, not a missing table.
+   */
+  @Test
+  void aServerWithoutTheCredentialEndpointIsUnsupportedOnTheLoadPathToo() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.listedLocation = Optional.empty();
+    fake.metadataLocation = Optional.empty();
+    fake.credentialFailure = DeltaSharingException.Failure.NOT_FOUND;
+    try (DeltaSharingCatalogClient client = client(fake)) {
+      assertThatThrownBy(() -> client.loadTable(events()))
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure ->
+                  assertThat(failure.code()).isEqualTo(CatalogAccessException.Code.UNSUPPORTED));
+    }
+  }
+
+  /**
+   * The same answer from the same server, classified the same way whichever path asked. Gating this
+   * on whether the table stated its modes would make one refusal a capability boundary on one path
+   * and a configuration error on the other.
+   */
+  @Test
+  void theSameCredentialRefusalIsClassifiedAlikeOnBothPaths() {
+    for (DeltaSharingException.Failure refusal :
+        List.of(
+            DeltaSharingException.Failure.NOT_FOUND,
+            DeltaSharingException.Failure.INVALID_REQUEST)) {
+      FakeSharingClient onVend = new FakeSharingClient();
+      onVend.accessModes = List.of(AccessMode.DIR);
+      onVend.credentialFailure = refusal;
+      onVend.credentialStatus = refusal == DeltaSharingException.Failure.NOT_FOUND ? 404 : 400;
+      FakeSharingClient onLoad = new FakeSharingClient();
+      onLoad.accessModes = List.of(AccessMode.DIR);
+      onLoad.listedLocation = Optional.empty();
+      onLoad.metadataLocation = Optional.empty();
+      onLoad.credentialFailure = refusal;
+      onLoad.credentialStatus = refusal == DeltaSharingException.Failure.NOT_FOUND ? 404 : 400;
+      try (DeltaSharingCatalogClient vending = client(onVend);
+          DeltaSharingCatalogClient loading = client(onLoad)) {
+        assertThatThrownBy(() -> vending.vendStorageCredentials(events()))
+            .describedAs("vend %s", refusal)
+            .isInstanceOfSatisfying(
+                CatalogAccessException.class,
+                failure ->
+                    assertThat(failure.code()).isEqualTo(CatalogAccessException.Code.UNSUPPORTED));
+        assertThatThrownBy(() -> loading.loadTable(events()))
+            .describedAs("load %s", refusal)
+            .isInstanceOfSatisfying(
+                CatalogAccessException.class,
+                failure ->
+                    assertThat(failure.code()).isEqualTo(CatalogAccessException.Code.UNSUPPORTED));
+      }
+    }
+  }
+
+  /**
+   * A stated location has to be reachable with the credential the server answered with.
+   *
+   * <p>Where both are known and disjoint, reconciling the stated one materialises a table every
+   * read of which is scoped elsewhere, and validation is optional so nothing else need catch it.
+   * The vend makes this comparison for a location the metaData action states; this covers the
+   * surface the vend cannot see.
+   */
+  @Test
+  void aStatedLocationTheCredentialDoesNotReachIsRefused() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.accessModes = List.of();
+    fake.metadataAccessModes = List.of();
+    fake.listedLocation = Optional.of("s3://sharing/gold/events");
+    fake.metadataLocation = Optional.empty();
+    fake.credentials =
+        new TemporaryCredentials(
+            CredentialCloud.AWS,
+            "s3://sharing/silver/elsewhere",
+            Optional.of("AKIA"),
+            Optional.of("secret"),
+            Optional.of("session"),
+            Optional.of(Instant.parse("2026-01-01T00:00:00Z")));
+    try (DeltaSharingCatalogClient client =
+        new DeltaSharingCatalogClient(fake, Map.of(), false, new RecordingProbe())) {
+      assertThatThrownBy(() -> client.loadTable(events()))
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure ->
+                  assertThat(failure.code())
+                      .isEqualTo(CatalogAccessException.Code.CREDENTIAL_SCOPE_INVALID));
+    }
+  }
+
+  /** A credential scoped above the stated location still reaches it, and is left alone. */
+  @Test
+  void aStatedLocationUnderABroaderCredentialScopeIsAccepted() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.accessModes = List.of();
+    fake.metadataAccessModes = List.of();
+    fake.listedLocation = Optional.of(LOCATION);
+    fake.metadataLocation = Optional.empty();
+    fake.credentials =
+        new TemporaryCredentials(
+            CredentialCloud.AWS,
+            "s3://sharing/gold",
+            Optional.of("AKIA"),
+            Optional.of("secret"),
+            Optional.of("session"),
+            Optional.of(Instant.parse("2026-01-01T00:00:00Z")));
+    try (DeltaSharingCatalogClient client =
+        new DeltaSharingCatalogClient(fake, Map.of(), false, new RecordingProbe())) {
+      assertThat(client.loadTable(events()).storageLocation()).contains(LOCATION);
+    }
+  }
+
+  /**
+   * A credential scoped to a bucket is the table's root.
+   *
+   * <p>The protocol answers a request naming no location with the table's main location, and a
+   * Delta table may sit directly at a bucket root -- {@code deltaLogPrefix("")} answers {@code
+   * _delta_log/} for that case. Whether the scope matches where the table lives is settled by
+   * reading the Delta log under it, which validation does; the shape of the path cannot settle it,
+   * and a load that refused on shape would skip tables validation reports as readable.
+   */
+  @Test
+  void aCredentialScopedToAWholeBucketIsTakenAsTheTableRoot() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.accessModes = List.of(AccessMode.DIR);
+    fake.listedLocation = Optional.empty();
+    fake.metadataLocation = Optional.empty();
+    fake.credentials =
+        new TemporaryCredentials(
+            CredentialCloud.AWS,
+            "s3://sharing-bucket/",
+            Optional.of("AKIA"),
+            Optional.of("secret"),
+            Optional.of("session"),
+            Optional.of(Instant.parse("2026-01-01T00:00:00Z")));
+    try (DeltaSharingCatalogClient client =
+        new DeltaSharingCatalogClient(fake, Map.of(), false, new RecordingProbe())) {
+      assertThat(client.loadTable(events()).storageLocation()).contains("s3://sharing-bucket/");
+    }
+  }
+
+  /** A sharing server whose answers each test bends to the one shape it is about. */
+  private static final class FakeSharingClient implements DeltaSharingClient {
+
+    private Optional<String> tableId = Optional.of("tbl-1");
+    private Optional<String> metadataId = Optional.of("tbl-1");
+    private String schemaName = "gold";
+    private Optional<String> shareId = Optional.of("share-uuid");
+    private List<String> auxiliaryLocations = List.of();
+    private List<String> listedAuxiliaryLocations = List.of();
+    // Null means "same as the listing", which is what a delta-format server does: it states the
+    // modes in both places. A test sets this only to make the two disagree.
+    private List<AccessMode> metadataAccessModes;
+    private List<AccessMode> accessModes = List.of(AccessMode.URL, AccessMode.DIR);
+    private Optional<String> listedLocation = Optional.of(LOCATION);
+    private Optional<String> metadataLocation = Optional.of(LOCATION);
+    private DeltaSharingException.Failure failure;
+    private DeltaSharingException.Failure credentialFailure;
+    private int credentialStatus;
+    private int credentialCalls;
+    private boolean credentialNamesNoLocation;
+    private TemporaryCredentials credentials =
+        new TemporaryCredentials(
+            CredentialCloud.AWS,
+            LOCATION,
+            Optional.of("AKIA"),
+            Optional.of("secret"),
+            Optional.of("session"),
+            Optional.of(Instant.parse("2026-01-01T00:00:00Z")));
+    private int listSharesCalls;
+    private int listTablesCalls;
+    private boolean closed;
+
+    @Override
+    public List<Share> listShares() {
+      listSharesCalls++;
+      raiseIfConfigured();
+      return List.of(new Share("prod", Optional.of("share-1")));
+    }
+
+    @Override
+    public List<Schema> listSchemas(String share) {
+      raiseIfConfigured();
+      return List.of(new Schema(share, schemaName));
+    }
+
+    @Override
+    public List<Table> listTables(String share, String schema) {
+      listTablesCalls++;
+      raiseIfConfigured();
+      List<Table> tables = new ArrayList<>();
+      tables.add(
+          new Table(
+              share,
+              schema,
+              "events",
+              tableId,
+              shareId,
+              listedLocation,
+              listedAuxiliaryLocations,
+              accessModes));
+      return tables;
+    }
+
+    @Override
+    public TableDescription describeTable(String share, String schema, String table) {
+      raiseIfConfigured();
+      return new TableDescription(
+          new Protocol(1, List.of()),
+          new TableMetadata(
+              metadataId,
+              Optional.of(table),
+              "parquet",
+              "{\"type\":\"struct\",\"fields\":[]}",
+              List.of("day"),
+              Map.of(),
+              Optional.of(12L),
+              metadataLocation,
+              auxiliaryLocations,
+              metadataAccessModes == null ? accessModes : metadataAccessModes),
+          Optional.of(12L));
+    }
+
+    @Override
+    public TemporaryCredentials temporaryTableCredentials(
+        String share, String schema, String table, String location) {
+      credentialCalls++;
+      raiseIfConfigured();
+      if (credentialFailure != null) {
+        throw new DeltaSharingException(
+            credentialFailure, credentialStatus, "configured for " + credentialFailure);
+      }
+      if (credentialNamesNoLocation) {
+        // The record forbids a blank location, so this stands in for a server naming none by
+        // answering somewhere the client's own filter will not accept as the table's.
+        throw new DeltaSharingException(
+            DeltaSharingException.Failure.INVALID_RESPONSE, 200, "named no location");
+      }
+      return credentials;
+    }
+
+    @Override
+    public void close() {
+      closed = true;
+    }
+
+    private void raiseIfConfigured() {
+      if (failure != null) {
+        throw new DeltaSharingException(failure, 0, "configured for " + failure);
+      }
+    }
+  }
+}

--- a/catalog-access/delta-sharing/src/test/java/ai/floedb/floecat/catalog/sharing/DeltaSharingClientProviderTest.java
+++ b/catalog-access/delta-sharing/src/test/java/ai/floedb/floecat/catalog/sharing/DeltaSharingClientProviderTest.java
@@ -1,0 +1,325 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.catalog.sharing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+import ai.floedb.floecat.catalog.access.CatalogAccessException;
+import ai.floedb.floecat.catalog.access.CatalogAuthentication;
+import ai.floedb.floecat.catalog.access.CatalogAuthenticationScheme;
+import ai.floedb.floecat.catalog.access.CatalogClient;
+import ai.floedb.floecat.catalog.access.CatalogClientProvider;
+import ai.floedb.floecat.catalog.access.CatalogConnectionConfig;
+import ai.floedb.floecat.catalog.access.CatalogProtocol;
+import ai.floedb.floecat.catalog.access.ResolvedCatalogCredentials;
+import ai.floedb.floecat.client.sharing.DeltaSharingClient;
+import ai.floedb.floecat.http.guards.HttpEndpointGuards;
+import java.net.URI;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceLoader;
+import org.junit.jupiter.api.Test;
+
+class DeltaSharingClientProviderTest {
+
+  @Test
+  void serviceLoaderFindsTheProviderForItsProtocol() {
+    assertThat(ServiceLoader.load(CatalogClientProvider.class))
+        .filteredOn(provider -> provider.protocol() == CatalogProtocol.DELTA_SHARING)
+        .hasSize(1)
+        .allSatisfy(
+            provider -> assertThat(provider).isInstanceOf(DeltaSharingClientProvider.class));
+  }
+
+  @Test
+  void aResolvedTokenAndTheDefaultTimeoutsReachTheRecipient() {
+    Recording recording = new Recording();
+    try (CatalogClient client =
+        new DeltaSharingClientProvider(recording)
+            .open(config(Map.of()), credentials("recipient"))) {
+      assertThat(client).isInstanceOf(DeltaSharingCatalogClient.class);
+    }
+    assertThat(recording.endpoint).isEqualTo(URI.create("https://sharing.example/delta-sharing"));
+    assertThat(recording.bearerToken).isEqualTo("recipient");
+    assertThat(recording.connectTimeout).isEqualTo(Duration.ofSeconds(10));
+    assertThat(recording.requestTimeout).isEqualTo(Duration.ofSeconds(30));
+  }
+
+  @Test
+  void noReaderFeatureIsClaimedUnlessAnOperatorOptsIn() {
+    Recording recording = new Recording();
+    new DeltaSharingClientProvider(recording).open(config(Map.of()), credentials("recipient"));
+    assertThat(recording.readerFeatures).isEmpty();
+
+    Recording opted = new Recording();
+    new DeltaSharingClientProvider(opted)
+        .open(
+            config(Map.of("delta.sharing.reader-features", "deletionVectors, columnMapping")),
+            credentials("recipient"));
+    assertThat(opted.readerFeatures).containsExactly("deletionVectors", "columnMapping");
+  }
+
+  @Test
+  void onlyTheStoragePropertiesAnObjectStoreNeedsAreCarriedThrough() {
+    Recording recording = new Recording();
+    DeltaSharingCatalogClient client =
+        (DeltaSharingCatalogClient)
+            new DeltaSharingClientProvider(recording)
+                .open(
+                    config(
+                        Map.of(
+                            "s3.endpoint", "https://minio.internal:9000",
+                            "s3.region", "us-east-1",
+                            "unrelated", "value")),
+                    credentials("recipient"));
+    assertThat(client.storageProperties())
+        .containsOnlyKeys("s3.endpoint", "s3.region")
+        .containsEntry("s3.region", "us-east-1");
+  }
+
+  @Test
+  void theStrictAccessModeSettingIsOffUnlessAnOperatorTurnsItOn() {
+    Recording recording = new Recording();
+    DeltaSharingCatalogClient asking =
+        (DeltaSharingCatalogClient)
+            new DeltaSharingClientProvider(recording)
+                .open(config(Map.of()), credentials("recipient"));
+    assertThat(asking.strictAccessModes()).isFalse();
+
+    DeltaSharingCatalogClient strict =
+        (DeltaSharingCatalogClient)
+            new DeltaSharingClientProvider(recording)
+                .open(
+                    config(Map.of(DeltaSharingCatalogClient.STRICT_ACCESS_MODES, "TRUE")),
+                    credentials("recipient"));
+    assertThat(strict.strictAccessModes()).isTrue();
+  }
+
+  @Test
+  void aStrictAccessModeSettingThatIsNeitherTrueNorFalseIsReported() {
+    assertThatThrownBy(
+            () ->
+                new DeltaSharingClientProvider(new Recording())
+                    .open(
+                        config(Map.of(DeltaSharingCatalogClient.STRICT_ACCESS_MODES, "yes")),
+                        credentials("recipient")))
+        .isInstanceOfSatisfying(
+            CatalogAccessException.class,
+            failure -> {
+              assertThat(failure.code())
+                  .isEqualTo(CatalogAccessException.Code.INVALID_CONFIGURATION);
+              assertThat(failure.getMessage())
+                  .contains(DeltaSharingCatalogClient.STRICT_ACCESS_MODES);
+            });
+  }
+
+  /**
+   * The storage endpoint is held to the gate the Unity provider uses, for the same reason: this
+   * vend publishes an AWS session token, which travels in a header and is replayable, and {@code
+   * s3.endpoint} travels on to query workers.
+   */
+  @Test
+  void refusesAStorageEndpointThatIsCleartextOrNamesAnAddressClassThatIsNotAllowed() {
+    DeltaSharingClientProvider provider = new DeltaSharingClientProvider(new Recording());
+
+    for (String refused :
+        List.of(
+            "http://minio.internal:9000", "https://169.254.169.254", "not-a-uri", "/no/scheme")) {
+      assertThatThrownBy(
+              () -> provider.open(config(Map.of("s3.endpoint", refused)), credentials("recipient")))
+          .describedAs("%s", refused)
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure ->
+                  assertThat(failure.code())
+                      .isEqualTo(CatalogAccessException.Code.INVALID_CONFIGURATION));
+    }
+
+    // HTTPS needs no opt-in.
+    provider
+        .open(config(Map.of("s3.endpoint", "https://storage.example")), credentials("recipient"))
+        .close();
+
+    System.setProperty(HttpEndpointGuards.ALLOW_CLEARTEXT_S3_PROPERTY, "true");
+    try {
+      provider
+          .open(
+              config(Map.of("s3.endpoint", "http://minio.internal:9000")), credentials("recipient"))
+          .close();
+    } finally {
+      System.clearProperty(HttpEndpointGuards.ALLOW_CLEARTEXT_S3_PROPERTY);
+    }
+  }
+
+  /**
+   * The transport's own message survives. Naming a property here was wrong: its constructor raises
+   * IllegalArgumentException for the endpoint gates and the response limits as well as for a reader
+   * feature, so an operator pointing at an http:// endpoint was told about a property they had
+   * never set.
+   */
+  @Test
+  void aTransportRefusalKeepsItsOwnMessage() {
+    DeltaSharingClientProvider.ClientFactory refusing =
+        (endpoint, token, connect, read, features) -> {
+          throw new IllegalArgumentException("Delta reader feature must be letters: x;y");
+        };
+    assertThatThrownBy(
+            () ->
+                new DeltaSharingClientProvider(refusing)
+                    .open(
+                        config(Map.of(DeltaSharingClientProvider.READER_FEATURES, "x;y")),
+                        credentials("recipient")))
+        .isInstanceOfSatisfying(
+            CatalogAccessException.class,
+            failure -> {
+              assertThat(failure.code())
+                  .isEqualTo(CatalogAccessException.Code.INVALID_CONFIGURATION);
+              assertThat(failure.getMessage()).contains("Delta reader feature must be letters");
+              assertThat(failure.getMessage())
+                  .doesNotContain(DeltaSharingClientProvider.READER_FEATURES);
+            });
+  }
+
+  /** A registry mis-dispatch is cheap to refuse, and the Unity provider refuses it too. */
+  @Test
+  void aConfigForAnotherProtocolIsRefused() {
+    assertThatThrownBy(
+            () ->
+                new DeltaSharingClientProvider(new Recording())
+                    .open(
+                        new CatalogConnectionConfig(
+                            CatalogProtocol.UNITY_CATALOG,
+                            URI.create("https://sharing.example/delta-sharing"),
+                            Map.of(),
+                            new CatalogAuthentication(
+                                CatalogAuthenticationScheme.OAUTH2, Map.of())),
+                        credentials("recipient")))
+        .isInstanceOfSatisfying(
+            CatalogAccessException.class,
+            failure ->
+                assertThat(failure.code())
+                    .isEqualTo(CatalogAccessException.Code.INVALID_CONFIGURATION));
+  }
+
+  @Test
+  void aSchemeOtherThanBearerIsAConfigurationError() {
+    assertThatThrownBy(
+            () ->
+                new DeltaSharingClientProvider(new Recording())
+                    .open(
+                        new CatalogConnectionConfig(
+                            CatalogProtocol.DELTA_SHARING,
+                            URI.create("https://sharing.example/delta-sharing"),
+                            Map.of(),
+                            CatalogAuthentication.none()),
+                        ResolvedCatalogCredentials.none()))
+        .isInstanceOfSatisfying(
+            CatalogAccessException.class,
+            failure -> {
+              assertThat(failure.code())
+                  .isEqualTo(CatalogAccessException.Code.INVALID_CONFIGURATION);
+              assertThat(failure.getMessage()).contains("NONE");
+            });
+  }
+
+  @Test
+  void anUnresolvedTokenIsAConfigurationErrorRatherThanAnAnonymousRequest() {
+    assertThatThrownBy(
+            () ->
+                new DeltaSharingClientProvider(new Recording())
+                    .open(config(Map.of()), ResolvedCatalogCredentials.none()))
+        .isInstanceOfSatisfying(
+            CatalogAccessException.class,
+            failure ->
+                assertThat(failure.code())
+                    .isEqualTo(CatalogAccessException.Code.INVALID_CONFIGURATION));
+  }
+
+  /**
+   * Arguments evaluate left to right, so resolving the flag inside the constructor call built the
+   * transport first and leaked it when the property was malformed -- once per open, which is once
+   * per vend and once per validation.
+   */
+  @Test
+  void aMalformedStrictSettingDoesNotLeaveAClientBehind() {
+    Recording recording = new Recording();
+    assertThatThrownBy(
+            () ->
+                new DeltaSharingClientProvider(recording)
+                    .open(
+                        config(Map.of(DeltaSharingCatalogClient.STRICT_ACCESS_MODES, "yes")),
+                        credentials("recipient")))
+        .isInstanceOf(CatalogAccessException.class);
+    assertThat(recording.created).isFalse();
+  }
+
+  @Test
+  void anUnreadableTimeoutIsReportedRatherThanSilentlyDefaulted() {
+    for (String bad : List.of("soon", "0", "-1")) {
+      assertThatThrownBy(
+              () ->
+                  new DeltaSharingClientProvider(new Recording())
+                      .open(config(Map.of("http.read.ms", bad)), credentials("recipient")))
+          .describedAs("http.read.ms=%s", bad)
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure ->
+                  assertThat(failure.code())
+                      .isEqualTo(CatalogAccessException.Code.INVALID_CONFIGURATION));
+    }
+  }
+
+  private static CatalogConnectionConfig config(Map<String, String> properties) {
+    return new CatalogConnectionConfig(
+        CatalogProtocol.DELTA_SHARING,
+        URI.create("https://sharing.example/delta-sharing"),
+        properties,
+        new CatalogAuthentication(CatalogAuthenticationScheme.OAUTH2, Map.of()));
+  }
+
+  private static ResolvedCatalogCredentials credentials(String token) {
+    return new ResolvedCatalogCredentials(Map.of("token", token), Map.of(), null);
+  }
+
+  /** Captures what the provider built the recipient from, without opening a connection. */
+  private static final class Recording implements DeltaSharingClientProvider.ClientFactory {
+    private URI endpoint;
+    private String bearerToken;
+    private Duration connectTimeout;
+    private Duration requestTimeout;
+    private List<String> readerFeatures;
+    private boolean created;
+
+    @Override
+    public DeltaSharingClient create(
+        URI endpoint,
+        String bearerToken,
+        Duration connectTimeout,
+        Duration requestTimeout,
+        List<String> readerFeatures) {
+      this.endpoint = endpoint;
+      this.bearerToken = bearerToken;
+      this.connectTimeout = connectTimeout;
+      this.requestTimeout = requestTimeout;
+      this.readerFeatures = readerFeatures;
+      this.created = true;
+      return mock(DeltaSharingClient.class);
+    }
+  }
+}

--- a/catalog-access/unity/pom.xml
+++ b/catalog-access/unity/pom.xml
@@ -26,6 +26,11 @@
     </dependency>
     <dependency>
       <groupId>ai.floedb.floecat</groupId>
+      <artifactId>floecat-http-endpoint-guards</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>ai.floedb.floecat</groupId>
       <artifactId>floecat-unity-catalog-client</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/catalog-access/unity/src/main/java/ai/floedb/floecat/catalog/unity/UnityCatalogAccessClient.java
+++ b/catalog-access/unity/src/main/java/ai/floedb/floecat/catalog/unity/UnityCatalogAccessClient.java
@@ -18,6 +18,7 @@ import ai.floedb.floecat.catalog.access.CatalogViewDefinition;
 import ai.floedb.floecat.catalog.access.ExternalObjectIdentity;
 import ai.floedb.floecat.catalog.access.NamespacePath;
 import ai.floedb.floecat.catalog.access.VendedStorageCredentials;
+import ai.floedb.floecat.catalog.delta.DeltaLogStorageProbe;
 import ai.floedb.floecat.client.unity.TemporaryTableCredentials;
 import ai.floedb.floecat.client.unity.UnityCatalogClient;
 import ai.floedb.floecat.client.unity.UnityCatalogException;
@@ -52,7 +53,7 @@ final class UnityCatalogAccessClient implements CatalogClient {
 
   private final UnityCatalogClient unity;
   private final AutoCloseable authenticationOwner;
-  private final UnityStorageAccessValidator storageValidator;
+  private final DeltaLogStorageProbe storageValidator;
   private final Map<String, String> storageRouting;
   private final AtomicBoolean closed = new AtomicBoolean();
 
@@ -87,7 +88,7 @@ final class UnityCatalogAccessClient implements CatalogClient {
   UnityCatalogAccessClient(
       UnityCatalogClient unity,
       AutoCloseable authenticationOwner,
-      UnityStorageAccessValidator storageValidator,
+      DeltaLogStorageProbe storageValidator,
       Map<String, String> storageRouting) {
     this.unity = Objects.requireNonNull(unity, "unity");
     this.authenticationOwner = authenticationOwner;
@@ -167,7 +168,11 @@ final class UnityCatalogAccessClient implements CatalogClient {
               schemaJson(name, table),
               partitionKeys(table),
               Optional.empty(),
-              optional(table.storageLocation()),
+              // Canonical, not raw. The shared probe percent-encodes a space before parsing,
+              // so it answers for a location this would otherwise publish unchanged -- and the
+              // read path calls URI.create on whatever was published. Publishing the raw form
+              // gives a table that validates clean and fails every scan.
+              optional(table.storageLocation()).map(DeltaLogStorageProbe::canonicalLocation),
               table.properties());
         });
   }
@@ -299,9 +304,12 @@ final class UnityCatalogAccessClient implements CatalogClient {
           // Refused by name rather than returned empty. An empty vend is now a refusal too, but a
           // generic one; naming the reason is the difference between an operator seeing "vended no
           // storage credentials" and seeing that the table has no location to scope against.
-          String scope = nonBlank(response.storageUrl());
+          String scope = DeltaLogStorageProbe.canonicalLocation(nonBlank(response.storageUrl()));
           if (scope == null) {
-            scope = optional(table.storageLocation()).orElse(null);
+            scope =
+                optional(table.storageLocation())
+                    .map(DeltaLogStorageProbe::canonicalLocation)
+                    .orElse(null);
           }
           if (scope == null) {
             throw new CatalogAccessException(
@@ -331,7 +339,8 @@ final class UnityCatalogAccessClient implements CatalogClient {
           }
           VendedStorageCredentials credentials =
               new VendedStorageCredentials(properties, scope, expiresAt);
-          String tableLocation = nonBlank(table.storageLocation());
+          String tableLocation =
+              DeltaLogStorageProbe.canonicalLocation(nonBlank(table.storageLocation()));
           if (tableLocation != null && !credentials.covers(tableLocation)) {
             throw new CatalogAccessException(
                 CatalogAccessException.Code.CREDENTIAL_SCOPE_INVALID,
@@ -353,6 +362,7 @@ final class UnityCatalogAccessClient implements CatalogClient {
           UnityCatalogTable table = vendedTableOrLoad(name);
           String location =
               optional(table.storageLocation())
+                  .map(DeltaLogStorageProbe::canonicalLocation)
                   .orElseThrow(
                       () ->
                           new CatalogAccessException(

--- a/catalog-access/unity/src/main/java/ai/floedb/floecat/catalog/unity/UnityCatalogClientProvider.java
+++ b/catalog-access/unity/src/main/java/ai/floedb/floecat/catalog/unity/UnityCatalogClientProvider.java
@@ -17,6 +17,7 @@ import ai.floedb.floecat.catalog.access.ResolvedCatalogCredentials;
 import ai.floedb.floecat.client.unity.HttpUnityCatalogClient;
 import ai.floedb.floecat.client.unity.UnityCatalogAuthentication;
 import ai.floedb.floecat.client.unity.UnityCatalogClient;
+import ai.floedb.floecat.http.guards.HttpEndpointGuards;
 import java.net.URI;
 import java.time.Duration;
 import java.util.LinkedHashMap;
@@ -198,77 +199,16 @@ public final class UnityCatalogClientProvider implements CatalogClientProvider {
   /**
    * Rejects an {@code s3.endpoint} that names somewhere the service should not be made to reach.
    *
-   * <p>Checked when the client is opened, before anything connects. The value is tenant-supplied
-   * and reaches {@code endpointOverride}, so validation would otherwise issue signed S3 requests
-   * wherever it pointed, and the same value travels on as client-safe routing to reconcile and
-   * query workers. The catalog and OAuth endpoints in this same integration are already held to
-   * this policy; this one was not.
-   *
-   * <p>HTTPS unless a deployment says otherwise. The earlier rule allowed cleartext outright, on
-   * the reasoning that an S3 request carries a SigV4 signature rather than a bearer secret -- which
-   * stopped being true here: this provider refuses to publish a vend without {@code
-   * s3.session-token}, so every signed request carries that token in {@code X-Amz-Security-Token},
-   * and a session token is replayable against the table's prefix by anyone who sees it for as long
-   * as it lives. The exposure is not confined to the validation probe either, because {@code
-   * s3.endpoint} travels on to query workers as client-safe routing.
-   *
-   * <p>The escape hatch stays, because an S3-compatible endpoint on a private network commonly is
-   * HTTP -- MinIO and LocalStack both -- but it is now a deployment saying so rather than a
-   * default: {@value #ALLOW_CLEARTEXT_S3_PROPERTY}, or the environment variable {@value
-   * #ALLOW_CLEARTEXT_S3_ENV}. The address-class rule still applies on top of either scheme: it is
-   * the one that refuses {@code 169.254.169.254}.
+   * <p>The policy and its reasoning live in {@link
+   * HttpEndpointGuards#requireUsableStorageEndpoint}, which the Delta Sharing provider holds its
+   * own storage endpoint to for the same reason: both publish a vend carrying a session token.
    */
-  static final String ALLOW_CLEARTEXT_S3_PROPERTY = "floecat.security.allow-cleartext-s3-endpoints";
-
-  static final String ALLOW_CLEARTEXT_S3_ENV = "FLOECAT_SECURITY_ALLOW_CLEARTEXT_S3_ENDPOINTS";
-
-  private static boolean allowCleartextS3Endpoints() {
-    return Boolean.parseBoolean(
-        System.getProperty(
-            ALLOW_CLEARTEXT_S3_PROPERTY,
-            System.getenv().getOrDefault(ALLOW_CLEARTEXT_S3_ENV, "false")));
-  }
-
   private static void requireUsableEndpoint(String endpoint) {
-    if (endpoint == null) {
-      return;
-    }
-    URI uri;
     try {
-      uri = URI.create(endpoint);
-    } catch (IllegalArgumentException malformed) {
-      throw new CatalogAccessException(
-          CatalogAccessException.Code.INVALID_CONFIGURATION,
-          "Unity Catalog s3.endpoint is not a valid URI",
-          malformed);
-    }
-    String scheme = uri.getScheme();
-    if (!uri.isAbsolute()
-        || uri.getHost() == null
-        || !("https".equalsIgnoreCase(scheme) || "http".equalsIgnoreCase(scheme))
-        || uri.getRawUserInfo() != null
-        || uri.getRawQuery() != null
-        || uri.getRawFragment() != null) {
-      throw new CatalogAccessException(
-          CatalogAccessException.Code.INVALID_CONFIGURATION,
-          "Unity Catalog s3.endpoint must be an absolute http or https URI with no userinfo,"
-              + " query or fragment");
-    }
-    if ("http".equalsIgnoreCase(scheme) && !allowCleartextS3Endpoints()) {
-      throw new CatalogAccessException(
-          CatalogAccessException.Code.INVALID_CONFIGURATION,
-          "Unity Catalog s3.endpoint must use HTTPS: a vended credential carries a session token,"
-              + " which travels in a header and is replayable. Set "
-              + ALLOW_CLEARTEXT_S3_ENV
-              + "=true to allow cleartext on a trusted network");
-    }
-    try {
-      HttpUnityCatalogClient.assertEndpointAddressAllowed(uri);
+      HttpEndpointGuards.requireUsableStorageEndpoint(endpoint, "Unity Catalog s3.endpoint");
     } catch (IllegalArgumentException refused) {
       throw new CatalogAccessException(
-          CatalogAccessException.Code.INVALID_CONFIGURATION,
-          "Unity Catalog s3.endpoint names an address class that is not allowed",
-          refused);
+          CatalogAccessException.Code.INVALID_CONFIGURATION, refused.getMessage(), refused);
     }
   }
 

--- a/catalog-access/unity/src/main/java/ai/floedb/floecat/catalog/unity/UnityCatalogClientProvider.java
+++ b/catalog-access/unity/src/main/java/ai/floedb/floecat/catalog/unity/UnityCatalogClientProvider.java
@@ -14,6 +14,7 @@ import ai.floedb.floecat.catalog.access.CatalogClientProvider;
 import ai.floedb.floecat.catalog.access.CatalogConnectionConfig;
 import ai.floedb.floecat.catalog.access.CatalogProtocol;
 import ai.floedb.floecat.catalog.access.ResolvedCatalogCredentials;
+import ai.floedb.floecat.catalog.delta.DeltaLogStorageProbe;
 import ai.floedb.floecat.client.unity.HttpUnityCatalogClient;
 import ai.floedb.floecat.client.unity.UnityCatalogAuthentication;
 import ai.floedb.floecat.client.unity.UnityCatalogClient;
@@ -23,6 +24,7 @@ import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 /** Opens Unity Catalog integrations without creating or reading Connector resources. */
 public final class UnityCatalogClientProvider implements CatalogClientProvider {
@@ -118,7 +120,10 @@ public final class UnityCatalogClientProvider implements CatalogClientProvider {
           clientFactory.create(
               config.endpoint(), connectTimeout, readTimeout, authentication, vendPath);
       return new UnityCatalogAccessClient(
-          unity, authenticationOwner, UnityStorageAccessValidator.s3(), routing(properties));
+          unity,
+          authenticationOwner,
+          DeltaLogStorageProbe.s3("Unity Catalog"),
+          routing(properties));
     } catch (RuntimeException | Error failure) {
       closeQuietly(unity);
       closeQuietly(authenticationOwner);
@@ -128,7 +133,19 @@ public final class UnityCatalogClientProvider implements CatalogClientProvider {
 
   private static UnityCatalogAuthentication bearer(
       String token, Map<String, String> resolvedHeaders) {
-    return () -> headers(token, resolvedHeaders);
+    // Not a lambda, so the token can be named for redaction. This is the operator-supplied one,
+    // which is under no obligation to match the token68 alphabet the generic pattern assumes.
+    return new UnityCatalogAuthentication() {
+      @Override
+      public Map<String, String> headers() {
+        return UnityCatalogClientProvider.headers(token, resolvedHeaders);
+      }
+
+      @Override
+      public Optional<String> redactableSecret() {
+        return Optional.of(token);
+      }
+    };
   }
 
   private static UnityCatalogAuthentication bearer(
@@ -174,11 +191,10 @@ public final class UnityCatalogClientProvider implements CatalogClientProvider {
   /**
    * The S3 routing an operator can set on the integration.
    *
-   * <p>No {@code s3.access-point}: nothing addresses one. {@code UnityStorageAccessValidator}
-   * deliberately probes the bucket named in the object URI, and {@code
-   * SourceCatalogCredentialVendor} strips the key before a credential leaves the service, so an
-   * operator who set it saw no effect and no error. Plumbing a key no consumer honours is how one
-   * starts being honoured inconsistently.
+   * <p>No {@code s3.access-point}: nothing addresses one. {@code DeltaLogStorageProbe} deliberately
+   * probes the bucket named in the object URI, and {@code SourceCatalogCredentialVendor} strips the
+   * key before a credential leaves the service, so an operator who set it saw no effect and no
+   * error. Plumbing a key no consumer honours is how one starts being honoured inconsistently.
    *
    * <p>A vended access point is different and still reported: Unity returning one on the
    * credentials response is a diagnostic for a later 403, which {@code noteIgnoredAccessPoint}

--- a/catalog-access/unity/src/test/java/ai/floedb/floecat/catalog/unity/UnityCatalogAccessClientTest.java
+++ b/catalog-access/unity/src/test/java/ai/floedb/floecat/catalog/unity/UnityCatalogAccessClientTest.java
@@ -8,6 +8,7 @@
 package ai.floedb.floecat.catalog.unity;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -19,10 +20,12 @@ import ai.floedb.floecat.catalog.access.CatalogCapability;
 import ai.floedb.floecat.catalog.access.CatalogObjectName;
 import ai.floedb.floecat.catalog.access.NamespacePath;
 import ai.floedb.floecat.catalog.access.VendedStorageCredentials;
+import ai.floedb.floecat.catalog.delta.DeltaLogStorageProbe;
 import ai.floedb.floecat.client.unity.TemporaryTableCredentials;
 import ai.floedb.floecat.client.unity.UnityCatalogClient;
 import ai.floedb.floecat.client.unity.UnityCatalogException;
 import ai.floedb.floecat.client.unity.UnityCatalogTable;
+import java.net.URI;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -34,8 +37,7 @@ class UnityCatalogAccessClientTest {
   private static final CatalogObjectName ORDERS = new CatalogObjectName(SALES, "orders");
 
   private final UnityCatalogClient unity = mock(UnityCatalogClient.class);
-  private final UnityStorageAccessValidator storageValidator =
-      mock(UnityStorageAccessValidator.class);
+  private final DeltaLogStorageProbe storageValidator = mock(DeltaLogStorageProbe.class);
   private final UnityCatalogAccessClient client =
       new UnityCatalogAccessClient(unity, null, storageValidator, Map.of("s3.region", "us-east-1"));
 
@@ -541,6 +543,63 @@ class UnityCatalogAccessClientTest {
       String name, String typeJson, boolean nullable) {
     return new UnityCatalogTable.Column(
         name, null, null, "{\"name\":\"" + name + "\",\"type\":" + typeJson + "}", nullable);
+  }
+
+  /**
+   * An s3a location stays s3a. The authority prefix an operator registers is compared literally by
+   * matchesLocationPrefix, and S3Location.parse accepts an s3a:// prefix, so storing the table
+   * under a folded s3:// would leave the two in different scheme namespaces and never match. Only
+   * the spellings the reader cannot parse are changed.
+   */
+  @Test
+  void loadTableKeepsAnS3aSchemeTheReaderAndTheAuthorityBothAccept() {
+    var table =
+        new UnityCatalogTable(
+            "orders",
+            "table-id",
+            "EXTERNAL",
+            "DELTA",
+            "s3a://warehouse/orders",
+            null,
+            List.of(
+                new UnityCatalogTable.Column(
+                    "order_id", "LONG", "bigint", "{\"type\":\"long\"}", false)),
+            Map.of());
+    when(unity.getTable("main.sales.orders")).thenReturn(Optional.of(table));
+
+    assertThat(client.loadTable(ORDERS).storageLocation()).contains("s3a://warehouse/orders");
+  }
+
+  /**
+   * The shared probe percent-encodes a space before parsing, so it answers for a location this used
+   * to publish unchanged -- and the read path calls {@code URI.create} on what was published.
+   * Before the probe accepted such a location it refused it outright, which was a recorded failure;
+   * accepting it on one side without canonicalising on the other made the table validate clean and
+   * fail every scan.
+   */
+  @Test
+  void loadTablePublishesALocationTheReadPathCanParse() {
+    var table =
+        new UnityCatalogTable(
+            "orders",
+            "table-id",
+            "EXTERNAL",
+            "DELTA",
+            "s3://warehouse/my orders",
+            null,
+            List.of(
+                new UnityCatalogTable.Column(
+                    "order_id", "LONG", "bigint", "{\"type\":\"long\"}", false)),
+            Map.of());
+    when(unity.getTable("main.sales.orders")).thenReturn(Optional.of(table));
+
+    var mapped = client.loadTable(ORDERS);
+
+    assertThat(mapped.storageLocation()).contains("s3://warehouse/my%20orders");
+    assertThatCode(() -> URI.create(mapped.storageLocation().orElseThrow()))
+        .doesNotThrowAnyException();
+    assertThat(URI.create(mapped.storageLocation().orElseThrow()).getPath())
+        .isEqualTo("/my orders");
   }
 
   /**

--- a/catalog-access/unity/src/test/java/ai/floedb/floecat/catalog/unity/UnityCatalogClientProviderTest.java
+++ b/catalog-access/unity/src/test/java/ai/floedb/floecat/catalog/unity/UnityCatalogClientProviderTest.java
@@ -20,6 +20,7 @@ import ai.floedb.floecat.catalog.access.CatalogProtocol;
 import ai.floedb.floecat.catalog.access.ResolvedCatalogCredentials;
 import ai.floedb.floecat.client.unity.UnityCatalogAuthentication;
 import ai.floedb.floecat.client.unity.UnityCatalogClient;
+import ai.floedb.floecat.http.guards.HttpEndpointGuards;
 import java.net.URI;
 import java.time.Duration;
 import java.util.Map;
@@ -174,18 +175,17 @@ class UnityCatalogClientProviderTest {
     // HTTPS needs no opt-in.
     provider.open(config(Map.of("s3.endpoint", "https://storage.example")), credentials()).close();
 
-    System.setProperty(UnityCatalogClientProvider.ALLOW_CLEARTEXT_S3_PROPERTY, "true");
+    System.setProperty(HttpEndpointGuards.ALLOW_CLEARTEXT_S3_PROPERTY, "true");
     try {
       provider
           .open(config(Map.of("s3.endpoint", "http://minio.internal:9000")), credentials())
           .close();
     } finally {
-      System.clearProperty(UnityCatalogClientProvider.ALLOW_CLEARTEXT_S3_PROPERTY);
+      System.clearProperty(HttpEndpointGuards.ALLOW_CLEARTEXT_S3_PROPERTY);
     }
   }
 
-  private static final String ALLOW_CLEARTEXT_S3_ENV =
-      UnityCatalogClientProvider.ALLOW_CLEARTEXT_S3_ENV;
+  private static final String ALLOW_CLEARTEXT_S3_ENV = HttpEndpointGuards.ALLOW_CLEARTEXT_S3_ENV;
 
   /** Real credentials, because the authentication check runs ahead of the endpoint check. */
   private static ResolvedCatalogCredentials credentials() {

--- a/client-cli/src/main/java/ai/floedb/floecat/client/cli/IntegrationCliSupport.java
+++ b/client-cli/src/main/java/ai/floedb/floecat/client/cli/IntegrationCliSupport.java
@@ -108,7 +108,7 @@ final class IntegrationCliSupport {
       case "create" -> {
         if (args.size() < 4) {
           out.println(
-              "usage: integration create <name> <iceberg-rest|unity> <uri>"
+              "usage: integration create <name> <iceberg-rest|unity|delta-sharing> <uri>"
                   + " --auth-type <type> [--auth k=v ...] [--cred k=v ...]"
                   + " [--props k=v ...]");
           return;
@@ -647,6 +647,7 @@ final class IntegrationCliSupport {
     return switch (normalized(value)) {
       case "ICEBERG_REST", "ICEBERG-REST", "ICEBERG" -> CatalogIntegrationType.CIT_ICEBERG_REST;
       case "UNITY" -> CatalogIntegrationType.CIT_UNITY;
+      case "DELTA_SHARING", "DELTA-SHARING", "SHARING" -> CatalogIntegrationType.CIT_DELTA_SHARING;
       default -> throw new IllegalArgumentException("Unknown integration type: " + value);
     };
   }

--- a/client-cli/src/main/java/ai/floedb/floecat/client/cli/Shell.java
+++ b/client-cli/src/main/java/ai/floedb/floecat/client/cli/Shell.java
@@ -581,7 +581,7 @@ public class Shell implements Runnable {
          query fetch-scan <query_id> <table_id>
          integrations
          integration get <name|id>
-         integration create <name> <iceberg-rest|unity> <uri> --auth-type <type>
+         integration create <name> <iceberg-rest|unity|delta-sharing> <uri> --auth-type <type>
              [--auth k=v ...] [--cred k=v ...] [--props k=v ...]
          integration update <name|id> [--display <name>] [--uri <uri>] [--props k=v ...] [--etag <etag>]
          integration update-auth <name|id> --auth-type <type>

--- a/connectors/catalogs/delta/src/main/java/ai/floedb/floecat/connector/delta/uc/impl/S3V2FileSystemClient.java
+++ b/connectors/catalogs/delta/src/main/java/ai/floedb/floecat/connector/delta/uc/impl/S3V2FileSystemClient.java
@@ -26,6 +26,7 @@ import io.delta.kernel.utils.FileStatus;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.Iterator;
@@ -85,6 +86,65 @@ final class S3V2FileSystemClient implements FileIO {
         "Copying files not implemented for read-only S3V2FileIO");
   }
 
+  /**
+   * An {@code s3://} path for a listed object, in a form the rest of this client can parse.
+   *
+   * <p>Every path here comes back through {@code resolvePath}, which calls {@code URI.create} --
+   * and an S3 object key may hold characters that rejects, a space being the one that occurs. This
+   * was built by concatenating the raw key, so a table under {@code db/my table} listed its Delta
+   * log fine and then threw when the next entry was opened: the caller's own location could be
+   * encoded, but a listing rebuilt every later path from the raw key and lost that.
+   *
+   * <p>Round-trips: {@code getPath} decodes, so the key asked of S3 is the key that was written.
+   * For a key holding nothing {@code URI} objects to, the result is byte-identical to plain
+   * concatenation, so only a path that would otherwise fail to parse is affected at all.
+   */
+  static String s3Uri(String bucket, String key) {
+    // Segment by segment, so no leading slash is ever handed to URI as part of a "//" it would read
+    // as an authority. An S3 key may begin with a slash, and for such a key the path is "//table",
+    // whose first segment URI takes as a host and drops from getRawPath -- silently, so a fallback
+    // never runs and S3 is asked for a key missing its first segment. Splitting keeps the empty
+    // leading segment that slash represents, and no segment can hold a slash to re-parse.
+    StringBuilder path = new StringBuilder();
+    for (String segment : key.split("/", -1)) {
+      try {
+        String encoded = new URI(null, null, "/" + segment, null).getRawPath();
+        path.append('/').append(encoded, 1, encoded.length());
+      } catch (URISyntaxException notAUri) {
+        path.append('/').append(segment);
+      }
+    }
+    return "s3://" + bucket + path;
+  }
+
+  /**
+   * The bucket a location addresses, falling back to the authority when it is not a hostname.
+   *
+   * <p>S3 permitted bucket names {@code java.net.URI} will not parse as a host -- an underscore is
+   * the one that survives in older regions -- and for those {@code getHost} answers null while the
+   * authority carries the name. {@code S3DeltaLogProbe.bucketOf} accepts such a name, so this has
+   * to as well: a table the probe validates and the reader cannot address is one that reconciles
+   * and then fails every scan. The fallback's shape matches that method -- an authority holding
+   * userinfo or a port is not a bucket name.
+   *
+   * <p>Not shared with it because this module does not depend on catalog-access, and a connector
+   * depending on it to parse a URI would be the wrong direction.
+   */
+  static String bucketOf(URI location) {
+    String host = location.getHost();
+    if (host != null && !host.isEmpty()) {
+      return host;
+    }
+    String authority = location.getAuthority();
+    if (authority == null
+        || authority.isEmpty()
+        || authority.indexOf('@') >= 0
+        || authority.indexOf(':') >= 0) {
+      return null;
+    }
+    return authority;
+  }
+
   @Override
   public String resolvePath(String path) {
     if (path.startsWith("s3a://")) {
@@ -99,7 +159,7 @@ final class S3V2FileSystemClient implements FileIO {
   @Override
   public FileStatus getFileStatus(String path) throws IOException {
     var u = URI.create(resolvePath(path));
-    var bucket = u.getHost();
+    var bucket = bucketOf(u);
     var key = u.getPath().startsWith("/") ? u.getPath().substring(1) : u.getPath();
     try {
       var head = s3.call(client -> client.headObject(b -> b.bucket(bucket).key(key)));
@@ -115,7 +175,7 @@ final class S3V2FileSystemClient implements FileIO {
       return false;
     }
     URI u = URI.create(resolvedPath);
-    String bucket = u.getHost();
+    String bucket = bucketOf(u);
     String key = u.getPath().startsWith("/") ? u.getPath().substring(1) : u.getPath();
     try {
       s3.callUnchecked(client -> client.headObject(b -> b.bucket(bucket).key(key)));
@@ -132,7 +192,7 @@ final class S3V2FileSystemClient implements FileIO {
   public CloseableIterator<FileStatus> listFrom(String filePath) throws IOException {
     final String resolved = resolvePath(filePath);
     final URI u = URI.create(resolved);
-    final String bucket = u.getHost();
+    final String bucket = bucketOf(u);
     if (bucket == null || bucket.isEmpty()) {
       throw new IOException("Invalid S3 path for listFrom: " + filePath);
     }
@@ -244,7 +304,7 @@ final class S3V2FileSystemClient implements FileIO {
               continue;
             }
 
-            String fullPath = "s3://" + bucket + "/" + key;
+            String fullPath = s3Uri(bucket, key);
             long size = (o.size() != null) ? o.size() : 0L;
             long mod =
                 (o.lastModified() != null)
@@ -267,7 +327,7 @@ final class S3V2FileSystemClient implements FileIO {
   @Override
   public boolean mkdirs(String path) throws IOException {
     var u = URI.create(resolvePath(path));
-    if (u.getHost() == null) {
+    if (bucketOf(u) == null) {
       throw new IOException("Invalid S3 path for mkdirs: " + path);
     }
     return true;
@@ -291,7 +351,7 @@ final class S3V2FileSystemClient implements FileIO {
       this.resolvedPath = resolvedPath;
 
       var u = URI.create(resolvedPath);
-      this.bucket = u.getHost();
+      this.bucket = bucketOf(u);
       this.key = u.getPath().startsWith("/") ? u.getPath().substring(1) : u.getPath();
 
       try {

--- a/connectors/catalogs/delta/src/test/java/ai/floedb/floecat/connector/delta/uc/impl/S3V2FileSystemClientTest.java
+++ b/connectors/catalogs/delta/src/test/java/ai/floedb/floecat/connector/delta/uc/impl/S3V2FileSystemClientTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.connector.delta.uc.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.net.URI;
+import org.junit.jupiter.api.Test;
+
+/** Paths handed back from a listing have to be paths this client can parse again. */
+class S3V2FileSystemClientTest {
+
+  /**
+   * A listed key holding a space becomes a path {@code URI.create} accepts, and decodes back to the
+   * key that was written.
+   *
+   * <p>These paths come back through {@code resolvePath}, which parses them. Built by concatenating
+   * the raw key, a table under {@code db/my table} listed its Delta log and then threw when the
+   * next entry was opened -- so the location could be encoded by the caller and a listing would
+   * lose it again on every entry after the first.
+   */
+  @Test
+  void aListedKeyWithASpaceRoundTrips() {
+    String path = S3V2FileSystemClient.s3Uri("warehouse", "db/my table/_delta_log/000.json");
+
+    assertThat(path).isEqualTo("s3://warehouse/db/my%20table/_delta_log/000.json");
+    assertThatCode(() -> URI.create(path)).doesNotThrowAnyException();
+    assertThat(URI.create(path).getPath()).isEqualTo("/db/my table/_delta_log/000.json");
+  }
+
+  /**
+   * A bucket name {@code java.net.URI} will not parse as a host. S3 permitted an underscore in
+   * older regions, and for such a name {@code getHost} answers null while the authority carries it.
+   * The shared probe accepts such a name, so this client has to address it: a table the probe
+   * validates and the reader cannot open is one that reconciles and then fails every scan.
+   */
+  @Test
+  void aBucketNameThatIsNotAHostnameIsStillAddressed() {
+    assertThat(S3V2FileSystemClient.bucketOf(URI.create("s3://legacy_bucket/db/table")))
+        .isEqualTo("legacy_bucket");
+    assertThat(S3V2FileSystemClient.bucketOf(URI.create("s3://warehouse/db/table")))
+        .isEqualTo("warehouse");
+  }
+
+  /**
+   * And the call sites use it. {@code mkdirs} is the one path that needs no S3 call to reach the
+   * bucket derivation, so it is where the wiring can be asserted rather than only the helper:
+   * deriving from {@code getHost} alone rejects a legacy bucket name outright.
+   */
+  @Test
+  void aLegacyBucketNameIsAddressableThroughTheClient() throws Exception {
+    var client = new S3V2FileSystemClient(null);
+
+    assertThat(client.mkdirs("s3://legacy_bucket/db/table")).isTrue();
+    assertThat(client.mkdirs("s3://warehouse/db/table")).isTrue();
+  }
+
+  /**
+   * The fallback accepts a plain authority and nothing else, which is the probe's rule too.
+   *
+   * <p>Only the fallback is guarded, because {@code getHost} answers the host for a location
+   * carrying userinfo or a port -- it is not part of the host -- so those never reach it. Refusing
+   * them is the location gate's job, and it does refuse them before anything is published.
+   */
+  @Test
+  void theFallbackRefusesAnAuthorityCarryingMoreThanAName() {
+    assertThat(S3V2FileSystemClient.bucketOf(URI.create("s3://user:pw@legacy_bucket/db/t")))
+        .isNull();
+    assertThat(S3V2FileSystemClient.bucketOf(URI.create("s3://legacy_bucket/db/t")))
+        .isEqualTo("legacy_bucket");
+  }
+
+  /**
+   * A bucket name {@code URI} will not parse as a host still gets an encoded path. Passing the
+   * bucket as a host makes {@code URI} reject such a name, and the fallback then emits the raw key
+   * -- leaving the space this method exists to encode, for exactly the bucket shape {@code
+   * bucketOf} was added to support.
+   */
+  @Test
+  void aLegacyBucketNameStillGetsAnEncodedPath() {
+    String path = S3V2FileSystemClient.s3Uri("legacy_bucket", "db/my table/_delta_log/000.json");
+
+    assertThat(path).isEqualTo("s3://legacy_bucket/db/my%20table/_delta_log/000.json");
+    assertThat(URI.create(path).getPath()).isEqualTo("/db/my table/_delta_log/000.json");
+    assertThat(S3V2FileSystemClient.bucketOf(URI.create(path))).isEqualTo("legacy_bucket");
+  }
+
+  /**
+   * A key beginning with a slash keeps it. S3 permits such a key, and the location gate publishes
+   * the {@code s3://bucket//table} shape that produces one, so a listing under it reaches here.
+   *
+   * <p>Encoding the key as one path handed {@code URI} a string opening "//", which it parsed as an
+   * authority: {@code getRawPath} answered without the first segment and threw nothing, so the
+   * fallback never ran and every listed entry addressed a key missing its leading name.
+   */
+  @Test
+  void aKeyBeginningWithASlashKeepsIt() {
+    assertThat(S3V2FileSystemClient.s3Uri("warehouse", "/table/_delta_log/000.json"))
+        .isEqualTo("s3://warehouse//table/_delta_log/000.json");
+    assertThat(S3V2FileSystemClient.s3Uri("warehouse", "/my table/000.json"))
+        .isEqualTo("s3://warehouse//my%20table/000.json");
+    assertThat(URI.create(S3V2FileSystemClient.s3Uri("warehouse", "/my table/000.json")).getPath())
+        .isEqualTo("//my table/000.json");
+  }
+
+  /**
+   * And a key holding nothing {@code URI} objects to is byte-identical to plain concatenation, so
+   * only a path that would otherwise fail to parse is affected at all.
+   */
+  @Test
+  void anOrdinaryKeyIsUnchanged() {
+    for (String key : new String[] {"db/orders/_delta_log/000.json", "a/b/c.parquet", "x"}) {
+      assertThat(S3V2FileSystemClient.s3Uri("warehouse", key))
+          .as(key)
+          .isEqualTo("s3://warehouse/" + key);
+    }
+  }
+}

--- a/connectors/clients/delta-sharing/pom.xml
+++ b/connectors/clients/delta-sharing/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright 2026 Yellowbrick Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>ai.floedb.floecat</groupId>
+    <artifactId>floecat</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <relativePath>../../..</relativePath>
+  </parent>
+
+  <artifactId>floecat-delta-sharing-client</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>ai.floedb.floecat</groupId>
+      <artifactId>floecat-http-endpoint-guards</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${version.jackson}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/connectors/clients/delta-sharing/src/main/java/ai/floedb/floecat/client/sharing/DeltaSharingClient.java
+++ b/connectors/clients/delta-sharing/src/main/java/ai/floedb/floecat/client/sharing/DeltaSharingClient.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.client.sharing;
+
+import ai.floedb.floecat.client.sharing.DeltaSharingModel.Schema;
+import ai.floedb.floecat.client.sharing.DeltaSharingModel.Share;
+import ai.floedb.floecat.client.sharing.DeltaSharingModel.Table;
+import ai.floedb.floecat.client.sharing.DeltaSharingModel.TableDescription;
+import ai.floedb.floecat.client.sharing.DeltaSharingModel.TemporaryCredentials;
+import java.util.List;
+
+/**
+ * The Delta Sharing recipient surface, separated from transport.
+ *
+ * <p>Only the operations a recipient needs to discover and read shared tables through directory
+ * access appear here. The query endpoint, which serves presigned per-file URLs, is deliberately
+ * absent: url mode is a different execution model rather than another credential shape, and nothing
+ * above this package can represent it yet.
+ *
+ * <p>Every method raises {@link DeltaSharingException} with a classified {@code Failure}. Paging is
+ * the implementation's business; these return complete lists.
+ */
+public interface DeltaSharingClient extends AutoCloseable {
+
+  /** Every share the recipient token can see. */
+  List<Share> listShares();
+
+  /** Every schema in one share. */
+  List<Schema> listSchemas(String share);
+
+  /** Every table in one schema, each carrying its advertised access modes. */
+  List<Table> listTables(String share, String schema);
+
+  /**
+   * The Protocol and Metadata actions for one table.
+   *
+   * <p>Raises {@code INVALID_RESPONSE} when the server sends fewer than the two required NDJSON
+   * lines, which is the shape a proxy error page takes when it arrives with a success status.
+   */
+  TableDescription describeTable(String share, String schema, String table);
+
+  /**
+   * Temporary credentials for reading a table location directly.
+   *
+   * <p>{@code location} selects an auxiliary location; when absent the server answers for the
+   * table's own location. Raises {@code INVALID_REQUEST} for a table that does not advertise
+   * directory access, since the endpoint is only required to exist for those.
+   *
+   * <p>Nothing passes {@code location} yet, and nothing can: selecting among several locations is
+   * the only reason to name one, and a table reporting auxiliary locations is refused at the load
+   * and at the vend. It is here because the request field is part of the protocol operation this
+   * method is, and it is exercised by a test rather than by a caller. Said plainly so the next
+   * reader does not have to derive it from the call sites, as this one had to.
+   */
+  TemporaryCredentials temporaryTableCredentials(
+      String share, String schema, String table, String location);
+
+  @Override
+  void close();
+}

--- a/connectors/clients/delta-sharing/src/main/java/ai/floedb/floecat/client/sharing/DeltaSharingException.java
+++ b/connectors/clients/delta-sharing/src/main/java/ai/floedb/floecat/client/sharing/DeltaSharingException.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.client.sharing;
+
+/**
+ * A Delta Sharing request that did not produce a usable answer, classified by what a caller can do
+ * about it.
+ *
+ * <p>The classification is the point of this type. A recipient talks to a server it does not
+ * administer, so the difference between "this token is not accepted", "this share is not shared
+ * with you", "come back later" and "the server sent something this client cannot read" decides
+ * whether a reconcile job retries, fails, or reports a configuration error to an operator.
+ */
+public final class DeltaSharingException extends RuntimeException {
+
+  /** What kind of failure occurred, from the caller's point of view. */
+  public enum Failure {
+    /** The recipient token was rejected. */
+    UNAUTHENTICATED,
+    /** The token is valid but does not carry access to the requested share, schema or table. */
+    PERMISSION_DENIED,
+    /** The share, schema or table does not exist, or is not shared with this recipient. */
+    NOT_FOUND,
+    /** The server asked the client to slow down. */
+    RATE_LIMITED,
+    /** The server failed. Retrying may succeed. */
+    SERVER_ERROR,
+    /** The request never reached the server, or its response never arrived. */
+    TRANSPORT,
+    /** A response arrived that this client cannot parse or that violates the protocol. */
+    INVALID_RESPONSE,
+    /** The server rejected the request as malformed or unsupported. */
+    INVALID_REQUEST,
+    /** The calling thread was interrupted. Not a server condition and not worth a retry budget. */
+    INTERRUPTED,
+    /** Anything else the server reported that a later attempt could clear. */
+    TRANSIENT,
+    /** Unclassified. */
+    OTHER
+  }
+
+  private final Failure failure;
+  private final int statusCode;
+
+  public DeltaSharingException(Failure failure, int statusCode, String message) {
+    this(failure, statusCode, message, null);
+  }
+
+  public DeltaSharingException(Failure failure, int statusCode, String message, Throwable cause) {
+    super(message, cause);
+    this.failure = failure == null ? Failure.OTHER : failure;
+    this.statusCode = statusCode;
+  }
+
+  public Failure failure() {
+    return failure;
+  }
+
+  /** The HTTP status that produced this, or -1 when the failure happened before a response. */
+  public int statusCode() {
+    return statusCode;
+  }
+}

--- a/connectors/clients/delta-sharing/src/main/java/ai/floedb/floecat/client/sharing/DeltaSharingModel.java
+++ b/connectors/clients/delta-sharing/src/main/java/ai/floedb/floecat/client/sharing/DeltaSharingModel.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.client.sharing;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Normalized Delta Sharing protocol objects.
+ *
+ * <p>Normalized rather than wire-shaped: the transport decodes what the server sent and hands these
+ * on, so nothing above this package has to know that lists paginate, that metadata arrives as
+ * NDJSON rather than a JSON object, or which of three cloud credential shapes a server chose.
+ */
+public final class DeltaSharingModel {
+
+  private DeltaSharingModel() {}
+
+  /** How a recipient may read a table's data. */
+  public enum AccessMode {
+    /** The server returns presigned per-file URLs from the query endpoint. */
+    URL,
+    /** The server issues temporary credentials for reading the table location directly. */
+    DIR,
+    /**
+     * A mode this client does not recognise.
+     *
+     * <p>Kept rather than dropped so a stated list stays distinguishable from an absent field.
+     * Dropping an unknown value made {@code ["dir2"]} decode to the empty list, which is the same
+     * value used for "the server said nothing" -- so a table that had stated its modes was refused
+     * under the strict setting with a message saying it had stated none.
+     */
+    OTHER
+  }
+
+  /** A share, the outermost level of the sharing hierarchy. */
+  public record Share(String name, Optional<String> id) {
+    public Share {
+      name = requireText(name, "name");
+      id = id == null ? Optional.empty() : id;
+    }
+  }
+
+  /** A schema within a share. */
+  public record Schema(String share, String name) {
+    public Schema {
+      share = requireText(share, "share");
+      name = requireText(name, "name");
+    }
+  }
+
+  /**
+   * A table within a schema.
+   *
+   * <p>{@code accessModes} is empty when the server did not send the field. That is left as it
+   * arrived rather than resolved here: the protocol reads an absent field as url only, but a caller
+   * may reasonably ask the server instead, and which of those applies is a policy the catalog
+   * provider owns through {@code delta.sharing.strict-access-modes}. A helper answering the strict
+   * reading here would have quietly reinstated it for every future caller.
+   *
+   * <p>{@code location} is present only for directory access. A url-only server does not disclose
+   * where the table lives, by design.
+   *
+   * <p>{@code id} is unique within the share, not across the server; {@code shareId} is the part
+   * the protocol makes server-unique. An identity built from {@code id} alone says nothing about
+   * which share it came from, and two shares may legally carry the same table id.
+   */
+  public record Table(
+      String share,
+      String schema,
+      String name,
+      Optional<String> id,
+      Optional<String> shareId,
+      Optional<String> location,
+      List<String> auxiliaryLocations,
+      List<AccessMode> accessModes) {
+
+    public Table {
+      share = requireText(share, "share");
+      schema = requireText(schema, "schema");
+      name = requireText(name, "name");
+      id = id == null ? Optional.empty() : id;
+      shareId = shareId == null ? Optional.empty() : shareId;
+      location = location == null ? Optional.empty() : location;
+      auxiliaryLocations = auxiliaryLocations == null ? List.of() : List.copyOf(auxiliaryLocations);
+      accessModes = accessModes == null ? List.of() : List.copyOf(accessModes);
+    }
+
+    /** Whether this listing reports storage locations beyond the table's root. */
+    public boolean hasAuxiliaryLocations() {
+      return !auxiliaryLocations.isEmpty();
+    }
+
+    /** The share, schema and table names joined as the protocol addresses them. */
+    public String fullName() {
+      return share + "." + schema + "." + name;
+    }
+  }
+
+  /**
+   * The Protocol action heading a metadata or query response.
+   *
+   * <p>{@code minReaderVersion} above 1 means the table uses features that require {@code
+   * responseformat=delta}, and {@code readerFeatures} names them.
+   */
+  public record Protocol(int minReaderVersion, List<String> readerFeatures) {
+    public Protocol {
+      readerFeatures = readerFeatures == null ? List.of() : List.copyOf(readerFeatures);
+    }
+  }
+
+  /** The Metadata action describing a table's schema and layout. */
+  public record TableMetadata(
+      Optional<String> id,
+      Optional<String> name,
+      String format,
+      String schemaJson,
+      List<String> partitionColumns,
+      Map<String, String> configuration,
+      Optional<Long> version,
+      Optional<String> location,
+      List<String> auxiliaryLocations,
+      List<AccessMode> accessModes) {
+
+    public TableMetadata {
+      id = id == null ? Optional.empty() : id;
+      name = name == null ? Optional.empty() : name;
+      format = requireText(format, "format");
+      schemaJson = requireText(schemaJson, "schemaJson");
+      partitionColumns = partitionColumns == null ? List.of() : List.copyOf(partitionColumns);
+      configuration = configuration == null ? Map.of() : Map.copyOf(configuration);
+      version = version == null ? Optional.empty() : version;
+      location = location == null ? Optional.empty() : location;
+      auxiliaryLocations = auxiliaryLocations == null ? List.of() : List.copyOf(auxiliaryLocations);
+      accessModes = accessModes == null ? List.of() : List.copyOf(accessModes);
+    }
+
+    /** Whether this table reports auxiliary storage locations beyond its root. */
+    public boolean hasAuxiliaryLocations() {
+      return !auxiliaryLocations.isEmpty();
+    }
+  }
+
+  /** A metadata response: the Protocol action, the Metadata action, and the reported version. */
+  public record TableDescription(
+      Protocol protocol, TableMetadata metadata, Optional<Long> version) {
+    public TableDescription {
+      Objects.requireNonNull(protocol, "protocol");
+      Objects.requireNonNull(metadata, "metadata");
+      version = version == null ? Optional.empty() : version;
+    }
+  }
+
+  /** Which cloud a temporary credential is for. */
+  public enum CredentialCloud {
+    AWS,
+    AZURE,
+    GCP
+  }
+
+  /**
+   * Temporary credentials for reading a table location directly.
+   *
+   * <p>Only the AWS shape carries key material here. Azure and GCP are recognised so the transport
+   * can report which cloud a server answered with, rather than the caller seeing an empty
+   * credential and having to guess why.
+   */
+  public record TemporaryCredentials(
+      CredentialCloud cloud,
+      String location,
+      Optional<String> accessKeyId,
+      Optional<String> secretAccessKey,
+      Optional<String> sessionToken,
+      Optional<Instant> expiresAt) {
+
+    public TemporaryCredentials {
+      Objects.requireNonNull(cloud, "cloud");
+      location = requireText(location, "location");
+      accessKeyId = accessKeyId == null ? Optional.empty() : accessKeyId;
+      secretAccessKey = secretAccessKey == null ? Optional.empty() : secretAccessKey;
+      sessionToken = sessionToken == null ? Optional.empty() : sessionToken;
+      expiresAt = expiresAt == null ? Optional.empty() : expiresAt;
+    }
+
+    /** Whether this carries a complete AWS session triad. */
+    public boolean hasAwsSession() {
+      return cloud == CredentialCloud.AWS
+          && accessKeyId.isPresent()
+          && secretAccessKey.isPresent()
+          && sessionToken.isPresent();
+    }
+
+    /**
+     * Never the key material.
+     *
+     * <p>These records reach logs through exception messages and diagnostic lines, so the default
+     * record toString would put a live secret in both.
+     */
+    @Override
+    public String toString() {
+      return "TemporaryCredentials[cloud="
+          + cloud
+          + ", location="
+          + location
+          + ", expiresAt="
+          + expiresAt.map(Instant::toString).orElse("<none>")
+          + ", credentials=<redacted>]";
+    }
+  }
+
+  private static String requireText(String value, String field) {
+    if (value == null || value.isBlank()) {
+      throw new IllegalArgumentException(field + " must not be blank");
+    }
+    return value;
+  }
+}

--- a/connectors/clients/delta-sharing/src/main/java/ai/floedb/floecat/client/sharing/HttpDeltaSharingClient.java
+++ b/connectors/clients/delta-sharing/src/main/java/ai/floedb/floecat/client/sharing/HttpDeltaSharingClient.java
@@ -1,0 +1,1379 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.client.sharing;
+
+import ai.floedb.floecat.client.sharing.DeltaSharingException.Failure;
+import ai.floedb.floecat.client.sharing.DeltaSharingModel.AccessMode;
+import ai.floedb.floecat.client.sharing.DeltaSharingModel.CredentialCloud;
+import ai.floedb.floecat.client.sharing.DeltaSharingModel.Protocol;
+import ai.floedb.floecat.client.sharing.DeltaSharingModel.Schema;
+import ai.floedb.floecat.client.sharing.DeltaSharingModel.Share;
+import ai.floedb.floecat.client.sharing.DeltaSharingModel.Table;
+import ai.floedb.floecat.client.sharing.DeltaSharingModel.TableDescription;
+import ai.floedb.floecat.client.sharing.DeltaSharingModel.TableMetadata;
+import ai.floedb.floecat.client.sharing.DeltaSharingModel.TemporaryCredentials;
+import ai.floedb.floecat.http.guards.HttpEndpointGuards;
+import ai.floedb.floecat.http.guards.HttpResponseSnippets;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
+
+/**
+ * A Delta Sharing recipient over HTTP.
+ *
+ * <p>Only the operations directory access needs. The query endpoint is absent because url mode is
+ * not supported here; see {@link DeltaSharingClient}.
+ */
+public final class HttpDeltaSharingClient implements DeltaSharingClient {
+
+  /** Cap on pages one listing will fetch, so a server minting fresh tokens cannot loop forever. */
+  static final String MAX_PAGES_PROPERTY = "floecat.delta-sharing.max-pages";
+
+  private static final int DEFAULT_MAX_PAGES = 10_000;
+
+  /** Cap on a single response body. A larger one is refused rather than buffered. */
+  static final String MAX_RESPONSE_BYTES_PROPERTY = "floecat.delta-sharing.max-response-bytes";
+
+  private static final int DEFAULT_MAX_RESPONSE_BYTES = 32 * 1024 * 1024;
+
+  /**
+   * The cumulative bound on everything one client lists, across pages and across listings.
+   *
+   * <p>Counts characters of decoded body. That is the unit that bounds heap, and it equals bytes
+   * for the ASCII JSON these endpoints answer with.
+   *
+   * <p>Per client rather than per listing, because a client's lifetime is one reconcile pass and a
+   * pass memoises each schema's tables for the whole of it. A per-listing bound would leave a share
+   * of two hundred schemas retaining two hundred times the cap, which is no bound on the pass.
+   *
+   * <p>The size comes from what a listing costs. A table entry carrying a name, its schema and
+   * share, a table id and a share id, a location and its access modes is roughly two hundred and
+   * eighty bytes of JSON -- nearer four hundred with an ordinary location, six hundred with a deep
+   * prefix. So this admits somewhere above sixty thousand tables across a whole share, where a
+   * large real share holds thousands, and the decoded records cost about the same again, so a pass
+   * peaks near twice this. Beyond it a reconcile is refused, naming this property, rather than
+   * taking the heap with it.
+   *
+   * <p>Neither of the other two bounds gives a memory bound. The per-response cap and the page cap
+   * multiply out to ten thousand pages of thirty-two mebibytes, and the endpoint is named by tenant
+   * configuration, so a server answering enormous pages takes the process down rather than failing
+   * its own reconcile.
+   */
+  static final String MAX_LISTING_BYTES_PROPERTY = "floecat.delta-sharing.max-listing-bytes";
+
+  private static final int DEFAULT_MAX_LISTING_BYTES = 32 * 1024 * 1024;
+
+  /** Bound on upstream text reaching an exception message. */
+  private static final int MAX_BODY_SNIPPET_CHARS = 2_000;
+
+  /**
+   * The last instant a proto Timestamp can carry, 9999-12-31T23:59:59.999Z.
+   *
+   * <p>Duplicated from {@code FloecatConnector.VendedStorageCredentials} for the reason the Unity
+   * client duplicates it: this module depends on neither. Cheap to copy, because the proto
+   * specification fixes it rather than any of the three copies owning it as policy.
+   */
+  private static final long MAX_EXPIRY_EPOCH_MILLIS = 253402300799999L;
+
+  /** Never requested. Only somewhere for the header probe in {@link #requireHeaderSafe} to hang. */
+  private static final URI PROBE_URI = URI.create("https://probe.invalid/");
+
+  /**
+   * Strict where the defaults are lenient, because the shape guards depend on it.
+   *
+   * <p>Two defaults let a malformed 200 through as an authoritative listing, which is the outcome
+   * every guard in this class exists to prevent: the reconciler reads a successful empty or partial
+   * inventory as the share having dropped what is missing, and retires it.
+   *
+   * <p>Trailing tokens: {@code readTree} reads the first document and discards whatever follows, so
+   * {@code {"items":[]}{"items":[...]}} parsed as an empty page. Duplicate keys: the last value
+   * wins, so a body naming tables and then restating {@code items} as empty parsed as empty. Both
+   * reach the page-shape checks below looking perfectly well formed, because by then the evidence
+   * is gone.
+   *
+   * <p>The NDJSON path splits on newlines and reads each line separately, so trailing-token
+   * strictness holds there too: a line carrying two concatenated actions is now refused rather than
+   * half read.
+   */
+  private static final ObjectMapper MAPPER =
+      new ObjectMapper()
+          .enable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS)
+          .enable(DeserializationFeature.FAIL_ON_READING_DUP_TREE_KEY);
+
+  private final String baseUri;
+  private final String bearerToken;
+  private final HttpClient httpClient;
+  private final Duration requestTimeout;
+  private final String capabilities;
+  private final int maxResponseBytes;
+  private final int maxPages;
+  private final int maxListingBytes;
+  private final AtomicLong listedChars = new AtomicLong();
+
+  public HttpDeltaSharingClient(
+      URI endpoint, String bearerToken, Duration connectTimeout, Duration requestTimeout) {
+    this(endpoint, bearerToken, connectTimeout, requestTimeout, List.of());
+  }
+
+  /**
+   * @param readerFeatures Delta reader features this caller can process. Sent with {@code
+   *     responseformat=delta}, which is required for a table whose {@code minReaderVersion} exceeds
+   *     1. Claiming a feature the reader cannot handle turns a protocol-level refusal into a
+   *     failure during a scan, so the caller names what it actually supports rather than
+   *     everything.
+   */
+  public HttpDeltaSharingClient(
+      URI endpoint,
+      String bearerToken,
+      Duration connectTimeout,
+      Duration requestTimeout,
+      List<String> readerFeatures) {
+    // Ahead of the transport, because these raise on a value they cannot use and anything built
+    // before the throw is unreachable and never closed. A zero or negative override made every
+    // listing fail with "exceeded 0 pages" and every response read as oversized.
+    this.maxResponseBytes = configuredMaxResponseBytes();
+    this.maxPages = positiveIntProperty(MAX_PAGES_PROPERTY, DEFAULT_MAX_PAGES);
+    this.maxListingBytes =
+        positiveIntProperty(MAX_LISTING_BYTES_PROPERTY, DEFAULT_MAX_LISTING_BYTES);
+    this.capabilities = buildCapabilities(readerFeatures);
+    URI validated =
+        HttpEndpointGuards.requireAllowedEndpoint(
+            Objects.requireNonNull(endpoint, "endpoint"), "Delta Sharing endpoint");
+    this.baseUri = stripTrailingSlash(validated.toString());
+    // Checked here, and the value never appears in the failure. HttpRequest.Builder.header quotes
+    // the value it rejects, and every RuntimeException from the send is classified as TRANSPORT
+    // with its cause attached -- so a token carrying a newline reached the cause chain the vendor
+    // logs, verbatim, on a request that never left the process.
+    this.bearerToken = requireHeaderSafe(requireText(bearerToken, "bearerToken"));
+    this.requestTimeout = requirePositive(requestTimeout, "requestTimeout");
+    this.httpClient =
+        HttpClient.newBuilder()
+            .connectTimeout(requirePositive(connectTimeout, "connectTimeout"))
+            // A sharing endpoint is tenant-supplied. Following a redirect would let it move the
+            // request, and the recipient token, to a host none of the transport gates saw.
+            .followRedirects(HttpClient.Redirect.NEVER)
+            .build();
+  }
+
+  @Override
+  public List<Share> listShares() {
+    String target = "shares";
+    return List.copyOf(
+        paginate(
+            "/shares",
+            target,
+            item -> new Share(text(item, "name", target), optionalText(item, "id", target))));
+  }
+
+  @Override
+  public List<Schema> listSchemas(String share) {
+    String path = "/shares/" + encode(share) + "/schemas";
+    String target = "schemas of " + share;
+    return List.copyOf(
+        paginate(path, target, item -> new Schema(share, text(item, "name", target))));
+  }
+
+  @Override
+  public List<Table> listTables(String share, String schema) {
+    String path = "/shares/" + encode(share) + "/schemas/" + encode(schema) + "/tables";
+    String target = "tables of " + share + "." + schema;
+    return List.copyOf(
+        paginate(
+            path,
+            target,
+            item ->
+                new Table(
+                    share,
+                    schema,
+                    text(item, "name", target),
+                    optionalText(item, "id", target),
+                    optionalText(item, "shareId", target),
+                    optionalText(item, "location", target),
+                    textList(item, "auxiliaryLocations", target),
+                    accessModes(item, target))));
+  }
+
+  @Override
+  public TableDescription describeTable(String share, String schema, String table) {
+    String path = tablePath(share, schema, table) + "/metadata";
+    String target = share + "." + schema + "." + table;
+    NdjsonResponse response = sendNdjson(HttpRequest.newBuilder().GET(), path, target, true);
+    List<JsonNode> actions = response.actions();
+
+    Protocol protocol = null;
+    TableMetadata metadata = null;
+    for (JsonNode action : actions) {
+      // hasNonNull, not has. An explicit null answers has() with true, and parseProtocol tolerates
+      // a null node -- path() on it yields a missing node, so minReaderVersion defaults and the
+      // reader features come back empty. A body of {"protocol":null} therefore satisfied the
+      // both-actions guard below with a protocol action this client had invented. Same explicit
+      // null the page shape was hardened against, and the same test parseCredentials already used.
+      if (action.hasNonNull("protocol")) {
+        // One of each. A second action of the same kind overwrote the first, so a concatenated or
+        // malformed response materialised the later schema and location on a table that reconciled
+        // clean -- the last-write-wins trap FAIL_ON_READING_DUP_TREE_KEY closes for duplicate keys,
+        // one level up at the action level, where multi-line framing is legal and so that setting
+        // does not reach it. Order is not enforced: the wire format states protocol then metaData,
+        // but accepting the reverse costs nothing and refusing it would fail a correct server.
+        requireFirst(protocol, "protocol", target);
+        protocol = parseProtocol(action.get("protocol"), target);
+      } else if (action.hasNonNull("metaData")) {
+        requireFirst(metadata, "metaData", target);
+        metadata = parseMetadata(action.get("metaData"), target);
+      }
+    }
+    // The protocol requires both, in that order. A proxy error page arriving with a success status
+    // is the shape that reaches here with neither, and reporting it as a protocol violation rather
+    // than a null later is the difference between a diagnosable failure and one that is not.
+    if (protocol == null || metadata == null) {
+      throw new DeltaSharingException(
+          Failure.INVALID_RESPONSE,
+          200,
+          "Delta Sharing metadata for "
+              + target
+              + " did not contain both a protocol and a metaData action");
+    }
+    // The header first: it states the current version for an ordinary metadata request, and the
+    // action's own version is populated only for a versioned or change-feed query.
+    return new TableDescription(protocol, metadata, response.version().or(metadata::version));
+  }
+
+  @Override
+  public TemporaryCredentials temporaryTableCredentials(
+      String share, String schema, String table, String location) {
+    String path = tablePath(share, schema, table) + "/temporary-table-credentials";
+    String target = share + "." + schema + "." + table;
+    String body =
+        location == null || location.isBlank()
+            ? "{}"
+            : "{\"location\":" + quoteJson(location) + "}";
+
+    HttpRequest.Builder builder =
+        HttpRequest.newBuilder()
+            .POST(HttpRequest.BodyPublishers.ofString(body, StandardCharsets.UTF_8))
+            .header("Content-Type", "application/json; charset=utf-8");
+    // The response carries live credentials, so no part of it reaches an exception message. Every
+    // other endpoint includes a body snippet, which is what makes a server-side error diagnosable.
+    // Both media types. The protocol specifies this response as x-ndjson carrying a single JSON
+    // action, and this request advertised application/json alone -- so a server honouring content
+    // negotiation could answer 406 to every credential request, which is every reconcile and every
+    // read. The parser is unaffected either way: nothing here inspects the response content type,
+    // and a one-action ndjson body is valid JSON. Advertising both is what a client that can read
+    // both should say, and it cannot be refused for either.
+    JsonNode root =
+        credentialsEnvelope(
+            sendForBody(builder, path, target, false, "application/x-ndjson, application/json"),
+            target);
+
+    JsonNode credentials = root.path("credentials");
+    if (credentials.isMissingNode() || !credentials.isObject()) {
+      throw new DeltaSharingException(
+          Failure.INVALID_RESPONSE,
+          200,
+          "Delta Sharing temporary credentials for " + target + " carried no credentials object");
+    }
+    return parseCredentials(credentials, target);
+  }
+
+  @Override
+  public void close() {
+    httpClient.close();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Paging
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Every item across every page of a list endpoint.
+   *
+   * <p>Three independent bounds, because a page token is server-supplied and none alone is enough.
+   * A repeated token is refused, which catches a server returning the same cursor forever; a page
+   * cap catches one minting a fresh cursor each time; and {@link #MAX_LISTING_BYTES_PROPERTY}
+   * bounds what this client will pull in total. Without the first two, a listing is an unbounded
+   * loop against an endpoint the recipient does not control. Without the third it is a bounded
+   * number of unbounded pages, which is no memory bound at all.
+   *
+   * <p>Each item is decoded as its page arrives rather than after the last one. A raw node is
+   * retained whole, including fields this client does not read, so a listing of ten thousand pages
+   * held ten thousand pages of unread JSON; the record it decodes into holds only the fields the
+   * protocol defines. It also fails a malformed item on the first page rather than after fetching
+   * every remaining one.
+   */
+  private <T> List<T> paginate(String path, String target, Function<JsonNode, T> decode) {
+    List<T> collected = new ArrayList<>();
+    Set<String> seenTokens = new LinkedHashSet<>();
+    String pageToken = null;
+
+    for (int page = 0; page < maxPages; page++) {
+      String pagePath =
+          pageToken == null ? path : path + "?pageToken=" + encodeQueryValue(pageToken);
+      String body =
+          sendForBody(HttpRequest.newBuilder().GET(), pagePath, target, true, "application/json");
+      // Across every listing this client has made, not just this one. A pass keeps each schema's
+      // tables for the whole of its life, so the total is what bounds the pass.
+      if (listedChars.addAndGet(body.length()) > maxListingBytes) {
+        // Not retryable, and not one branch of the walk. INVALID_RESPONSE reaches the catalog
+        // client as INTERNAL, which CatalogTraversalFailures does not treat as describing a single
+        // branch, so a listing this size ends the pass instead of being recorded as one skipped
+        // schema and leaving the share looking healthy.
+        throw new DeltaSharingException(
+            Failure.INVALID_RESPONSE,
+            200,
+            "Delta Sharing listings exceeded "
+                + maxListingBytes
+                + " bytes ("
+                + MAX_LISTING_BYTES_PROPERTY
+                + ") while listing "
+                + target);
+      }
+      JsonNode root = parseJson(body, target, true);
+
+      // A page has to be an object, and items has to be an array where it appears at all. Absent
+      // and empty are both legal and mean the same thing; anything else is a malformed response.
+      // Reading a non-array items as an empty listing is destructive rather than merely wrong: the
+      // reconciler treats a successful empty inventory as the share having nothing left and retires
+      // the overlay's tables, so a malformed 200 deletes what a failure would have preserved.
+      if (!root.isObject()) {
+        throw new DeltaSharingException(
+            Failure.INVALID_RESPONSE,
+            200,
+            "Delta Sharing page for " + target + " is not an object");
+      }
+      JsonNode items = root.path("items");
+      // Present and not an array, including an explicit null. The protocol allows the field to be
+      // omitted or to be an array; a null is neither, and exempting it made a malformed page an
+      // authoritative empty inventory again -- the shape that lets the reconciler retire what a
+      // classified failure would have preserved.
+      if (!items.isMissingNode() && !items.isArray()) {
+        throw new DeltaSharingException(
+            Failure.INVALID_RESPONSE,
+            200,
+            "Delta Sharing page for " + target + " carried a non-array items field");
+      }
+      if (items.isArray()) {
+        for (JsonNode item : items) {
+          collected.add(decode.apply(item));
+        }
+      }
+
+      // A cursor has to be a scalar. A stated object or array answers asText("") with the empty
+      // string, which reads here as "there are no more pages", so a malformed cursor after a
+      // legitimate first page reported a partial listing as the whole inventory -- and an
+      // authoritative listing that leaves tables out is what makes the reconciler retire them.
+      // This is the shape the items guard above exists for, on the other field. Absent and null
+      // both legitimately mean the listing is done, and a number is a cursor dialect there is no
+      // reason to refuse.
+      JsonNode cursor = root.path("nextPageToken");
+      if (cursor.isObject() || cursor.isArray()) {
+        throw new DeltaSharingException(
+            Failure.INVALID_RESPONSE,
+            200,
+            "Delta Sharing page for " + target + " carried a non-scalar nextPageToken");
+      }
+      String next = cursor.asText("");
+      // Empty, not blank. A cursor is opaque, and the protocol ends pagination on an absent, null
+      // or empty token -- nothing else. Reading a whitespace token as the end returned the first
+      // page as the complete authoritative inventory, which is what lets the reconciler retire
+      // every table the later pages would have named.
+      if (next.isEmpty()) {
+        return collected;
+      }
+      if (!seenTokens.add(next)) {
+        throw new DeltaSharingException(
+            Failure.INVALID_RESPONSE,
+            200,
+            "Delta Sharing repeated a page token while listing " + target);
+      }
+      pageToken = next;
+    }
+    throw new DeltaSharingException(
+        Failure.INVALID_RESPONSE,
+        200,
+        "Delta Sharing listing of " + target + " exceeded " + maxPages + " pages");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Transport
+  // ---------------------------------------------------------------------------
+
+  /**
+   * The credential envelope, from a body framed as one JSON document or as ndjson lines.
+   *
+   * <p>The Accept header offers ndjson, so a server may legitimately answer in it -- with a
+   * protocol action ahead of the credentials, the way the metadata route does on this same
+   * transport. Reading the body as a single document would then fail on the second line, since
+   * FAIL_ON_TRAILING_TOKENS refuses one, and that arrives as INVALID_RESPONSE which reaches the
+   * client as INTERNAL and ends the whole reconcile rather than skipping a table. Advertising a
+   * framing this could not read was the mistake; a single JSON body is one line of ndjson, so both
+   * shapes go through the same reader.
+   */
+  private JsonNode credentialsEnvelope(String body, String target) {
+    // The whole body first. This request advertises application/json as well as ndjson, and a
+    // single-action ndjson body is itself valid JSON, so one parse covers both the compact and the
+    // formatted shape. Splitting on newlines ahead of that would hand "{" to the parser alone for
+    // any server that formats its JSON across lines.
+    try {
+      return parseJson(body, target, false);
+    } catch (DeltaSharingException notOneDocument) {
+      // Only a body carrying more than one document lands here, which is what ndjson framing is.
+      // A body that is simply malformed has one line, so its own failure is what gets reported.
+      if (body.lines().filter(line -> !line.isBlank()).count() < 2) {
+        throw notOneDocument;
+      }
+      return credentialsAction(body, target);
+    }
+  }
+
+  /**
+   * The credentials action from an ndjson body.
+   *
+   * <p>The protocol frames this response as ndjson, so a server may legitimately put a protocol
+   * action ahead of the credentials the way the metadata route does on this same transport.
+   */
+  private JsonNode credentialsAction(String body, String target) {
+    JsonNode last = null;
+    for (String line : body.split("\n")) {
+      String trimmed = line.trim();
+      if (trimmed.isEmpty()) {
+        continue;
+      }
+      JsonNode action = parseJson(trimmed, target, false);
+      if (action.hasNonNull("credentials")) {
+        return action;
+      }
+      last = action;
+    }
+    // No line named credentials. The last one read is answered so the caller's own envelope check
+    // stays the single place that reports what was missing.
+    return last == null ? parseJson(body, target, false) : last;
+  }
+
+  /** The JSON body, classified. Separate from the send so a caller can weigh the body first. */
+  private JsonNode parseJson(String body, String target, boolean includeBody) {
+    try {
+      JsonNode root = MAPPER.readTree(body);
+      // Jackson 2.20 answers an empty or blank body with MissingNode, which the callers' own shape
+      // checks already reject; older versions answered null, which would reach them as an NPE and
+      // bypass this transport's classification entirely. Stated here so which it is does not
+      // matter.
+      if (root == null || root.isMissingNode()) {
+        throw new DeltaSharingException(
+            Failure.INVALID_RESPONSE,
+            200,
+            "Delta Sharing returned an empty response for " + target);
+      }
+      return root;
+    } catch (IOException e) {
+      // The cause is never attached. Jackson quotes the offending input in its message, and the
+      // recipient token that authorises the credential endpoint authorises the listing and metadata
+      // ones too -- so a server echoing it inside a malformed 200 would carry it into the cause
+      // chain the vendor logs, on any path.
+      //
+      // A redacted snippet is appended where the caller allows a body. Without one a malformed 200
+      // reaches an operator as a parse position and nothing else, and the message is hidden again
+      // at the gRPC boundary. Withheld on the credential route, which is the route that passes
+      // includeBodyInErrors false -- redaction covers the token this client sent, not the keys a
+      // credential response carries.
+      throw new DeltaSharingException(
+          Failure.INVALID_RESPONSE,
+          200,
+          "Delta Sharing returned a response for "
+              + target
+              + " that could not be read as one JSON document"
+              + parseLocation(e)
+              + (includeBody ? ": " + snippet(body) : ""),
+          null);
+    }
+  }
+
+  /** The decoded NDJSON actions together with the version the server stated in its headers. */
+  private record NdjsonResponse(List<JsonNode> actions, Optional<Long> version) {}
+
+  private NdjsonResponse sendNdjson(
+      HttpRequest.Builder builder, String path, String target, boolean includeBodyInErrors) {
+    BodyAndVersion response =
+        sendForBodyAndVersion(builder, path, target, includeBodyInErrors, "application/x-ndjson");
+    String body = response.body();
+    List<JsonNode> actions = new ArrayList<>();
+    for (String line : body.split("\n")) {
+      String trimmed = line.trim();
+      if (trimmed.isEmpty()) {
+        continue;
+      }
+      try {
+        actions.add(MAPPER.readTree(trimmed));
+      } catch (IOException e) {
+        // Never attached, for the reason the JSON path states: Jackson quotes the offending input,
+        // and the same recipient token authorises every endpoint.
+        throw new DeltaSharingException(
+            Failure.INVALID_RESPONSE,
+            200,
+            "Delta Sharing returned a line for "
+                + target
+                + " that could not be read as one JSON document"
+                + parseLocation(e)
+                + (includeBodyInErrors ? ": " + snippet(trimmed) : ""),
+            null);
+      }
+    }
+    return new NdjsonResponse(actions, response.version());
+  }
+
+  /** A response body together with the table version the server stated in its headers. */
+  private record BodyAndVersion(String body, Optional<Long> version) {}
+
+  private String sendForBody(
+      HttpRequest.Builder builder,
+      String path,
+      String target,
+      boolean includeBodyInErrors,
+      String accept) {
+    return sendForBodyAndVersion(builder, path, target, includeBodyInErrors, accept).body();
+  }
+
+  private BodyAndVersion sendForBodyAndVersion(
+      HttpRequest.Builder builder,
+      String path,
+      String target,
+      boolean includeBodyInErrors,
+      String accept) {
+    HttpResponse<InputStream> response;
+    try {
+      builder
+          .uri(URI.create(baseUri + path))
+          .timeout(requestTimeout)
+          .header("Accept", accept)
+          .header("Authorization", "Bearer " + bearerToken)
+          .header("delta-sharing-capabilities", capabilities);
+      response = httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofInputStream());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new DeltaSharingException(
+          Failure.INTERRUPTED, -1, "Delta Sharing request interrupted for " + target, e);
+    } catch (DeltaSharingException e) {
+      throw e;
+    } catch (IOException | RuntimeException e) {
+      throw new DeltaSharingException(
+          Failure.TRANSPORT, -1, "Delta Sharing request failed for " + target, e);
+    }
+
+    int status = response.statusCode();
+
+    // Read outside the send above. ofInputStream returns once the headers arrive, so by the time
+    // this can fail the status is already known; reading it in the same try would let a body that
+    // stops mid-stream erase that status and report TRANSPORT, so a permanent 403 from a
+    // consistently truncating proxy would be retried forever.
+    String body;
+    try {
+      body = readBounded(response);
+    } catch (IOException | RuntimeException e) {
+      // Ahead of the status, so a cancellation is not dressed up as a refusal from the server.
+      if (Thread.currentThread().isInterrupted()) {
+        throw new DeltaSharingException(
+            Failure.INTERRUPTED,
+            -1,
+            "Delta Sharing request interrupted reading the response for " + target,
+            e);
+      }
+      if (status < 200 || status >= 300) {
+        throw httpFailure(status, target, "", includeBodyInErrors);
+      }
+      throw new DeltaSharingException(
+          Failure.TRANSPORT,
+          -1,
+          "Delta Sharing response body for " + target + " did not complete",
+          e);
+    }
+
+    if (status < 200 || status >= 300) {
+      throw httpFailure(status, target, body == null ? "" : body, includeBodyInErrors);
+    }
+    if (body == null) {
+      throw new DeltaSharingException(
+          Failure.INVALID_RESPONSE,
+          status,
+          "Delta Sharing response for " + target + " exceeded " + maxResponseBytes + " bytes");
+    }
+    return new BodyAndVersion(body, tableVersion(response));
+  }
+
+  /**
+   * The response cap, which cannot be the largest int.
+   *
+   * <p>The bounded reader asks for the cap plus one byte to spot an overrun, and that addition
+   * overflows at {@code Integer.MAX_VALUE} -- so a deployment setting the cap to its largest
+   * allowed value got a negative length and every response failed as a transport error. The Unity
+   * client already refuses this value on the same property; this one copied the pattern without the
+   * guard.
+   */
+  private static int configuredMaxResponseBytes() {
+    int value = positiveIntProperty(MAX_RESPONSE_BYTES_PROPERTY, DEFAULT_MAX_RESPONSE_BYTES);
+    if (value == Integer.MAX_VALUE) {
+      throw new IllegalArgumentException(
+          MAX_RESPONSE_BYTES_PROPERTY + " must be a positive integer below " + Integer.MAX_VALUE);
+    }
+    return value;
+  }
+
+  /**
+   * A positive integer override, or the default.
+   *
+   * <p>Raises on a value it cannot use rather than falling back. A zero or negative bound made
+   * every listing fail with "exceeded 0 pages" and every response read as oversized, which reports
+   * a protocol violation for a server that answered correctly.
+   */
+  private static int positiveIntProperty(String name, int defaultValue) {
+    String configured = System.getProperty(name);
+    if (configured == null || configured.isBlank()) {
+      return defaultValue;
+    }
+    int value;
+    try {
+      value = Integer.parseInt(configured.trim());
+    } catch (NumberFormatException notAnInteger) {
+      throw new IllegalArgumentException(
+          name + " must be a positive integer: " + configured, notAnInteger);
+    }
+    if (value <= 0) {
+      throw new IllegalArgumentException(name + " must be a positive integer: " + configured);
+    }
+    return value;
+  }
+
+  /**
+   * The table version the server stated in {@code Delta-Table-Version}.
+   *
+   * <p>The protocol puts the current version here for an ordinary metadata request and populates
+   * the metaData action's own {@code version} only for a versioned, timestamped or change-feed
+   * query. Reading the body alone left the version empty against every conforming server.
+   *
+   * <p>A header that is present but not a long is ignored rather than raised on: it is a detail
+   * beside the metadata itself, and refusing the whole table over it would trade a missing property
+   * for an unusable share.
+   */
+  private static Optional<Long> tableVersion(HttpResponse<InputStream> response) {
+    return response
+        .headers()
+        .firstValue("Delta-Table-Version")
+        .flatMap(
+            value -> {
+              try {
+                return Optional.of(Long.parseLong(value.trim()));
+              } catch (NumberFormatException notALong) {
+                return Optional.empty();
+              }
+            });
+  }
+
+  /**
+   * The body, or null when it exceeded the cap.
+   *
+   * <p>Null rather than an exception, because for a non-2xx an oversized body means nothing: the
+   * status already answered. Throwing would classify a permanent 403 whose error page happens to be
+   * large as a retryable protocol violation.
+   */
+  private String readBounded(HttpResponse<InputStream> response) throws IOException {
+    try (InputStream stream = response.body()) {
+      // Under its own deadline. HttpRequest.timeout gates receipt of the headers only, because
+      // ofInputStream returns as soon as they arrive, so a server that sends headers and then
+      // stalls would hold a reconcile worker here with nothing to interrupt it.
+      byte[] bytes =
+          HttpResponseSnippets.readWithin(
+              stream, maxResponseBytes, requestTimeout, "Delta Sharing");
+      return bytes.length > maxResponseBytes ? null : new String(bytes, StandardCharsets.UTF_8);
+    }
+  }
+
+  /**
+   * Classification from the status alone.
+   *
+   * <p>Delta Sharing defines no error envelope, unlike Unity Catalog, so there is no body code to
+   * consult and nothing to weigh against the status.
+   */
+  private DeltaSharingException httpFailure(
+      int status, String target, String body, boolean includeBody) {
+    Failure failure =
+        switch (status) {
+          case 401 -> Failure.UNAUTHENTICATED;
+          case 403 -> Failure.PERMISSION_DENIED;
+          case 404 -> Failure.NOT_FOUND;
+          case 429 -> Failure.RATE_LIMITED;
+          case 400, 405, 422 -> Failure.INVALID_REQUEST;
+          case 408 -> Failure.TRANSIENT;
+          default -> {
+            if (status >= 500) {
+              yield Failure.SERVER_ERROR;
+            }
+            // A 3xx reaching here means the endpoint tried to redirect and the client refused, so
+            // the base URI names something other than a sharing server.
+            yield status >= 300 && status < 400 ? Failure.INVALID_REQUEST : Failure.OTHER;
+          }
+        };
+    StringBuilder message =
+        new StringBuilder("Delta Sharing request for ")
+            .append(target)
+            .append(" failed with HTTP ")
+            .append(status);
+    if (includeBody && body != null && !body.isBlank()) {
+      message.append(": ").append(snippet(body));
+    }
+    return new DeltaSharingException(failure, status, message.toString());
+  }
+
+  // ---------------------------------------------------------------------------
+  // Decoding
+  // ---------------------------------------------------------------------------
+
+  /** Refuses a second action of a kind already seen, rather than letting it overwrite the first. */
+  private static void requireFirst(Object seen, String action, String target) {
+    if (seen != null) {
+      throw new DeltaSharingException(
+          Failure.INVALID_RESPONSE,
+          200,
+          "Delta Sharing sent more than one " + action + " action for " + target);
+    }
+  }
+
+  /**
+   * The protocol action, in either response format.
+   *
+   * <p>The same two shapes the metaData action comes in: a server honouring {@code
+   * responseformat=delta} nests the delta protocol under {@code deltaProtocol}, and one ignoring
+   * the header answers flat. Read flat only, every table decoded as minReaderVersion 1 with no
+   * reader features whatever it actually required.
+   */
+  private static Protocol parseProtocol(JsonNode node, String target) {
+    JsonNode delta = node.path("deltaProtocol");
+    JsonNode source = delta.isObject() ? delta : node;
+    // The fifth array field in this parser and the only one that was not held to the rule, because
+    // nothing reads what it produces: the Protocol record is written and never consulted. That is
+    // what made it easy to leave out, and what would make a feature-negotiation reader added later
+    // treat an unsupported feature as absent -- the same silence a scalar read as empty produces
+    // everywhere else here.
+    requireArrayWhereStated(source, "readerFeatures", target);
+    List<String> features = new ArrayList<>();
+    for (JsonNode feature : source.path("readerFeatures")) {
+      if (!feature.isTextual() || feature.asText().isBlank()) {
+        throw new DeltaSharingException(
+            Failure.INVALID_RESPONSE,
+            200,
+            "Delta Sharing stated a readerFeatures entry that is not a feature name for " + target);
+      }
+      features.add(feature.asText());
+    }
+    // Numbers and numeric strings both, since a server sending "2" is stating a version and
+    // refusing it would fail a working share over a field no consumer reads. Anything that is not
+    // a version at all is refused, rather than defaulting silently to 1.
+    JsonNode version = source.path("minReaderVersion");
+    if (!version.isMissingNode() && !version.isNull() && !isIntegerValued(version)) {
+      throw new DeltaSharingException(
+          Failure.INVALID_RESPONSE,
+          200,
+          "Delta Sharing stated a minReaderVersion that is not a version for " + target);
+    }
+    return new Protocol(version.asInt(1), features);
+  }
+
+  /** Whether a node states an integer, as a number or as a string holding one. */
+  private static boolean isIntegerValued(JsonNode node) {
+    if (node.isIntegralNumber()) {
+      return true;
+    }
+    if (!node.isTextual()) {
+      return false;
+    }
+    try {
+      // Long, not int. These are int64 fields, and an expiry in epoch milliseconds overflows an
+      // int -- so a server rendering it as a JSON string, which is the standard protobuf JSON
+      // encoding for int64, is refused. That refusal is INVALID_RESPONSE, which reaches the client
+      // as INTERNAL and ends the whole reconcile rather than skipping one table.
+      Long.parseLong(node.asText().trim());
+      return true;
+    } catch (NumberFormatException notAnInteger) {
+      return false;
+    }
+  }
+
+  /**
+   * The metaData action, in either response format.
+   *
+   * <p>Every request here sends {@code responseformat=delta}, and a server honouring it nests the
+   * table's own fields under {@code deltaMetadata}, leaving version, size, location, auxiliary
+   * locations and access modes on the wrapper. A server that ignores the header answers with the
+   * flat legacy shape instead. Reading the nested object where it exists and falling back to the
+   * wrapper covers both, and reading it flat covered only the second: the schema arrived blank and
+   * the model rejected it before this class could classify anything.
+   */
+  private static TableMetadata parseMetadata(JsonNode node, String target) {
+    JsonNode delta = node.path("deltaMetadata");
+    JsonNode table = delta.isObject() ? delta : node;
+    return parseMetadata(node, table, target);
+  }
+
+  private static TableMetadata parseMetadata(JsonNode node, JsonNode table, String target) {
+    // Checked before the record, for the reason the credentials envelope is: requireText raises
+    // IllegalArgumentException, which is not a DeltaSharingException and so escapes this class's
+    // classification and the translate() in the catalog client, reaching the reconciler as a bare
+    // RuntimeException naming neither the table nor the server.
+    if (!table.path("schemaString").isTextual() || table.path("schemaString").asText().isBlank()) {
+      throw new DeltaSharingException(
+          Failure.INVALID_RESPONSE,
+          200,
+          "Delta Sharing metadata for " + target + " carried no schemaString");
+    }
+    // The same rule the other two array fields follow, and this is the one that persists. These
+    // become CatalogTable.partitionKeys and then UpstreamRef.partition_keys, so a scalar read as
+    // absent reconciled a partitioned table as unpartitioned -- a wrong table definition that
+    // validates clean, rather than a failure. Absent stays legal and means unpartitioned; a
+    // non-text element is refused, because asText answers an object with the empty string and an
+    // empty partition key is worse than none.
+    requireArrayWhereStated(table, "partitionColumns", target);
+    List<String> partitions = new ArrayList<>();
+    for (JsonNode column : table.path("partitionColumns")) {
+      if (!column.isTextual() || column.asText().isBlank()) {
+        throw new DeltaSharingException(
+            Failure.INVALID_RESPONSE,
+            200,
+            "Delta Sharing stated a partitionColumns entry that is not a name for " + target);
+      }
+      partitions.add(column.asText());
+    }
+    // Delta defines this as a map of strings, and these entries are published as the table's
+    // properties. A stated value that is not an object leaves no properties at all, and a value
+    // that is a number, a boolean or a null coerces through asText -- either way the table carries
+    // metadata the server did not send. Absence still means no configuration.
+    Map<String, String> configuration = new HashMap<>();
+    JsonNode config = table.path("configuration");
+    if (!config.isMissingNode() && !config.isNull() && !config.isObject()) {
+      throw new DeltaSharingException(
+          Failure.INVALID_RESPONSE,
+          200,
+          "Delta Sharing stated a configuration that is not an object for " + target);
+    }
+    if (config.isObject()) {
+      Iterator<Map.Entry<String, JsonNode>> fields = config.fields();
+      while (fields.hasNext()) {
+        Map.Entry<String, JsonNode> field = fields.next();
+        if (!field.getValue().isTextual()) {
+          throw new DeltaSharingException(
+              Failure.INVALID_RESPONSE,
+              200,
+              "Delta Sharing stated a non-string configuration value for "
+                  + field.getKey()
+                  + " in "
+                  + target);
+        }
+        configuration.put(field.getKey(), field.getValue().asText());
+      }
+    }
+    List<String> auxiliary = textList(node, "auxiliaryLocations", target);
+    return new TableMetadata(
+        optionalText(table, "id", target),
+        optionalText(table, "name", target),
+        formatProvider(table, target),
+        table.path("schemaString").asText(),
+        partitions,
+        configuration,
+        tableVersion(node, target),
+        optionalText(node, "location", target),
+        auxiliary,
+        accessModes(node, target));
+  }
+
+  private static TemporaryCredentials parseCredentials(JsonNode node, String target) {
+    String location = node.path("location").isTextual() ? node.path("location").asText() : "";
+    // Checked here rather than left to the record. requireText raises IllegalArgumentException,
+    // which is not a DeltaSharingException, so it escapes this class's classification and reaches
+    // the vendor as a bare RuntimeException naming neither the table nor the server.
+    if (location.isBlank()) {
+      throw new DeltaSharingException(
+          Failure.INVALID_RESPONSE,
+          200,
+          "Delta Sharing temporary credentials for " + target + " named no location");
+    }
+    // Which cloud first, because that is the more basic question about the envelope: a body naming
+    // none is not a credential at all, and saying so is more use than complaining about its expiry.
+    // Exactly one, not at least one. The protocol makes these a choice, and the decode below takes
+    // the first branch that matches -- so an envelope naming two clouds silently became whichever
+    // one is tested first, making the answer a property of this method's ordering rather than of
+    // the response. Two clouds is not a credential this client can be confident it read correctly,
+    // and a message saying so is more use than a session token from the wrong one.
+    int clouds = 0;
+    for (String field : List.of("awsTempCredentials", "azureUserDelegationSas", "gcpOauthToken")) {
+      if (node.hasNonNull(field)) {
+        clouds++;
+      }
+    }
+    if (clouds == 0) {
+      throw new DeltaSharingException(
+          Failure.INVALID_RESPONSE,
+          200,
+          "Delta Sharing temporary credentials for " + target + " named no supported cloud");
+    }
+    if (clouds > 1) {
+      throw new DeltaSharingException(
+          Failure.INVALID_RESPONSE,
+          200,
+          "Delta Sharing temporary credentials for "
+              + target
+              + " named "
+              + clouds
+              + " clouds, and the protocol allows one");
+    }
+
+    // Required, not optional. A Catalog Integration session without one is refused at query time by
+    // SourceCatalogCredentialVendor, while validation does not treat an absent expiry as expired --
+    // so a share omitting it would validate clean and then fail every read, which is the least
+    // diagnosable shape this can take.
+    JsonNode statedExpiry = node.path("expirationTime");
+    if (!statedExpiry.isMissingNode() && !statedExpiry.isNull()) {
+      if (!isIntegerValued(statedExpiry)) {
+        throw new DeltaSharingException(
+            Failure.INVALID_RESPONSE,
+            200,
+            "Delta Sharing temporary credentials for "
+                + target
+                + " named an expiry that is not a number");
+      }
+    }
+    long expiresAtMillis = statedExpiry.asLong(0L);
+    if (!node.hasNonNull("expirationTime") || expiresAtMillis <= 0L) {
+      throw new DeltaSharingException(
+          Failure.INVALID_RESPONSE,
+          200,
+          "Delta Sharing temporary credentials for " + target + " named no expiry");
+    }
+    // The upper bound the other two parsers of this field already apply. A value past the last
+    // instant a proto Timestamp carries is a unit mismatch rather than a date -- microseconds where
+    // milliseconds were meant, which Unity deployments have been seen to send -- and without this
+    // it survives every downstream expiry check by looking far in the future and then throws inside
+    // Timestamps.fromMillis while the gRPC response is built. That is an unclassified
+    // RuntimeException in a handler, on a share that validated clean, for every read.
+    if (expiresAtMillis > MAX_EXPIRY_EPOCH_MILLIS) {
+      throw new DeltaSharingException(
+          Failure.INVALID_RESPONSE,
+          200,
+          "Delta Sharing temporary credentials for "
+              + target
+              + " named an expiry beyond the last representable instant, which is a unit mismatch"
+              + " rather than a date");
+    }
+    Optional<Instant> expiresAt = Optional.of(Instant.ofEpochMilli(expiresAtMillis));
+
+    if (node.hasNonNull("awsTempCredentials")) {
+      JsonNode aws = node.get("awsTempCredentials");
+      Optional<String> accessKeyId = optionalText(aws, "accessKeyId", target);
+      Optional<String> secretAccessKey = optionalText(aws, "secretAccessKey", target);
+      Optional<String> sessionToken = optionalText(aws, "sessionToken", target);
+      // All three, checked here. Left to the caller's hasAwsSession() an incomplete triad reads as
+      // "this cloud cannot be published", which reports UNSUPPORTED -- a per-table skip meaning the
+      // provider will never do this. A 200 missing a key is a malformed envelope like any other,
+      // and belongs with the rest of them.
+      if (!aws.isObject()
+          || accessKeyId.isEmpty()
+          || secretAccessKey.isEmpty()
+          || sessionToken.isEmpty()) {
+        throw new DeltaSharingException(
+            Failure.INVALID_RESPONSE,
+            200,
+            "Delta Sharing temporary credentials for "
+                + target
+                + " carried an incomplete AWS session");
+      }
+      return new TemporaryCredentials(
+          CredentialCloud.AWS, location, accessKeyId, secretAccessKey, sessionToken, expiresAt);
+    }
+    // Recognised and reported by cloud rather than returned empty. A caller that cannot use an
+    // Azure or GCP credential should say which one arrived, not that the server vended nothing.
+    if (node.hasNonNull("azureUserDelegationSas")) {
+      return new TemporaryCredentials(
+          CredentialCloud.AZURE,
+          location,
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
+          expiresAt);
+    }
+    if (node.hasNonNull("gcpOauthToken")) {
+      return new TemporaryCredentials(
+          CredentialCloud.GCP,
+          location,
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
+          expiresAt);
+    }
+    throw new DeltaSharingException(
+        Failure.INVALID_RESPONSE,
+        200,
+        "Delta Sharing temporary credentials for " + target + " named no supported cloud");
+  }
+
+  /** Where a parse failed, without any of what it was parsing. */
+  private static String parseLocation(IOException failure) {
+    if (failure instanceof com.fasterxml.jackson.core.JsonProcessingException json
+        && json.getLocation() != null) {
+      return " at line "
+          + json.getLocation().getLineNr()
+          + ", column "
+          + json.getLocation().getColumnNr();
+    }
+    return "";
+  }
+
+  /**
+   * The table version the metaData action stated, refused where it is not a number.
+   *
+   * <p>{@code asLong} answers zero for a string or a container, and this value is published as the
+   * {@code delta.sharing.version} property. Left unchecked, a malformed version is a table
+   * definition nobody sent rather than a failure.
+   */
+  private static Optional<Long> tableVersion(JsonNode node, String target) {
+    JsonNode version = node.path("version");
+    if (version.isMissingNode() || version.isNull()) {
+      return Optional.empty();
+    }
+    if (!isIntegerValued(version)) {
+      throw new DeltaSharingException(
+          Failure.INVALID_RESPONSE,
+          200,
+          "Delta Sharing stated a version that is not a number for " + target);
+    }
+    return Optional.of(version.asLong());
+  }
+
+  private static String formatProvider(JsonNode table, String target) {
+    JsonNode provider = table.path("format").path("provider");
+    if (provider.isMissingNode() || provider.isNull()) {
+      return "parquet";
+    }
+    // asText supplies its default for a missing or container node but not for a stated empty
+    // string, so {"provider":""} arrived blank at the record's own requireText -- which raises
+    // IllegalArgumentException, not a DeltaSharingException, and so escapes this class's
+    // classification and the provider's translate() to reach the reconciler naming neither the
+    // table nor the server. The same escape the schemaString and credentials-envelope checks close.
+    if (!provider.isTextual() || provider.asText().isBlank()) {
+      throw new DeltaSharingException(
+          Failure.INVALID_RESPONSE,
+          200,
+          "Delta Sharing stated a format provider that is not a name for " + target);
+    }
+    return provider.asText();
+  }
+
+  /**
+   * Refuses a field that is stated but is not an array.
+   *
+   * <p>Iterating a scalar node yields nothing, so {@code "auxiliaryLocations": "s3://other/part"}
+   * read as absent -- which is the one shape the auxiliary-location refusal exists to catch, and it
+   * would have reconciled with a credential covering the root alone and failed at scan time on the
+   * files it does not reach. A stated {@code accessModes} scalar read as unstated for the same
+   * reason. This is the rule the page shape already enforces for {@code items}; the fields inside
+   * an item were not held to it.
+   */
+  private static void requireArrayWhereStated(JsonNode node, String field, String target) {
+    JsonNode value = node.path(field);
+    // Null counts as not stated, as it does for every other optional field here -- configuration,
+    // version, minReaderVersion, the page cursor and optionalText all read it that way. Refusing it
+    // ends the whole reconcile over an ordinary JSON rendering of an absent list. The page's own
+    // items field is the one place null is refused, because there it would mean an empty inventory.
+    if (!value.isMissingNode() && !value.isNull() && !value.isArray()) {
+      throw new DeltaSharingException(
+          Failure.INVALID_RESPONSE,
+          200,
+          "Delta Sharing stated a non-array " + field + " for " + target);
+    }
+  }
+
+  private static List<String> textList(JsonNode node, String field, String target) {
+    requireArrayWhereStated(node, field, target);
+    List<String> values = new ArrayList<>();
+    for (JsonNode value : node.path(field)) {
+      // A non-text element is refused rather than dropped. asText answers an object with the empty
+      // string, so an array of objects read as an empty list -- and for auxiliaryLocations that
+      // means hasAuxiliaryLocations() answers false and the refusal at the load never fires, which
+      // is the silence the array guard was added to end one level up.
+      if (!value.isTextual() || value.asText().isBlank()) {
+        throw new DeltaSharingException(
+            Failure.INVALID_RESPONSE,
+            200,
+            "Delta Sharing stated a " + field + " entry that is not a value for " + target);
+      }
+      values.add(value.asText().trim());
+    }
+    return List.copyOf(values);
+  }
+
+  private static List<AccessMode> accessModes(JsonNode item, String target) {
+    requireArrayWhereStated(item, "accessModes", target);
+    List<AccessMode> modes = new ArrayList<>();
+    for (JsonNode mode : item.path("accessModes")) {
+      // Refused, not coerced. asText answers an object with the empty string, which mapped to
+      // OTHER -- and OTHER alongside a readable value is the unsafe direction: ["{...}", "dir"]
+      // decoded to [OTHER, DIR], contains(DIR) answered true, and the table was treated as
+      // directory-accessible on the strength of a response this client could not read.
+      if (!mode.isTextual()) {
+        throw new DeltaSharingException(
+            Failure.INVALID_RESPONSE,
+            200,
+            "Delta Sharing stated an accessModes entry that is not a mode for " + target);
+      }
+      String value = mode.asText("").trim().toLowerCase(Locale.ROOT);
+      if ("url".equals(value)) {
+        modes.add(AccessMode.URL);
+      } else if ("dir".equals(value)) {
+        modes.add(AccessMode.DIR);
+      } else {
+        // Kept as OTHER rather than dropped. A server adding a third mode still must not make an
+        // otherwise readable table undiscoverable -- a list holding dir and something unknown still
+        // holds dir -- but dropping it made a table stating only unknown modes indistinguishable
+        // from one stating none, and the strict setting then refused it saying it had stated none.
+        modes.add(AccessMode.OTHER);
+      }
+    }
+    return modes;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  /** What a Delta reader feature name may contain, so it cannot reshape the capability header. */
+  private static final java.util.regex.Pattern FEATURE_TOKEN =
+      java.util.regex.Pattern.compile("[A-Za-z0-9_-]+");
+
+  /**
+   * The capability header, with each feature checked where it is interpolated.
+   *
+   * <p>Checked here rather than only in the provider that reads the operator's property, because
+   * this constructor is public and is itself the provider's factory seam. A value carrying a
+   * semicolon appends a capability field of its own -- {@code x;responseformat=parquet} makes a
+   * server answer in the flat shape, which this client then parses without complaint -- and one
+   * carrying a newline is refused by the request builder at send time instead of here.
+   */
+  private static String buildCapabilities(List<String> readerFeatures) {
+    StringBuilder value = new StringBuilder("responseformat=delta");
+    if (readerFeatures != null && !readerFeatures.isEmpty()) {
+      for (String feature : readerFeatures) {
+        if (feature == null || !FEATURE_TOKEN.matcher(feature).matches()) {
+          throw new IllegalArgumentException(
+              "Delta reader feature must be letters, digits, hyphens or underscores: " + feature);
+        }
+      }
+      value.append(";readerfeatures=").append(String.join(",", readerFeatures));
+    }
+    return value.toString();
+  }
+
+  private static String tablePath(String share, String schema, String table) {
+    return "/shares/" + encode(share) + "/schemas/" + encode(schema) + "/tables/" + encode(table);
+  }
+
+  /**
+   * A query value, encoded without the path-segment rules.
+   *
+   * <p>A page token is opaque and may be anything the server chose, including a value {@code
+   * encode} refuses: that method rejects a blank string as an unusable path segment, which for a
+   * cursor would raise an unclassified IllegalArgumentException out of a listing rather than send
+   * the token back. Same escaping, no judgement about the content.
+   */
+  private static String encodeQueryValue(String value) {
+    return URLEncoder.encode(value, StandardCharsets.UTF_8).replace("+", "%20");
+  }
+
+  /**
+   * Percent-encodes one path segment.
+   *
+   * <p>{@code URLEncoder} is form encoding, where a space becomes {@code +}. In a path segment a
+   * {@code +} is a literal plus, so a share, schema or table name containing a space would be
+   * requested at the wrong path and come back 404. A literal plus in the input is already {@code
+   * %2B} by the time of the substitution, so anything still {@code +} stands for a space.
+   */
+  private static String encode(String value) {
+    return URLEncoder.encode(requireText(value, "path segment"), StandardCharsets.UTF_8)
+        .replace("+", "%20");
+  }
+
+  private static String text(JsonNode node, String field, String target) {
+    JsonNode stated = node.path(field);
+    // Textual, not merely coercible. asText answers "17" for a number and "true" for a boolean, so
+    // {"name": 17} became a table named 17 in an inventory the reconciler treats as authoritative
+    // -- and tables the same malformed page omitted are retired against it. The protocol defines
+    // these as strings.
+    if (!stated.isMissingNode() && !stated.isNull() && !stated.isTextual()) {
+      throw new DeltaSharingException(
+          Failure.INVALID_RESPONSE,
+          200,
+          "Delta Sharing stated a non-textual " + field + " in " + target);
+    }
+    String value = stated.asText("");
+    if (value.isBlank()) {
+      throw new DeltaSharingException(
+          Failure.INVALID_RESPONSE,
+          200,
+          "Delta Sharing item is missing " + field + " in " + target);
+    }
+    return value;
+  }
+
+  private static Optional<String> optionalText(JsonNode node, String field, String target) {
+    JsonNode value = node.path(field);
+    // Every field decoded through here is a string in the protocol. asText answers "17" for a
+    // number and the empty string for a container, so a stated non-string is either metadata the
+    // server did not send or a field read as absent.
+    if (!value.isMissingNode() && !value.isNull() && !value.isTextual()) {
+      throw new DeltaSharingException(
+          Failure.INVALID_RESPONSE,
+          200,
+          "Delta Sharing stated a non-string " + field + " for " + target);
+    }
+    return optionalText(node, field);
+  }
+
+  private static Optional<String> optionalText(JsonNode node, String field) {
+    String value = node.path(field).asText("");
+    return value.isBlank() ? Optional.empty() : Optional.of(value);
+  }
+
+  /**
+   * A response snippet with the recipient's own token taken out of it.
+   *
+   * <p>The Authorization header goes out on every request, and a server that echoes request headers
+   * in an error body would otherwise put a live recipient token into an exception message, which
+   * reaches validation output and operator logs.
+   */
+  private String snippet(String body) {
+    // The token this client sent, by value. The generic pattern covers a token shaped the way the
+    // grammar says one should be; this one need not be, since a header value permits more than the
+    // grammar does, and a suffix past the first unmatched character reached the message.
+    return HttpResponseSnippets.boundedSingleLine(body, MAX_BODY_SNIPPET_CHARS, bearerToken);
+  }
+
+  private static String quoteJson(String value) {
+    StringBuilder quoted = new StringBuilder("\"");
+    for (int i = 0; i < value.length(); i++) {
+      char c = value.charAt(i);
+      switch (c) {
+        case '"' -> quoted.append("\\\"");
+        case '\\' -> quoted.append("\\\\");
+        case '\n' -> quoted.append("\\n");
+        case '\r' -> quoted.append("\\r");
+        case '\t' -> quoted.append("\\t");
+        default -> {
+          if (c < 0x20) {
+            quoted.append(String.format("\\u%04x", (int) c));
+          } else {
+            quoted.append(c);
+          }
+        }
+      }
+    }
+    return quoted.append('"').toString();
+  }
+
+  private static String stripTrailingSlash(String value) {
+    String trimmed = value;
+    while (trimmed.endsWith("/")) {
+      trimmed = trimmed.substring(0, trimmed.length() - 1);
+    }
+    return trimmed;
+  }
+
+  /**
+   * A recipient token that can be sent as a header value, described without being quoted.
+   *
+   * <p>Field-value rules, not a guess: a header value may not carry a control character, and a
+   * newline in a bearer token is the shape a copied secret usually takes. Nor anything above {@code
+   * U+00FF}, which is where the JDK's own header validation stops -- a token carrying an emoji
+   * passed this check and was refused by {@code HttpRequest.Builder.header} instead, whose
+   * IllegalArgumentException quotes the whole header value. The send wraps a RuntimeException as
+   * TRANSPORT with the cause attached, so that put the live token into the chain the vendor logs,
+   * on a request that never left the process.
+   *
+   * <p>Then the JDK is asked directly, because matching another component's private validation by
+   * restating its rules is a thing that goes stale. The probe builds the header it would send and
+   * discards it; a refusal is reported without the cause and without the value, since that
+   * exception is itself the leak.
+   */
+  private static String requireHeaderSafe(String token) {
+    for (int i = 0; i < token.length(); i++) {
+      char c = token.charAt(i);
+      if (c < 0x20 || c == 0x7F) {
+        throw new IllegalArgumentException(
+            "bearerToken carries a control character at index " + i + " and cannot be sent");
+      }
+      if (c > 0x7E) {
+        // Printable ASCII, which is narrower than the JDK's own limit of U+00FF, and deliberately.
+        // A JSON serializer that escapes non-ASCII -- Python's default among them -- renders such a
+        // token as Bearer abc\u00e9SECRET in an echoed error body, where neither redaction pass
+        // reaches it: the literal is not present in that form, and the pattern stops at the
+        // backslash. Closing that by unescaping, redacting and re-escaping puts more machinery in
+        // the one control that must not be subtly wrong; refusing the range instead removes the
+        // case. A bearer token outside printable ASCII is not a shape any deployment sends, while
+        // the punctuation this still accepts -- a colon among it -- is the shape that does occur.
+        throw new IllegalArgumentException(
+            "bearerToken carries a character outside printable ASCII at index "
+                + i
+                + ", which cannot be redacted reliably where a server echoes it");
+      }
+    }
+    try {
+      HttpRequest.newBuilder(PROBE_URI).header("Authorization", "Bearer " + token);
+    } catch (IllegalArgumentException rejected) {
+      // Deliberately not chained. rejected.getMessage() is the header value in full.
+      throw new IllegalArgumentException("bearerToken cannot be sent as a header value");
+    }
+    return token;
+  }
+
+  private static String requireText(String value, String field) {
+    if (value == null || value.isBlank()) {
+      throw new IllegalArgumentException(field + " must not be blank");
+    }
+    return value;
+  }
+
+  private static Duration requirePositive(Duration value, String field) {
+    Objects.requireNonNull(value, field);
+    if (value.isZero() || value.isNegative()) {
+      throw new IllegalArgumentException(field + " must be positive");
+    }
+    return value;
+  }
+}

--- a/connectors/clients/delta-sharing/src/test/java/ai/floedb/floecat/client/sharing/HttpDeltaSharingClientTest.java
+++ b/connectors/clients/delta-sharing/src/test/java/ai/floedb/floecat/client/sharing/HttpDeltaSharingClientTest.java
@@ -1,0 +1,1904 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.client.sharing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import ai.floedb.floecat.client.sharing.DeltaSharingModel.AccessMode;
+import ai.floedb.floecat.client.sharing.DeltaSharingModel.CredentialCloud;
+import ai.floedb.floecat.client.sharing.DeltaSharingModel.TableDescription;
+import ai.floedb.floecat.client.sharing.DeltaSharingModel.TemporaryCredentials;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class HttpDeltaSharingClientTest {
+
+  private HttpServer server;
+  private final List<String> requestPaths = new ArrayList<>();
+  private final List<String> capabilityHeaders = new ArrayList<>();
+  private final List<String> authorizationHeaders = new ArrayList<>();
+  private final List<String> acceptHeaders = new ArrayList<>();
+
+  @BeforeEach
+  void allowCleartextLoopback() {
+    // The endpoint gates require HTTPS. A test server is loopback cleartext, which is the shape the
+    // opt-in exists for.
+    System.setProperty("floecat.security.allow-loopback-catalog-endpoints", "true");
+  }
+
+  @AfterEach
+  void tearDown() {
+    System.clearProperty("floecat.security.allow-loopback-catalog-endpoints");
+    System.clearProperty(HttpDeltaSharingClient.MAX_PAGES_PROPERTY);
+    System.clearProperty(HttpDeltaSharingClient.MAX_LISTING_BYTES_PROPERTY);
+    System.clearProperty(HttpDeltaSharingClient.MAX_RESPONSE_BYTES_PROPERTY);
+    if (server != null) {
+      server.stop(0);
+      server = null;
+    }
+    requestPaths.clear();
+    capabilityHeaders.clear();
+    authorizationHeaders.clear();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Discovery and paging
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void listSharesFollowsPagesUntilTheTokenIsEmpty() throws Exception {
+    AtomicInteger call = new AtomicInteger();
+    startServer(
+        exchange -> {
+          int n = call.getAndIncrement();
+          respond(
+              exchange,
+              200,
+              n == 0
+                  ? "{\"items\":[{\"name\":\"one\"}],\"nextPageToken\":\"t1\"}"
+                  : "{\"items\":[{\"name\":\"two\"}],\"nextPageToken\":\"\"}");
+        });
+
+    try (DeltaSharingClient client = client()) {
+      assertThat(client.listShares())
+          .extracting(DeltaSharingModel.Share::name)
+          .containsExactly("one", "two");
+    }
+    assertThat(requestPaths.get(1)).contains("pageToken=t1");
+  }
+
+  @Test
+  void anAbsentItemsArrayIsNotAnError() throws Exception {
+    // The protocol says items may be absent or empty and a client has to handle either.
+    startServer(exchange -> respond(exchange, 200, "{\"nextPageToken\":\"\"}"));
+    try (DeltaSharingClient client = client()) {
+      assertThat(client.listShares()).isEmpty();
+    }
+  }
+
+  @Test
+  void aRepeatedPageTokenIsRefusedRatherThanLoopedOn() throws Exception {
+    // A server returning the same cursor forever would otherwise page until the cap, issuing
+    // thousands of requests against an endpoint the recipient does not control.
+    startServer(
+        exchange ->
+            respond(exchange, 200, "{\"items\":[{\"name\":\"one\"}],\"nextPageToken\":\"same\"}"));
+    try (DeltaSharingClient client = client()) {
+      assertThatThrownBy(client::listShares)
+          .isInstanceOf(DeltaSharingException.class)
+          .hasMessageContaining("repeated a page token")
+          .extracting(e -> ((DeltaSharingException) e).failure())
+          .isEqualTo(DeltaSharingException.Failure.INVALID_RESPONSE);
+    }
+  }
+
+  @Test
+  void aServerMintingFreshTokensStopsAtThePageCap() throws Exception {
+    // The other half of the bound: a repeated-token guard alone does not stop a server that issues
+    // a new cursor every time.
+    System.setProperty(HttpDeltaSharingClient.MAX_PAGES_PROPERTY, "3");
+    AtomicInteger call = new AtomicInteger();
+    startServer(
+        exchange ->
+            respond(
+                exchange,
+                200,
+                "{\"items\":[],\"nextPageToken\":\"t" + call.getAndIncrement() + "\"}"));
+    try (DeltaSharingClient client = client()) {
+      assertThatThrownBy(client::listShares).hasMessageContaining("exceeded 3 pages");
+    }
+    assertThat(requestPaths).hasSize(3);
+  }
+
+  @Test
+  void anAbsentAccessModesFieldIsLeftUnresolvedRatherThanReadAsUrl() throws Exception {
+    // Left as it arrived. The protocol reads an absent field as url only, but resolving it here
+    // would fix that reading for every caller, and the catalog provider owns the choice for
+    // backward compatibility, and it decides whether a table
+    // is readable at all through this client.
+    startServer(
+        exchange ->
+            respond(
+                exchange,
+                200,
+                "{\"items\":[{\"name\":\"t\",\"location\":\"s3://b/t\"}],\"nextPageToken\":\"\"}"));
+    try (DeltaSharingClient client = client()) {
+      DeltaSharingModel.Table table = client.listTables("s", "sc").get(0);
+      assertThat(table.accessModes()).isEmpty();
+      assertThat(table.accessModes()).doesNotContain(DeltaSharingModel.AccessMode.DIR);
+    }
+  }
+
+  @Test
+  void directoryAccessIsRecognisedAndUnknownModesAreKept() throws Exception {
+    startServer(
+        exchange ->
+            respond(
+                exchange,
+                200,
+                "{\"items\":[{\"name\":\"t\",\"id\":\"abc\",\"location\":\"s3://b/t\","
+                    + "\"accessModes\":[\"url\",\"dir\",\"future\"]}],\"nextPageToken\":\"\"}"));
+    try (DeltaSharingClient client = client()) {
+      DeltaSharingModel.Table table = client.listTables("s", "sc").get(0);
+      // Kept, not dropped: a list holding dir still holds dir, and keeping the unknown value is
+      // what makes a table stating only unknown modes distinguishable from one stating none.
+      assertThat(table.accessModes())
+          .containsExactly(AccessMode.URL, AccessMode.DIR, AccessMode.OTHER);
+      assertThat(table.accessModes()).contains(DeltaSharingModel.AccessMode.DIR);
+      assertThat(table.id()).contains("abc");
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // NDJSON metadata
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void metadataParsesTheTwoNdjsonActions() throws Exception {
+    startServer(
+        exchange ->
+            respond(
+                exchange,
+                200,
+                "{\"protocol\":{\"minReaderVersion\":3,\"readerFeatures\":[\"deletionVectors\"]}}\n"
+                    + "{\"metaData\":{\"id\":\"m1\",\"format\":{\"provider\":\"parquet\"},"
+                    + "\"schemaString\":\"{\\\"type\\\":\\\"struct\\\"}\","
+                    + "\"partitionColumns\":[\"day\"],\"version\":7,"
+                    + "\"location\":\"s3://b/t\"}}"));
+    try (DeltaSharingClient client = client()) {
+      TableDescription described = client.describeTable("s", "sc", "t");
+      assertThat(described.protocol().minReaderVersion()).isEqualTo(3);
+      assertThat(described.protocol().readerFeatures()).containsExactly("deletionVectors");
+      assertThat(described.metadata().partitionColumns()).containsExactly("day");
+      assertThat(described.metadata().location()).contains("s3://b/t");
+      assertThat(described.version()).contains(7L);
+    }
+  }
+
+  /**
+   * The shape a server answers with when it honours the {@code responseformat=delta} capability
+   * this client sends on every metadata request, taken from the protocol's own example: the table's
+   * fields nest under {@code deltaMetadata} while version, location, auxiliary locations and access
+   * modes stay on the wrapper. Read flat, the schema arrived blank and the model rejected it before
+   * any of this class's classification could run.
+   */
+  @Test
+  void metadataParsesTheDeltaResponseFormatEnvelope() throws Exception {
+    startServer(
+        exchange ->
+            respond(
+                exchange,
+                200,
+                "{\"protocol\":{\"deltaProtocol\":{\"minReaderVersion\":3,"
+                    + "\"readerFeatures\":[\"columnMapping\"]}}}\n"
+                    + "{\"metaData\":{\"version\":20,\"size\":123456,\"numFiles\":5,"
+                    + "\"location\":\"s3://b/t\","
+                    + "\"auxiliaryLocations\":[\"s3://b/t-aux\"],"
+                    + "\"accessModes\":[\"url\",\"dir\"],"
+                    + "\"deltaMetadata\":{\"id\":\"m1\","
+                    + "\"format\":{\"provider\":\"parquet\"},"
+                    + "\"schemaString\":\"{\\\"type\\\":\\\"struct\\\"}\","
+                    + "\"partitionColumns\":[\"date\"],"
+                    + "\"configuration\":{\"enableChangeDataFeed\":\"true\"}}}}"));
+    try (DeltaSharingClient client = client()) {
+      TableDescription described = client.describeTable("s", "sc", "t");
+      assertThat(described.protocol().minReaderVersion()).isEqualTo(3);
+      assertThat(described.protocol().readerFeatures()).containsExactly("columnMapping");
+      assertThat(described.metadata().schemaJson()).contains("struct");
+      assertThat(described.metadata().id()).contains("m1");
+      assertThat(described.metadata().format()).isEqualTo("parquet");
+      assertThat(described.metadata().partitionColumns()).containsExactly("date");
+      assertThat(described.metadata().configuration())
+          .containsEntry("enableChangeDataFeed", "true");
+      assertThat(described.metadata().location()).contains("s3://b/t");
+      assertThat(described.metadata().auxiliaryLocations()).containsExactly("s3://b/t-aux");
+      assertThat(described.metadata().accessModes())
+          .containsExactly(DeltaSharingModel.AccessMode.URL, DeltaSharingModel.AccessMode.DIR);
+      assertThat(described.version()).contains(20L);
+    }
+  }
+
+  /**
+   * Destructive rather than merely wrong: the reconciler reads a successful empty inventory as the
+   * share having nothing left and retires the overlay's tables, so a malformed 200 deletes what a
+   * recorded failure would have preserved.
+   */
+  @Test
+  void aNonArrayItemsFieldIsAProtocolViolationNotAnEmptyListing() throws Exception {
+    startServer(exchange -> respond(exchange, 200, "{\"items\":{\"name\":\"prod\"}}"));
+    try (DeltaSharingClient client = client()) {
+      assertThatThrownBy(client::listShares)
+          .isInstanceOf(DeltaSharingException.class)
+          .hasMessageContaining("non-array items")
+          .extracting(e -> ((DeltaSharingException) e).failure())
+          .isEqualTo(DeltaSharingException.Failure.INVALID_RESPONSE);
+    }
+  }
+
+  /**
+   * An explicit null is not an array either, and exempting it made a malformed page authoritative.
+   */
+  @Test
+  void anExplicitNullItemsFieldIsAProtocolViolation() throws Exception {
+    startServer(exchange -> respond(exchange, 200, "{\"items\":null}"));
+    try (DeltaSharingClient client = client()) {
+      assertThatThrownBy(client::listShares)
+          .isInstanceOf(DeltaSharingException.class)
+          .hasMessageContaining("non-array items")
+          .extracting(e -> ((DeltaSharingException) e).failure())
+          .isEqualTo(DeltaSharingException.Failure.INVALID_RESPONSE);
+    }
+  }
+
+  /**
+   * A header value permits more than the bearer grammar does, so a token carrying a colon matched
+   * the redaction pattern only up to it and the remainder reached the message -- defeating the
+   * control in the echoed-header case it exists for.
+   */
+  @Test
+  void aTokenOutsideTheBearerGrammarIsStillRedactedWhenEchoed() throws Exception {
+    startServer(
+        exchange ->
+            respond(
+                exchange,
+                500,
+                "upstream failed; headers were {Authorization=Bearer part1:part2-SECRET}"));
+    try (DeltaSharingClient client =
+        new HttpDeltaSharingClient(
+            endpoint(), "part1:part2-SECRET", Duration.ofSeconds(2), Duration.ofSeconds(2))) {
+      assertThatThrownBy(client::listShares)
+          .isInstanceOf(DeltaSharingException.class)
+          .satisfies(e -> assertThat(e.getMessage()).doesNotContain("part2-SECRET"));
+    }
+  }
+
+  @Test
+  void aPageThatIsNotAnObjectIsAProtocolViolation() throws Exception {
+    startServer(exchange -> respond(exchange, 200, "[\"prod\"]"));
+    try (DeltaSharingClient client = client()) {
+      assertThatThrownBy(client::listShares)
+          .isInstanceOf(DeltaSharingException.class)
+          .hasMessageContaining("is not an object")
+          .extracting(e -> ((DeltaSharingException) e).failure())
+          .isEqualTo(DeltaSharingException.Failure.INVALID_RESPONSE);
+    }
+  }
+
+  /** Absent stays legal, and means an empty listing. */
+  @Test
+  void anAbsentItemsFieldIsAnEmptyListing() throws Exception {
+    startServer(exchange -> respond(exchange, 200, "{}"));
+    try (DeltaSharingClient client = client()) {
+      assertThat(client.listShares()).isEmpty();
+    }
+  }
+
+  /** So does an empty array, which means the same thing. */
+  @Test
+  void anEmptyItemsArrayIsAnEmptyListing() throws Exception {
+    startServer(exchange -> respond(exchange, 200, "{\"items\":[]}"));
+    try (DeltaSharingClient client = client()) {
+      assertThat(client.listShares()).isEmpty();
+    }
+  }
+
+  /** A non-positive override made every listing fail against a server that answered correctly. */
+  @Test
+  void aNonPositiveLimitIsRejectedRatherThanFailingEveryListing() throws Exception {
+    startServer(exchange -> respond(exchange, 200, "{\"items\":[]}"));
+    System.setProperty(HttpDeltaSharingClient.MAX_PAGES_PROPERTY, "0");
+    try {
+      assertThatThrownBy(this::client).isInstanceOf(IllegalArgumentException.class);
+    } finally {
+      System.clearProperty(HttpDeltaSharingClient.MAX_PAGES_PROPERTY);
+    }
+  }
+
+  /**
+   * Left to the caller's own completeness check, an incomplete triad reads as "this cloud cannot be
+   * published" and reports UNSUPPORTED -- a per-table skip meaning the provider will never do this,
+   * when in fact the server sent a malformed envelope.
+   */
+  @Test
+  void anIncompleteAwsSessionIsReportedAsAProtocolViolation() throws Exception {
+    startServer(
+        exchange ->
+            respond(
+                exchange,
+                200,
+                "{\"credentials\":{\"location\":\"s3://b/t\",\"expirationTime\":1893456000000,"
+                    + "\"awsTempCredentials\":{\"accessKeyId\":\"a\","
+                    + "\"secretAccessKey\":\"b\"}}}"));
+    try (DeltaSharingClient client = client()) {
+      assertThatThrownBy(() -> client.temporaryTableCredentials("s", "sc", "t", null))
+          .isInstanceOf(DeltaSharingException.class)
+          .hasMessageContaining("incomplete AWS session")
+          .extracting(e -> ((DeltaSharingException) e).failure())
+          .isEqualTo(DeltaSharingException.Failure.INVALID_RESPONSE);
+    }
+  }
+
+  /**
+   * The protocol states the current version in this header for an ordinary metadata request and
+   * populates the action's own version only for a versioned or change-feed query, so reading the
+   * body alone left the version empty against every conforming server.
+   */
+  @Test
+  void theTableVersionComesFromTheResponseHeader() throws Exception {
+    startServer(
+        exchange -> {
+          exchange.getResponseHeaders().add("Delta-Table-Version", "42");
+          respond(
+              exchange,
+              200,
+              "{\"protocol\":{\"deltaProtocol\":{\"minReaderVersion\":1}}}\n"
+                  + "{\"metaData\":{\"deltaMetadata\":{\"id\":\"m1\","
+                  + "\"format\":{\"provider\":\"parquet\"},"
+                  + "\"schemaString\":\"{\\\"type\\\":\\\"struct\\\"}\"}}}");
+        });
+    try (DeltaSharingClient client = client()) {
+      assertThat(client.describeTable("s", "sc", "t").version()).contains(42L);
+    }
+  }
+
+  /**
+   * The features are interpolated into delta-sharing-capabilities, so a value carrying a semicolon
+   * appends a capability field of its own: {@code x;responseformat=parquet} makes a server answer
+   * in the flat shape, which this client then parses without complaint. Checked at the constructor
+   * because that is the interpolation site and every construction path goes through it.
+   */
+  @Test
+  void aReaderFeatureThatCouldReshapeTheCapabilityHeaderIsRefused() {
+    for (String bad :
+        List.of("x;responseformat=parquet", "has space", "line\nbreak", "semi;colon")) {
+      assertThatThrownBy(
+              () ->
+                  new HttpDeltaSharingClient(
+                      URI.create("https://sharing.example"),
+                      "token",
+                      Duration.ofSeconds(1),
+                      Duration.ofSeconds(1),
+                      List.of(bad)))
+          .describedAs("%s", bad)
+          .isInstanceOf(IllegalArgumentException.class);
+    }
+  }
+
+  /**
+   * HttpRequest.Builder.header quotes the value it rejects, and every RuntimeException from the
+   * send is classified as TRANSPORT with its cause attached -- so a token carrying a newline
+   * reached the cause chain the vendor logs, verbatim, on a request that never left the process.
+   */
+  @Test
+  void aTokenThatCannotBeSentIsRefusedWithoutQuotingIt() {
+    assertThatThrownBy(
+            () ->
+                new HttpDeltaSharingClient(
+                    URI.create("https://sharing.example"),
+                    "secret-with\nnewline",
+                    Duration.ofSeconds(1),
+                    Duration.ofSeconds(1),
+                    List.of()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .satisfies(
+            e -> {
+              assertThat(e.getMessage()).doesNotContain("secret-with");
+              assertThat(e.getMessage()).contains("control character");
+            });
+  }
+
+  /**
+   * An empty 200 or a 204 is a malformed response, not something the callers should meet as an NPE.
+   */
+  @Test
+  void anEmptyBodyIsClassifiedRatherThanReachingTheCallers() throws Exception {
+    startServer(exchange -> respond(exchange, 200, ""));
+    try (DeltaSharingClient client = client()) {
+      assertThatThrownBy(() -> client.temporaryTableCredentials("s", "sc", "t", null))
+          .isInstanceOf(DeltaSharingException.class)
+          .extracting(e -> ((DeltaSharingException) e).failure())
+          .isEqualTo(DeltaSharingException.Failure.INVALID_RESPONSE);
+    }
+  }
+
+  /**
+   * Jackson quotes the offending input in its message, so chaining a parse failure on a credentials
+   * body carried the secret into the cause chain -- which the vendor logs -- even though the
+   * message itself withholds the body.
+   */
+  @Test
+  void aMalformedCredentialsBodyDoesNotCarryTheSecretIntoTheCause() throws Exception {
+    startServer(
+        exchange ->
+            respond(
+                exchange,
+                200,
+                "{\"credentials\":{\"awsTempCredentials\":{\"secretAccessKey\":"
+                    + "super-secret-unquoted-value}}}"));
+    try (DeltaSharingClient client = client()) {
+      assertThatThrownBy(() -> client.temporaryTableCredentials("s", "sc", "t", null))
+          .isInstanceOf(DeltaSharingException.class)
+          .satisfies(
+              e -> {
+                String chain = e.toString();
+                for (Throwable cause = e.getCause(); cause != null; cause = cause.getCause()) {
+                  chain = chain + " | " + cause;
+                }
+                assertThat(chain).doesNotContain("super-secret-unquoted-value");
+                // Where, without what.
+                assertThat(e.getMessage()).contains("line", "column");
+              });
+    }
+  }
+
+  /**
+   * A session with no expiry validates clean and is refused at query time, because the vendor
+   * requires one for every Catalog Integration session and validation does not treat an absent
+   * expiry as expired. That split is the least diagnosable shape this can take.
+   */
+  @Test
+  void credentialsNamingNoExpiryAreReportedAsAProtocolViolation() throws Exception {
+    startServer(
+        exchange ->
+            respond(
+                exchange,
+                200,
+                "{\"credentials\":{\"location\":\"s3://b/t\","
+                    + "\"awsTempCredentials\":{\"accessKeyId\":\"a\","
+                    + "\"secretAccessKey\":\"b\",\"sessionToken\":\"c\"}}}"));
+    try (DeltaSharingClient client = client()) {
+      assertThatThrownBy(() -> client.temporaryTableCredentials("s", "sc", "t", null))
+          .isInstanceOf(DeltaSharingException.class)
+          .hasMessageContaining("named no expiry")
+          .extracting(e -> ((DeltaSharingException) e).failure())
+          .isEqualTo(DeltaSharingException.Failure.INVALID_RESPONSE);
+    }
+  }
+
+  /** Same reason as the credentials guard below: the record's check is not a classified failure. */
+  @Test
+  void metadataCarryingNoSchemaIsReportedAsAProtocolViolation() throws Exception {
+    startServer(
+        exchange ->
+            respond(
+                exchange,
+                200,
+                "{\"protocol\":{\"minReaderVersion\":1}}\n"
+                    + "{\"metaData\":{\"id\":\"m1\",\"format\":{\"provider\":\"parquet\"}}}"));
+    try (DeltaSharingClient client = client()) {
+      assertThatThrownBy(() -> client.describeTable("s", "sc", "t"))
+          .isInstanceOf(DeltaSharingException.class)
+          .hasMessageContaining("carried no schemaString")
+          .extracting(e -> ((DeltaSharingException) e).failure())
+          .isEqualTo(DeltaSharingException.Failure.INVALID_RESPONSE);
+    }
+  }
+
+  /**
+   * The record's own check raises IllegalArgumentException, which is not a DeltaSharingException
+   * and so escapes this class's classification entirely, reaching the vendor as a bare
+   * RuntimeException naming neither the table nor the server.
+   */
+  @Test
+  void credentialsNamingNoLocationAreReportedAsAProtocolViolation() throws Exception {
+    startServer(
+        exchange ->
+            respond(
+                exchange,
+                200,
+                "{\"credentials\":{\"awsTempCredentials\":{\"accessKeyId\":\"a\","
+                    + "\"secretAccessKey\":\"b\",\"sessionToken\":\"c\"}}}"));
+    try (DeltaSharingClient client = client()) {
+      assertThatThrownBy(() -> client.temporaryTableCredentials("s", "sc", "t", null))
+          .isInstanceOf(DeltaSharingException.class)
+          .hasMessageContaining("named no location")
+          .extracting(e -> ((DeltaSharingException) e).failure())
+          .isEqualTo(DeltaSharingException.Failure.INVALID_RESPONSE);
+    }
+  }
+
+  /**
+   * {@code URLEncoder} is form encoding, where a space is {@code +}. A {@code +} in a path segment
+   * is a literal plus, so the request would go to the wrong path and come back 404.
+   */
+  @Test
+  void aNameContainingASpaceIsPercentEncodedNotPlusEncoded() throws Exception {
+    java.util.List<String> paths = new java.util.ArrayList<>();
+    startServer(
+        exchange -> {
+          paths.add(exchange.getRequestURI().getRawPath());
+          respond(exchange, 200, "{\"items\":[]}");
+        });
+    try (DeltaSharingClient client = client()) {
+      client.listTables("my share", "my schema");
+    }
+    assertThat(paths).hasSize(1);
+    assertThat(paths.get(0)).contains("my%20share", "my%20schema").doesNotContain("+");
+  }
+
+  /**
+   * A server echoing request headers in an error body would otherwise put the recipient's own token
+   * into the exception, which reaches validation output and operator logs.
+   */
+  @Test
+  void anErrorBodyEchoingTheAuthorizationHeaderIsRedacted() throws Exception {
+    startServer(
+        exchange ->
+            respond(
+                exchange,
+                500,
+                "upstream failed; request headers were "
+                    + "{Authorization=Bearer super-secret-recipient-token, Accept=*/*}"));
+    try (DeltaSharingClient client = client()) {
+      assertThatThrownBy(() -> client.listShares())
+          .isInstanceOf(DeltaSharingException.class)
+          .satisfies(
+              e -> {
+                assertThat(e.getMessage()).doesNotContain("super-secret-recipient-token");
+                // The whole header value goes, scheme included -- the pass recognises the header
+                // name rather than the token's shape, so how the value was encoded stops
+                // mattering. The name survives, so the message still says what was echoed.
+                assertThat(e.getMessage()).contains("Authorization=<redacted>");
+              });
+    }
+  }
+
+  @Test
+  void aNonJsonBodyIsReportedAsSuchRatherThanAsMissingActions() throws Exception {
+    // The shape a proxy error page takes when it arrives with a success status. It fails at the
+    // line parse, which names the actual problem more precisely than the missing-actions check
+    // below would.
+    startServer(exchange -> respond(exchange, 200, "<html>hello</html>"));
+    try (DeltaSharingClient client = client()) {
+      assertThatThrownBy(() -> client.describeTable("s", "sc", "t"))
+          .isInstanceOf(DeltaSharingException.class)
+          .hasMessageContaining("could not be read as one JSON document")
+          .extracting(e -> ((DeltaSharingException) e).failure())
+          .isEqualTo(DeltaSharingException.Failure.INVALID_RESPONSE);
+    }
+  }
+
+  @Test
+  void validNdjsonMissingTheMetadataActionIsAProtocolViolation() throws Exception {
+    // Parses cleanly and is still unusable: the protocol requires both actions, and a caller given
+    // only a protocol has no schema to materialize.
+    startServer(exchange -> respond(exchange, 200, "{\"protocol\":{\"minReaderVersion\":1}}"));
+    try (DeltaSharingClient client = client()) {
+      assertThatThrownBy(() -> client.describeTable("s", "sc", "t"))
+          .isInstanceOf(DeltaSharingException.class)
+          .hasMessageContaining("did not contain both a protocol and a metaData action");
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Temporary credentials
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void awsCredentialsCarryTheCompleteSessionTriadAndExpiry() throws Exception {
+    startServer(
+        exchange ->
+            respond(
+                exchange,
+                200,
+                "{\"credentials\":{\"location\":\"s3://b/t\",\"expirationTime\":1700000000000,"
+                    + "\"awsTempCredentials\":{\"accessKeyId\":\"AK\",\"secretAccessKey\":\"SK\","
+                    + "\"sessionToken\":\"ST\"}}}"));
+    try (DeltaSharingClient client = client()) {
+      TemporaryCredentials credentials = client.temporaryTableCredentials("s", "sc", "t", null);
+      assertThat(credentials.cloud()).isEqualTo(CredentialCloud.AWS);
+      assertThat(credentials.hasAwsSession()).isTrue();
+      assertThat(credentials.location()).isEqualTo("s3://b/t");
+      assertThat(credentials.expiresAt()).isPresent();
+    }
+  }
+
+  @Test
+  void azureAndGcpAreNamedRatherThanReturnedEmpty() throws Exception {
+    // A caller that cannot use these should be able to say which cloud answered, not that the
+    // server vended nothing.
+    startServer(
+        exchange ->
+            respond(
+                exchange,
+                200,
+                "{\"credentials\":{\"location\":\"abfss://c/t\","
+                    + "\"expirationTime\":1893456000000,\"azureUserDelegationSas\":{\"sasToken\":\"s\"}}}"));
+    try (DeltaSharingClient client = client()) {
+      TemporaryCredentials credentials = client.temporaryTableCredentials("s", "sc", "t", null);
+      assertThat(credentials.cloud()).isEqualTo(CredentialCloud.AZURE);
+      assertThat(credentials.hasAwsSession()).isFalse();
+    }
+  }
+
+  @Test
+  void aCredentialsResponseNamingNoCloudIsAProtocolViolation() throws Exception {
+    startServer(
+        exchange -> respond(exchange, 200, "{\"credentials\":{\"location\":\"s3://b/t\"}}"));
+    try (DeltaSharingClient client = client()) {
+      assertThatThrownBy(() -> client.temporaryTableCredentials("s", "sc", "t", null))
+          .hasMessageContaining("named no supported cloud");
+    }
+  }
+
+  @Test
+  void anAuxiliaryLocationIsSentAsTheRequestBody() throws Exception {
+    List<String> bodies = new ArrayList<>();
+    startServer(
+        exchange -> {
+          bodies.add(new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8));
+          respond(
+              exchange,
+              200,
+              "{\"credentials\":{\"location\":\"s3://b/aux\",\"expirationTime\":1893456000000,"
+                  + "\"awsTempCredentials\":{\"accessKeyId\":\"AK\",\"secretAccessKey\":\"SK\","
+                  + "\"sessionToken\":\"ST\"}}}");
+        });
+    try (DeltaSharingClient client = client()) {
+      client.temporaryTableCredentials("s", "sc", "t", "s3://b/aux");
+    }
+    assertThat(bodies).containsExactly("{\"location\":\"s3://b/aux\"}");
+  }
+
+  @Test
+  void theCredentialsResponseNeverReachesAnErrorMessage() throws Exception {
+    // Every other endpoint includes a body snippet, which is what makes a server-side error
+    // diagnosable. This one must not, because the body carries live credentials.
+    startServer(
+        exchange ->
+            respond(
+                exchange,
+                403,
+                "{\"credentials\":{\"awsTempCredentials\":{\"secretAccessKey\":\"LEAKED\"}}}"));
+    try (DeltaSharingClient client = client()) {
+      assertThatThrownBy(() -> client.temporaryTableCredentials("s", "sc", "t", null))
+          .hasMessageNotContaining("LEAKED")
+          .hasMessageContaining("HTTP 403");
+    }
+  }
+
+  @Test
+  void credentialsAreNotPrintedByToString() {
+    TemporaryCredentials credentials =
+        new TemporaryCredentials(
+            CredentialCloud.AWS,
+            "s3://b/t",
+            java.util.Optional.of("AK"),
+            java.util.Optional.of("SUPERSECRET"),
+            java.util.Optional.of("ST"),
+            java.util.Optional.empty());
+    assertThat(credentials.toString())
+        .doesNotContain("SUPERSECRET")
+        .doesNotContain("AK")
+        .contains("redacted");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Classification and transport
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void statusesClassifyIntoActionableFailures() throws Exception {
+    record Case(int status, DeltaSharingException.Failure expected) {}
+    for (Case c :
+        List.of(
+            new Case(401, DeltaSharingException.Failure.UNAUTHENTICATED),
+            new Case(403, DeltaSharingException.Failure.PERMISSION_DENIED),
+            new Case(404, DeltaSharingException.Failure.NOT_FOUND),
+            new Case(429, DeltaSharingException.Failure.RATE_LIMITED),
+            new Case(400, DeltaSharingException.Failure.INVALID_REQUEST),
+            new Case(503, DeltaSharingException.Failure.SERVER_ERROR),
+            // A redirect reaching the client means the base URI names something that is not a
+            // sharing server, since redirects are never followed.
+            new Case(302, DeltaSharingException.Failure.INVALID_REQUEST))) {
+      tearDown();
+      allowCleartextLoopback();
+      startServer(exchange -> respond(exchange, c.status(), "{}"));
+      try (DeltaSharingClient client = client()) {
+        assertThatThrownBy(client::listShares)
+            .describedAs("status %s", c.status())
+            .isInstanceOf(DeltaSharingException.class)
+            .extracting(e -> ((DeltaSharingException) e).failure())
+            .isEqualTo(c.expected());
+      }
+    }
+  }
+
+  @Test
+  void theRecipientTokenAndCapabilitiesAreSentOnEveryRequest() throws Exception {
+    startServer(exchange -> respond(exchange, 200, "{\"items\":[],\"nextPageToken\":\"\"}"));
+    try (DeltaSharingClient client =
+        new HttpDeltaSharingClient(
+            endpoint(),
+            "recipient-token",
+            Duration.ofSeconds(2),
+            Duration.ofSeconds(2),
+            List.of("deletionVectors"))) {
+      client.listShares();
+    }
+    assertThat(authorizationHeaders).containsExactly("Bearer recipient-token");
+    assertThat(capabilityHeaders)
+        .containsExactly("responseformat=delta;readerfeatures=deletionVectors");
+  }
+
+  @Test
+  void aCleartextEndpointIsRefusedWithoutTheOptIn() {
+    System.clearProperty("floecat.security.allow-loopback-catalog-endpoints");
+    assertThatThrownBy(
+            () ->
+                new HttpDeltaSharingClient(
+                    URI.create("http://example.invalid/sharing"),
+                    "t",
+                    Duration.ofSeconds(1),
+                    Duration.ofSeconds(1)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Delta Sharing endpoint")
+        .hasMessageContaining("HTTPS");
+  }
+
+  @Test
+  void anEndpointNamingTheMetadataAddressIsRefused() {
+    // Shared with the Unity client through HttpEndpointGuards. Asserted here too because this
+    // client is a second caller of that rule and the point of sharing it is that both hold.
+    assertThatThrownBy(
+            () ->
+                new HttpDeltaSharingClient(
+                    URI.create("https://169.254.169.254/sharing"),
+                    "t",
+                    Duration.ofSeconds(1),
+                    Duration.ofSeconds(1)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("link-local");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Harness
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void aSecretStraddlingTheSnippetBoundIsStillRedacted() throws Exception {
+    // The bound cuts at 2000 characters. The filler puts "Bearer " at 1980, so the colon lands at
+    // 1992 and the cut falls inside "part2-SECRETSUFFIX" -- the window where bounding before
+    // redacting leaked. The literal no longer matched the halved token, and the pattern stops at
+    // the colon, which is the character that puts this token outside the grammar, so the fragment
+    // between the two survived into the message.
+    String secret = "part1:part2-SECRETSUFFIX";
+    startServer(
+        exchange -> respond(exchange, 500, "x".repeat(1980) + "Bearer " + secret + " trailing"));
+    try (DeltaSharingClient client =
+        new HttpDeltaSharingClient(
+            endpoint(), secret, Duration.ofSeconds(2), Duration.ofSeconds(2))) {
+      assertThatThrownBy(client::listShares)
+          .isInstanceOf(DeltaSharingException.class)
+          .satisfies(e -> assertThat(e.getMessage()).doesNotContain("SECRETSUFFIX"))
+          .satisfies(e -> assertThat(e.getMessage()).doesNotContain("part2"));
+    }
+  }
+
+  @Test
+  void everyOccurrenceIsRedactedAndNotOnlyTheOneInsideTheBound() throws Exception {
+    // Why the whole body is scanned rather than a window around the cut. A replacement is shorter
+    // than what it replaces, so redacting the first occurrence pulls later text forward into the
+    // bounded range -- text a window would not have reached.
+    String secret = "part1:part2-SECRETSUFFIX";
+    String body =
+        "y".repeat(1900) + "Bearer " + secret + "z".repeat(60) + secret + "z".repeat(60) + secret;
+    startServer(exchange -> respond(exchange, 500, body));
+    try (DeltaSharingClient client =
+        new HttpDeltaSharingClient(
+            endpoint(), secret, Duration.ofSeconds(2), Duration.ofSeconds(2))) {
+      assertThatThrownBy(client::listShares)
+          .isInstanceOf(DeltaSharingException.class)
+          .satisfies(e -> assertThat(e.getMessage()).doesNotContain("part1:"));
+    }
+  }
+
+  @Test
+  void aListingIsBoundedInTotalAndNotOnlyPerPage() throws Exception {
+    // The page cap and the per-response cap multiply out to more than any heap. This is the bound
+    // that makes a listing's size finite.
+    System.setProperty(HttpDeltaSharingClient.MAX_LISTING_BYTES_PROPERTY, "40");
+    startServer(exchange -> respond(exchange, 200, "{\"items\":[],\"nextPageToken\":\"t1\"}"));
+    try (DeltaSharingClient client = client()) {
+      assertThatThrownBy(client::listShares)
+          .isInstanceOf(DeltaSharingException.class)
+          .hasMessageContaining("exceeded")
+          .hasMessageContaining(HttpDeltaSharingClient.MAX_LISTING_BYTES_PROPERTY)
+          .extracting(e -> ((DeltaSharingException) e).failure())
+          .isEqualTo(DeltaSharingException.Failure.INVALID_RESPONSE);
+    }
+  }
+
+  @Test
+  void theListingBoundIsCumulativeAcrossListingsOnOneClient() throws Exception {
+    // Per client, because a client's life is one reconcile pass and the pass memoises every
+    // schema's tables for the whole of it. A per-listing bound leaves the pass unbounded.
+    System.setProperty(HttpDeltaSharingClient.MAX_LISTING_BYTES_PROPERTY, "20");
+    startServer(exchange -> respond(exchange, 200, "{\"items\":[]}"));
+    try (DeltaSharingClient client = client()) {
+      assertThat(client.listShares()).isEmpty();
+      assertThatThrownBy(client::listShares)
+          .isInstanceOf(DeltaSharingException.class)
+          .hasMessageContaining("exceeded");
+    }
+  }
+
+  @Test
+  void aNonArrayAuxiliaryLocationsIsRefused() throws Exception {
+    // Iterating a scalar yields nothing, so this read as absent -- the one shape the auxiliary
+    // refusal exists to catch, reconciling with a root-only credential.
+    startServer(
+        exchange ->
+            respond(
+                exchange,
+                200,
+                "{\"items\":[{\"name\":\"t\",\"auxiliaryLocations\":\"s3://other/part\"}]}"));
+    try (DeltaSharingClient client = client()) {
+      assertThatThrownBy(() -> client.listTables("share", "schema"))
+          .isInstanceOf(DeltaSharingException.class)
+          .hasMessageContaining("non-array auxiliaryLocations")
+          // Named. INVALID_RESPONSE reaches the boundary as INTERNAL, whose message GrpcErrors
+          // hides, so this log line is the only place the malformed entry is identified.
+          .hasMessageContaining("tables of share.schema")
+          .extracting(e -> ((DeltaSharingException) e).failure())
+          .isEqualTo(DeltaSharingException.Failure.INVALID_RESPONSE);
+    }
+  }
+
+  @Test
+  void aNonArrayAccessModesIsRefused() throws Exception {
+    startServer(
+        exchange ->
+            respond(exchange, 200, "{\"items\":[{\"name\":\"t\",\"accessModes\":\"dir\"}]}"));
+    try (DeltaSharingClient client = client()) {
+      assertThatThrownBy(() -> client.listTables("share", "schema"))
+          .isInstanceOf(DeltaSharingException.class)
+          .hasMessageContaining("non-array accessModes")
+          .hasMessageContaining("tables of share.schema");
+    }
+  }
+
+  @Test
+  void aMalformedItemFailsBeforeTheRestOfTheListingIsFetched() throws Exception {
+    // Decoding as each page arrives, rather than after the last one, is what keeps a listing from
+    // retaining raw pages. It also stops the walk at the page that is wrong.
+    startServer(exchange -> respond(exchange, 200, "{\"items\":[{}],\"nextPageToken\":\"t1\"}"));
+    try (DeltaSharingClient client = client()) {
+      assertThatThrownBy(client::listShares)
+          .isInstanceOf(DeltaSharingException.class)
+          .hasMessageContaining("missing name");
+    }
+    assertThat(requestPaths).hasSize(1);
+  }
+
+  @Test
+  void aNonScalarNextPageTokenIsRefusedAndNotReadAsTheEndOfTheListing() throws Exception {
+    // The destructive shape: a legitimate first page followed by a malformed cursor. asText("")
+    // answers the empty string for an object, which read here as "no more pages", so this returned
+    // one page as the authoritative inventory and the reconciler retires whatever it leaves out.
+    startServer(
+        exchange ->
+            respond(
+                exchange,
+                200,
+                "{\"items\":[{\"name\":\"share1\"}],\"nextPageToken\":{\"cursor\":\"x\"}}"));
+    try (DeltaSharingClient client = client()) {
+      assertThatThrownBy(client::listShares)
+          .isInstanceOf(DeltaSharingException.class)
+          .hasMessageContaining("non-scalar nextPageToken")
+          .extracting(e -> ((DeltaSharingException) e).failure())
+          .isEqualTo(DeltaSharingException.Failure.INVALID_RESPONSE);
+    }
+  }
+
+  @Test
+  void anArrayNextPageTokenIsRefusedToo() throws Exception {
+    startServer(exchange -> respond(exchange, 200, "{\"items\":[],\"nextPageToken\":[\"x\"]}"));
+    try (DeltaSharingClient client = client()) {
+      assertThatThrownBy(client::listShares)
+          .isInstanceOf(DeltaSharingException.class)
+          .hasMessageContaining("non-scalar nextPageToken");
+    }
+  }
+
+  @Test
+  void aNullNextPageTokenEndsTheListingRatherThanFailingIt() throws Exception {
+    // Absent and null both mean the listing is done. Null is the ordinary idiom for it, so
+    // refusing it would fail a server that is conforming in substance.
+    startServer(
+        exchange ->
+            respond(exchange, 200, "{\"items\":[{\"name\":\"share1\"}],\"nextPageToken\":null}"));
+    try (DeltaSharingClient client = client()) {
+      assertThat(client.listShares()).hasSize(1);
+    }
+    assertThat(requestPaths).hasSize(1);
+  }
+
+  @Test
+  void aTokenAboveLatin1IsRefusedAtConstructionAndNeverReachesACauseChain() {
+    // The JDK's header validation stops at U+00FF and quotes the whole header value when it
+    // refuses. The send wraps a RuntimeException as TRANSPORT with the cause attached, so without
+    // this the live token reached the chain the vendor logs.
+    String token = "abc\uD83D\uDE00def";
+    assertThatThrownBy(
+            () ->
+                new HttpDeltaSharingClient(
+                    URI.create("https://sharing.example.com/delta-sharing"),
+                    token,
+                    Duration.ofSeconds(2),
+                    Duration.ofSeconds(2)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .satisfies(
+            e -> {
+              for (Throwable t = e; t != null; t = t.getCause()) {
+                assertThat(String.valueOf(t.getMessage())).doesNotContain(token);
+                assertThat(String.valueOf(t.getMessage())).doesNotContain("abc");
+              }
+            });
+  }
+
+  @Test
+  void aTokenOfPrintableAsciiPunctuationIsAccepted() {
+    // Printable ASCII, narrower than the JDK's own U+00FF limit and deliberately so: a token
+    // outside it cannot be redacted reliably, because a JSON serializer that escapes non-ASCII
+    // renders it as \u00e9 in an echoed body, where the literal is not present in that form and
+    // the pattern stops at the backslash. The punctuation real tokens do carry still passes, which
+    // is the case the by-value redaction exists for.
+    assertThatCode(
+            () ->
+                new HttpDeltaSharingClient(
+                        URI.create("https://sharing.example.com/delta-sharing"),
+                        "part1:part2-tilde~end",
+                        Duration.ofSeconds(2),
+                        Duration.ofSeconds(2))
+                    .close())
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void aTokenOutsidePrintableAsciiIsRefused() {
+    // The range that would otherwise need escape-aware redaction, refused at construction instead.
+    for (String token : List.of("abc\u00e9SECRET", "abc\u00FFdef", "abc\u007Fdef")) {
+      assertThatThrownBy(
+              () ->
+                  new HttpDeltaSharingClient(
+                      URI.create("https://sharing.example.com/delta-sharing"),
+                      token,
+                      Duration.ofSeconds(2),
+                      Duration.ofSeconds(2)))
+          .as(token)
+          .isInstanceOf(IllegalArgumentException.class)
+          .satisfies(
+              e -> {
+                for (Throwable t = e; t != null; t = t.getCause()) {
+                  assertThat(String.valueOf(t.getMessage())).doesNotContain("SECRET");
+                }
+              });
+    }
+  }
+
+  @Test
+  void aListingWithATrailingDocumentIsRefusedRatherThanReadAsItsFirstPage() throws Exception {
+    // readTree reads the first document and discards what follows, so this parsed as an empty
+    // listing and every shape guard below saw a well-formed empty page. An empty inventory with no
+    // recorded skip is what the reconciler reads as the share having dropped its tables.
+    startServer(
+        exchange -> respond(exchange, 200, "{\"items\":[]}{\"items\":[{\"name\":\"share1\"}]}"));
+    try (DeltaSharingClient client = client()) {
+      assertThatThrownBy(client::listShares)
+          .isInstanceOf(DeltaSharingException.class)
+          .hasMessageContaining("could not be read as one JSON document")
+          .extracting(e -> ((DeltaSharingException) e).failure())
+          .isEqualTo(DeltaSharingException.Failure.INVALID_RESPONSE);
+    }
+  }
+
+  @Test
+  void aListingRestatingItemsIsRefusedRatherThanTakingTheLastValue() throws Exception {
+    // Last key wins by default, so naming tables and then restating items as empty parsed as
+    // empty -- the destructive direction, and indistinguishable from a share that really is empty.
+    startServer(
+        exchange -> respond(exchange, 200, "{\"items\":[{\"name\":\"share1\"}],\"items\":[]}"));
+    try (DeltaSharingClient client = client()) {
+      assertThatThrownBy(client::listShares)
+          .isInstanceOf(DeltaSharingException.class)
+          .hasMessageContaining("could not be read as one JSON document")
+          .extracting(e -> ((DeltaSharingException) e).failure())
+          .isEqualTo(DeltaSharingException.Failure.INVALID_RESPONSE);
+    }
+  }
+
+  @Test
+  void anNdjsonLineCarryingTwoActionsIsRefused() throws Exception {
+    // The metadata path reads a line at a time, so the same leniency applied there.
+    startServer(
+        exchange ->
+            respond(
+                exchange,
+                200,
+                "{\"protocol\":{\"minReaderVersion\":1}}\n"
+                    + "{\"metaData\":{\"schemaString\":\"{}\"}}{\"metaData\":{}}"));
+    try (DeltaSharingClient client = client()) {
+      assertThatThrownBy(() -> client.describeTable("share", "schema", "table"))
+          .isInstanceOf(DeltaSharingException.class)
+          .hasMessageContaining("could not be read as one JSON document");
+    }
+  }
+
+  /**
+   * The third array field, and the one that persists. partitionColumns becomes
+   * CatalogTable.partitionKeys and then UpstreamRef.partition_keys, so a scalar read as absent
+   * reconciled a partitioned table as unpartitioned -- a wrong table definition that validates
+   * clean rather than a failure.
+   */
+  @Test
+  void aNonArrayPartitionColumnsIsRefused() throws Exception {
+    startServer(
+        exchange ->
+            respond(
+                exchange,
+                200,
+                "{\"protocol\":{\"minReaderVersion\":1}}\n"
+                    + "{\"metaData\":{\"schemaString\":\"{}\",\"partitionColumns\":\"day\"}}"));
+    try (DeltaSharingClient client = client()) {
+      assertThatThrownBy(() -> client.describeTable("share", "schema", "table"))
+          .isInstanceOf(DeltaSharingException.class)
+          .hasMessageContaining("non-array partitionColumns")
+          .extracting(e -> ((DeltaSharingException) e).failure())
+          .isEqualTo(DeltaSharingException.Failure.INVALID_RESPONSE);
+    }
+  }
+
+  /**
+   * asText answers an object with the empty string, and an empty partition key is worse than none.
+   */
+  @Test
+  void aPartitionColumnThatIsNotANameIsRefused() throws Exception {
+    startServer(
+        exchange ->
+            respond(
+                exchange,
+                200,
+                "{\"protocol\":{\"minReaderVersion\":1}}\n"
+                    + "{\"metaData\":{\"schemaString\":\"{}\",\"partitionColumns\":[{}]}}"));
+    try (DeltaSharingClient client = client()) {
+      assertThatThrownBy(() -> client.describeTable("share", "schema", "table"))
+          .isInstanceOf(DeltaSharingException.class)
+          .hasMessageContaining("partitionColumns entry that is not a name");
+    }
+  }
+
+  /** An absent field still means unpartitioned, which is the ordinary shape. */
+  @Test
+  void anAbsentPartitionColumnsIsAnUnpartitionedTable() throws Exception {
+    startServer(
+        exchange ->
+            respond(
+                exchange,
+                200,
+                "{\"protocol\":{\"minReaderVersion\":1}}\n"
+                    + "{\"metaData\":{\"schemaString\":\"{}\"}}"));
+    try (DeltaSharingClient client = client()) {
+      assertThat(client.describeTable("share", "schema", "table").metadata().partitionColumns())
+          .isEmpty();
+    }
+  }
+
+  /**
+   * An explicit null is not stated either. Serializers emit one for an absent list routinely, and
+   * refusing it raises INVALID_RESPONSE -- which is not one branch skipped but the end of the whole
+   * reconcile pass, over a shape every other optional field in this parser already reads as absent.
+   */
+  @Test
+  void anExplicitlyNullListFieldIsAbsent() throws Exception {
+    startServer(
+        exchange ->
+            respond(
+                exchange,
+                200,
+                "{\"protocol\":{\"minReaderVersion\":1,\"readerFeatures\":null}}\n"
+                    + "{\"metaData\":{\"schemaString\":\"{}\",\"partitionColumns\":null}}"));
+    try (DeltaSharingClient client = client()) {
+      assertThat(client.describeTable("share", "schema", "table").metadata().partitionColumns())
+          .isEmpty();
+    }
+  }
+
+  /**
+   * Exactly one cloud, not at least one. The decode takes the first branch that matches, so an
+   * envelope naming two silently became whichever is tested first -- the answer a property of the
+   * decoder's ordering rather than of the response.
+   */
+  @Test
+  void aCredentialsEnvelopeNamingTwoCloudsIsRefused() throws Exception {
+    startServer(
+        exchange ->
+            respond(
+                exchange,
+                200,
+                "{\"credentials\":{\"location\":\"s3://b/t\","
+                    + "\"expirationTime\":1893456000000,"
+                    + "\"awsTempCredentials\":{\"accessKeyId\":\"AK\","
+                    + "\"secretAccessKey\":\"SK\",\"sessionToken\":\"ST\"},"
+                    + "\"gcpOauthToken\":{\"oauthToken\":\"g\"}}}"));
+    try (DeltaSharingClient client = client()) {
+      assertThatThrownBy(() -> client.temporaryTableCredentials("s", "sc", "t", null))
+          .isInstanceOf(DeltaSharingException.class)
+          .hasMessageContaining("named 2 clouds")
+          .extracting(e -> ((DeltaSharingException) e).failure())
+          .isEqualTo(DeltaSharingException.Failure.INVALID_RESPONSE);
+    }
+  }
+
+  /**
+   * An explicit null is not an action. has() answers true for one and parseProtocol tolerates a
+   * null node, so this satisfied the both-actions guard with a protocol this client had invented --
+   * a fabricated minReaderVersion and no reader features, for a body that stated neither.
+   */
+  @Test
+  void anExplicitlyNullProtocolActionIsNotAProtocolAction() throws Exception {
+    startServer(
+        exchange ->
+            respond(
+                exchange, 200, "{\"protocol\":null}\n{\"metaData\":{\"schemaString\":\"{}\"}}"));
+    try (DeltaSharingClient client = client()) {
+      assertThatThrownBy(() -> client.describeTable("share", "schema", "table"))
+          .isInstanceOf(DeltaSharingException.class)
+          .hasMessageContaining("did not contain both a protocol and a metaData action")
+          .extracting(e -> ((DeltaSharingException) e).failure())
+          .isEqualTo(DeltaSharingException.Failure.INVALID_RESPONSE);
+    }
+  }
+
+  /**
+   * A value past the last instant a proto Timestamp carries is a unit mismatch, not a date. Without
+   * this it survives every downstream expiry check by looking far in the future and then throws
+   * inside Timestamps.fromMillis while the gRPC response is built -- an unclassified
+   * RuntimeException in a handler, on a share that validated clean, for every read.
+   */
+  @Test
+  void anExpiryBeyondTheRepresentableRangeIsRefused() throws Exception {
+    startServer(
+        exchange ->
+            respond(
+                exchange,
+                200,
+                "{\"credentials\":{\"location\":\"s3://b/t\","
+                    + "\"expirationTime\":1893456000000000,"
+                    + "\"awsTempCredentials\":{\"accessKeyId\":\"AK\","
+                    + "\"secretAccessKey\":\"SK\",\"sessionToken\":\"ST\"}}}"));
+    try (DeltaSharingClient client = client()) {
+      assertThatThrownBy(() -> client.temporaryTableCredentials("s", "sc", "t", null))
+          .isInstanceOf(DeltaSharingException.class)
+          .hasMessageContaining("unit mismatch")
+          .extracting(e -> ((DeltaSharingException) e).failure())
+          .isEqualTo(DeltaSharingException.Failure.INVALID_RESPONSE);
+    }
+  }
+
+  /**
+   * The version is published as the {@code delta.sharing.version} property, and {@code asLong}
+   * answers zero for a string or a container. Unchecked, a malformed version is a table definition
+   * nobody sent rather than a failure.
+   */
+  @Test
+  void aVersionThatIsNotANumberIsRefused() throws Exception {
+    startServer(
+        exchange ->
+            respond(
+                exchange,
+                200,
+                "{\"protocol\":{\"minReaderVersion\":1}}\n"
+                    + "{\"metaData\":{\"schemaString\":\"{}\",\"version\":\"latest\"}}"));
+    try (DeltaSharingClient client = client()) {
+      assertThatThrownBy(() -> client.describeTable("share", "schema", "table"))
+          .isInstanceOf(DeltaSharingException.class)
+          .hasMessageContaining("version that is not a number")
+          .extracting(e -> ((DeltaSharingException) e).failure())
+          .isEqualTo(DeltaSharingException.Failure.INVALID_RESPONSE);
+    }
+  }
+
+  /**
+   * Delta defines this as a map of strings, and these entries become the table's properties -- so a
+   * number, a boolean or a null coercing through {@code asText} is metadata the server did not
+   * send.
+   */
+  @Test
+  void aNonStringConfigurationValueIsRefused() throws Exception {
+    startServer(
+        exchange ->
+            respond(
+                exchange,
+                200,
+                "{\"protocol\":{\"minReaderVersion\":1}}\n"
+                    + "{\"metaData\":{\"schemaString\":\"{}\","
+                    + "\"configuration\":{\"delta.minReaderVersion\":5}}}"));
+    try (DeltaSharingClient client = client()) {
+      assertThatThrownBy(() -> client.describeTable("share", "schema", "table"))
+          .isInstanceOf(DeltaSharingException.class)
+          .hasMessageContaining("non-string configuration value")
+          .extracting(e -> ((DeltaSharingException) e).failure())
+          .isEqualTo(DeltaSharingException.Failure.INVALID_RESPONSE);
+    }
+  }
+
+  /** A stated configuration that is not an object leaves no properties, which is not the same. */
+  @Test
+  void aConfigurationThatIsNotAnObjectIsRefused() throws Exception {
+    startServer(
+        exchange ->
+            respond(
+                exchange,
+                200,
+                "{\"protocol\":{\"minReaderVersion\":1}}\n"
+                    + "{\"metaData\":{\"schemaString\":\"{}\",\"configuration\":\"oops\"}}"));
+    try (DeltaSharingClient client = client()) {
+      assertThatThrownBy(() -> client.describeTable("share", "schema", "table"))
+          .isInstanceOf(DeltaSharingException.class)
+          .hasMessageContaining("configuration that is not an object");
+    }
+  }
+
+  /** A container value is refused by the same rule. */
+  @Test
+  void aNonScalarConfigurationValueIsRefused() throws Exception {
+    startServer(
+        exchange ->
+            respond(
+                exchange,
+                200,
+                "{\"protocol\":{\"minReaderVersion\":1}}\n"
+                    + "{\"metaData\":{\"schemaString\":\"{}\","
+                    + "\"configuration\":{\"delta.enableDeletionVectors\":{\"on\":true}}}}"));
+    try (DeltaSharingClient client = client()) {
+      assertThatThrownBy(() -> client.describeTable("share", "schema", "table"))
+          .isInstanceOf(DeltaSharingException.class)
+          .hasMessageContaining("non-string configuration value");
+    }
+  }
+
+  /**
+   * A name has to be a string. {@code asText} answers "17" for a number, so such an entry became a
+   * table named 17 in an inventory the reconciler treats as authoritative -- and tables the same
+   * malformed page omitted are retired against it.
+   */
+  @Test
+  void aNonTextualNameIsRefusedRatherThanCoerced() throws Exception {
+    startServer(exchange -> respond(exchange, 200, "{\"items\":[{\"name\":17}]}"));
+    try (DeltaSharingClient client = client()) {
+      assertThatThrownBy(() -> client.listTables("share", "schema"))
+          .isInstanceOf(DeltaSharingException.class)
+          .hasMessageContaining("non-textual name")
+          .extracting(e -> ((DeltaSharingException) e).failure())
+          .isEqualTo(DeltaSharingException.Failure.INVALID_RESPONSE);
+    }
+  }
+
+  /**
+   * A server formatting ordinary JSON across lines. This request advertises application/json as
+   * well as ndjson, so both framings have to be read; splitting on newlines ahead of a whole-body
+   * parse would hand "{" to the parser alone.
+   */
+  @Test
+  void aPrettyPrintedCredentialResponseIsRead() throws Exception {
+    startServer(
+        exchange ->
+            respond(
+                exchange,
+                200,
+                "{\n  \"credentials\": {\n    \"location\": \"s3://b/t\",\n"
+                    + "    \"expirationTime\": 1893456000000,\n"
+                    + "    \"awsTempCredentials\": {\n      \"accessKeyId\": \"AK\",\n"
+                    + "      \"secretAccessKey\": \"SK\",\n"
+                    + "      \"sessionToken\": \"ST\"\n    }\n  }\n}"));
+    try (DeltaSharingClient client = client()) {
+      assertThat(client.temporaryTableCredentials("s", "sc", "t", null).location())
+          .isEqualTo("s3://b/t");
+    }
+  }
+
+  /**
+   * The Accept header offers ndjson, so a server may answer in it -- with a protocol action ahead
+   * of the credentials, the way the metadata route does on this transport. Reading the body as one
+   * document failed on the second line, and that arrives as INVALID_RESPONSE, which reaches the
+   * client as INTERNAL and ends the whole reconcile rather than skipping a table.
+   */
+  @Test
+  void aCredentialResponseFramedAsNdjsonIsRead() throws Exception {
+    startServer(
+        exchange ->
+            respond(
+                exchange,
+                200,
+                "{\"protocol\":{\"minReaderVersion\":1}}\n"
+                    + "{\"credentials\":{\"location\":\"s3://b/t\","
+                    + "\"expirationTime\":1893456000000,"
+                    + "\"awsTempCredentials\":{\"accessKeyId\":\"AK\","
+                    + "\"secretAccessKey\":\"SK\",\"sessionToken\":\"ST\"}}}"));
+    try (DeltaSharingClient client = client()) {
+      assertThat(client.temporaryTableCredentials("s", "sc", "t", null).location())
+          .isEqualTo("s3://b/t");
+    }
+  }
+
+  /**
+   * The schema is persisted as the reconciled table's Delta schema without being parsed here, so a
+   * coerced value materialises a table that fails when a query maps it.
+   */
+  @Test
+  void aNonStringSchemaStringIsRefused() throws Exception {
+    startServer(
+        exchange ->
+            respond(
+                exchange,
+                200,
+                "{\"protocol\":{\"minReaderVersion\":1}}\n"
+                    + "{\"metaData\":{\"schemaString\":17}}"));
+    try (DeltaSharingClient client = client()) {
+      assertThatThrownBy(() -> client.describeTable("share", "schema", "table"))
+          .isInstanceOf(DeltaSharingException.class)
+          .hasMessageContaining("carried no schemaString")
+          .extracting(e -> ((DeltaSharingException) e).failure())
+          .isEqualTo(DeltaSharingException.Failure.INVALID_RESPONSE);
+    }
+  }
+
+  /**
+   * A numeric AWS field otherwise passes {@code hasAwsSession} and is published as a complete
+   * tuple, so every storage access with it fails.
+   */
+  @Test
+  void aNonStringAwsSessionFieldIsRefused() throws Exception {
+    startServer(
+        exchange ->
+            respond(
+                exchange,
+                200,
+                "{\"credentials\":{\"location\":\"s3://b/t\","
+                    + "\"expirationTime\":1893456000000,"
+                    + "\"awsTempCredentials\":{\"accessKeyId\":17,"
+                    + "\"secretAccessKey\":\"SK\",\"sessionToken\":\"ST\"}}}"));
+    try (DeltaSharingClient client = client()) {
+      assertThatThrownBy(() -> client.temporaryTableCredentials("s", "sc", "t", null))
+          .isInstanceOf(DeltaSharingException.class)
+          .hasMessageContaining("non-string accessKeyId")
+          .extracting(e -> ((DeltaSharingException) e).failure())
+          .isEqualTo(DeltaSharingException.Failure.INVALID_RESPONSE);
+    }
+  }
+
+  /** A numeric credential location is not a location, and it stands in for the table root. */
+  @Test
+  void aNonStringCredentialLocationIsRefused() throws Exception {
+    startServer(
+        exchange ->
+            respond(
+                exchange,
+                200,
+                "{\"credentials\":{\"location\":17,\"expirationTime\":1893456000000,"
+                    + "\"awsTempCredentials\":{\"accessKeyId\":\"AK\","
+                    + "\"secretAccessKey\":\"SK\",\"sessionToken\":\"ST\"}}}"));
+    try (DeltaSharingClient client = client()) {
+      assertThatThrownBy(() -> client.temporaryTableCredentials("s", "sc", "t", null))
+          .isInstanceOf(DeltaSharingException.class)
+          .hasMessageContaining("named no location");
+    }
+  }
+
+  /**
+   * {@code asLong} answers 1 for {@code true}, which clears both bounds and yields an expiry one
+   * millisecond after the epoch -- a session the vendor refuses as expired, reported as an expired
+   * credential rather than a malformed response.
+   */
+  @Test
+  void anExpiryThatIsNotANumberIsRefused() throws Exception {
+    startServer(
+        exchange ->
+            respond(
+                exchange,
+                200,
+                "{\"credentials\":{\"location\":\"s3://b/t\",\"expirationTime\":true,"
+                    + "\"awsTempCredentials\":{\"accessKeyId\":\"AK\","
+                    + "\"secretAccessKey\":\"SK\",\"sessionToken\":\"ST\"}}}"));
+    try (DeltaSharingClient client = client()) {
+      assertThatThrownBy(() -> client.temporaryTableCredentials("s", "sc", "t", null))
+          .isInstanceOf(DeltaSharingException.class)
+          .hasMessageContaining("expiry that is not a number")
+          .extracting(e -> ((DeltaSharingException) e).failure())
+          .isEqualTo(DeltaSharingException.Failure.INVALID_RESPONSE);
+    }
+  }
+
+  /**
+   * An expiry in epoch milliseconds overflows an int, so rendering it as a JSON string -- the
+   * standard protobuf encoding for int64 -- must still be accepted. Refusing it is
+   * INVALID_RESPONSE, which reaches the client as INTERNAL and ends the whole reconcile rather than
+   * skipping a table.
+   */
+  @Test
+  void anExpirySentAsAStringOfEpochMillisIsAccepted() throws Exception {
+    startServer(
+        exchange ->
+            respond(
+                exchange,
+                200,
+                "{\"credentials\":{\"location\":\"s3://b/t\","
+                    + "\"expirationTime\":\"1893456000000\","
+                    + "\"awsTempCredentials\":{\"accessKeyId\":\"AK\","
+                    + "\"secretAccessKey\":\"SK\",\"sessionToken\":\"ST\"}}}"));
+    try (DeltaSharingClient client = client()) {
+      assertThat(client.temporaryTableCredentials("s", "sc", "t", null).expiresAt())
+          .contains(Instant.ofEpochMilli(1893456000000L));
+    }
+  }
+
+  /** The version takes the same rule as the other two int64 fields. */
+  @Test
+  void aVersionSentAsAStringIsAccepted() throws Exception {
+    startServer(
+        exchange ->
+            respond(
+                exchange,
+                200,
+                "{\"protocol\":{\"minReaderVersion\":1}}\n"
+                    + "{\"metaData\":{\"schemaString\":\"{}\",\"version\":\"12\"}}"));
+    try (DeltaSharingClient client = client()) {
+      assertThat(client.describeTable("share", "schema", "table").version()).contains(12L);
+    }
+  }
+
+  /** The boundary itself is a date, and has to stay one. */
+  @Test
+  void theLastRepresentableExpiryIsStillAccepted() throws Exception {
+    startServer(
+        exchange ->
+            respond(
+                exchange,
+                200,
+                "{\"credentials\":{\"location\":\"s3://b/t\","
+                    + "\"expirationTime\":253402300799999,"
+                    + "\"awsTempCredentials\":{\"accessKeyId\":\"AK\","
+                    + "\"secretAccessKey\":\"SK\",\"sessionToken\":\"ST\"}}}"));
+    try (DeltaSharingClient client = client()) {
+      assertThat(client.temporaryTableCredentials("s", "sc", "t", null).expiresAt())
+          .contains(Instant.ofEpochMilli(253402300799999L));
+    }
+  }
+
+  /**
+   * The bounded reader asks for the cap plus one byte to spot an overrun, and that addition
+   * overflows at the largest int -- so setting the cap to its largest allowed value gave a negative
+   * length and failed every response as a transport error. The sibling client already refuses this
+   * value on the same property.
+   */
+  @Test
+  void theLargestIntIsNotAUsableResponseCap() {
+    System.setProperty(
+        HttpDeltaSharingClient.MAX_RESPONSE_BYTES_PROPERTY, String.valueOf(Integer.MAX_VALUE));
+    assertThatThrownBy(
+            () ->
+                new HttpDeltaSharingClient(
+                    URI.create("https://sharing.example.com/delta-sharing"),
+                    "token",
+                    Duration.ofSeconds(2),
+                    Duration.ofSeconds(2)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(HttpDeltaSharingClient.MAX_RESPONSE_BYTES_PROPERTY);
+  }
+
+  /**
+   * asText supplies its default for a missing or container node but not for a stated empty string,
+   * so this arrived blank at the record's own requireText -- an IllegalArgumentException, which is
+   * not a DeltaSharingException and so escapes this class's classification entirely.
+   */
+  @Test
+  void aStatedButEmptyFormatProviderIsClassifiedRatherThanEscaping() throws Exception {
+    startServer(
+        exchange ->
+            respond(
+                exchange,
+                200,
+                "{\"protocol\":{\"minReaderVersion\":1}}\n"
+                    + "{\"metaData\":{\"schemaString\":\"{}\",\"format\":{\"provider\":\"\"}}}"));
+    try (DeltaSharingClient client = client()) {
+      assertThatThrownBy(() -> client.describeTable("share", "schema", "table"))
+          .isInstanceOf(DeltaSharingException.class)
+          .hasMessageContaining("format provider that is not a name")
+          .extracting(e -> ((DeltaSharingException) e).failure())
+          .isEqualTo(DeltaSharingException.Failure.INVALID_RESPONSE);
+    }
+  }
+
+  /** An absent format still means parquet, which is the field's own default. */
+  @Test
+  void anAbsentFormatProviderIsStillParquet() throws Exception {
+    startServer(
+        exchange ->
+            respond(
+                exchange,
+                200,
+                "{\"protocol\":{\"minReaderVersion\":1}}\n"
+                    + "{\"metaData\":{\"schemaString\":\"{}\"}}"));
+    try (DeltaSharingClient client = client()) {
+      assertThat(client.describeTable("share", "schema", "table").metadata().format())
+          .isEqualTo("parquet");
+    }
+  }
+
+  /** The fifth array field in this parser, held to the same shape rule as the other four. */
+  @Test
+  void aNonArrayReaderFeaturesIsRefused() throws Exception {
+    startServer(
+        exchange ->
+            respond(
+                exchange,
+                200,
+                "{\"protocol\":{\"minReaderVersion\":1,\"readerFeatures\":\"deletionVectors\"}}\n"
+                    + "{\"metaData\":{\"schemaString\":\"{}\"}}"));
+    try (DeltaSharingClient client = client()) {
+      assertThatThrownBy(() -> client.describeTable("share", "schema", "table"))
+          .isInstanceOf(DeltaSharingException.class)
+          .hasMessageContaining("non-array readerFeatures")
+          .extracting(e -> ((DeltaSharingException) e).failure())
+          .isEqualTo(DeltaSharingException.Failure.INVALID_RESPONSE);
+    }
+  }
+
+  /** A version that is not one is refused rather than defaulting silently to 1. */
+  @Test
+  void aMinReaderVersionThatIsNotAVersionIsRefused() throws Exception {
+    startServer(
+        exchange ->
+            respond(
+                exchange,
+                200,
+                "{\"protocol\":{\"minReaderVersion\":\"x\"}}\n"
+                    + "{\"metaData\":{\"schemaString\":\"{}\"}}"));
+    try (DeltaSharingClient client = client()) {
+      assertThatThrownBy(() -> client.describeTable("share", "schema", "table"))
+          .isInstanceOf(DeltaSharingException.class)
+          .hasMessageContaining("not a version");
+    }
+  }
+
+  /**
+   * A numeric string is a version. Refusing it would fail a working share over a field no consumer
+   * reads, which is a worse trade than the silence being closed here.
+   */
+  @Test
+  void aMinReaderVersionSentAsAStringIsStillAVersion() throws Exception {
+    startServer(
+        exchange ->
+            respond(
+                exchange,
+                200,
+                "{\"protocol\":{\"minReaderVersion\":\"2\",\"readerFeatures\":[\"dv\"]}}\n"
+                    + "{\"metaData\":{\"schemaString\":\"{}\"}}"));
+    try (DeltaSharingClient client = client()) {
+      assertThat(client.describeTable("share", "schema", "table").protocol().minReaderVersion())
+          .isEqualTo(2);
+    }
+  }
+
+  /**
+   * The credential response is specified as x-ndjson carrying a single action, and this request
+   * advertised application/json alone -- so a server honouring content negotiation could answer 406
+   * to every credential request, which is every reconcile and every read.
+   */
+  @Test
+  void theCredentialRequestAdvertisesTheProtocolResponseType() throws Exception {
+    startServer(
+        exchange ->
+            respond(
+                exchange,
+                200,
+                "{\"credentials\":{\"location\":\"s3://b/t\","
+                    + "\"expirationTime\":1893456000000,"
+                    + "\"awsTempCredentials\":{\"accessKeyId\":\"AK\","
+                    + "\"secretAccessKey\":\"SK\",\"sessionToken\":\"ST\"}}}"));
+    try (DeltaSharingClient client = client()) {
+      client.temporaryTableCredentials("s", "sc", "t", null);
+    }
+    assertThat(acceptHeaders)
+        .singleElement()
+        .satisfies(
+            accept -> {
+              assertThat(accept).contains("application/x-ndjson");
+              assertThat(accept).contains("application/json");
+            });
+  }
+
+  /** And the body is read either way, since nothing here inspects the response content type. */
+  @Test
+  void anNdjsonFramedCredentialBodyIsStillRead() throws Exception {
+    startServer(
+        exchange ->
+            respond(
+                exchange,
+                200,
+                "{\"credentials\":{\"location\":\"s3://b/t\","
+                    + "\"expirationTime\":1893456000000,"
+                    + "\"awsTempCredentials\":{\"accessKeyId\":\"AK\","
+                    + "\"secretAccessKey\":\"SK\",\"sessionToken\":\"ST\"}}}\n"));
+    try (DeltaSharingClient client = client()) {
+      assertThat(client.temporaryTableCredentials("s", "sc", "t", null).location())
+          .isEqualTo("s3://b/t");
+    }
+  }
+
+  /**
+   * A cursor is opaque, and only an absent, null or empty token ends pagination. Reading a
+   * whitespace token as the end returned the first page as the complete authoritative inventory --
+   * which is what lets the reconciler retire every table the later pages would have named.
+   */
+  @Test
+  void aWhitespaceCursorIsSentBackRatherThanEndingTheListing() throws Exception {
+    AtomicInteger call = new AtomicInteger();
+    startServer(
+        exchange -> {
+          if (call.getAndIncrement() == 0) {
+            respond(exchange, 200, "{\"items\":[{\"name\":\"one\"}],\"nextPageToken\":\" \"}");
+          } else {
+            respond(exchange, 200, "{\"items\":[{\"name\":\"two\"}]}");
+          }
+        });
+    try (DeltaSharingClient client = client()) {
+      assertThat(client.listShares())
+          .extracting(DeltaSharingModel.Share::name)
+          .containsExactly("one", "two");
+    }
+    // Sent back exactly, as a query value rather than a path segment: encode() rejects a blank
+    // string as an unusable segment, which would have raised out of the listing unclassified.
+    assertThat(requestPaths).last().asString().contains("pageToken=%20");
+  }
+
+  /**
+   * asText answers an object with the empty string, so an array of objects read as an empty list --
+   * and for auxiliaryLocations that makes hasAuxiliaryLocations() false, so the refusal at the load
+   * never fires and the table reconciles with a credential covering only its root.
+   */
+  @Test
+  void anAuxiliaryLocationThatIsNotATextValueIsRefused() throws Exception {
+    startServer(
+        exchange ->
+            respond(
+                exchange,
+                200,
+                "{\"items\":[{\"name\":\"t\","
+                    + "\"auxiliaryLocations\":[{\"p\":\"s3://other/part\"}]}]}"));
+    try (DeltaSharingClient client = client()) {
+      assertThatThrownBy(() -> client.listTables("share", "schema"))
+          .isInstanceOf(DeltaSharingException.class)
+          .hasMessageContaining("auxiliaryLocations entry that is not a value")
+          .extracting(e -> ((DeltaSharingException) e).failure())
+          .isEqualTo(DeltaSharingException.Failure.INVALID_RESPONSE);
+    }
+  }
+
+  /**
+   * The metadata endpoint is where a proxy error page arriving with a 200 lands, and the message is
+   * hidden again at the gRPC boundary -- so the log line was all an operator had, and it said where
+   * the parse failed without ever saying what arrived.
+   */
+  @Test
+  void anNdjsonLineParseFailureCarriesTheRedactedBody() throws Exception {
+    startServer(exchange -> respond(exchange, 200, "<html>proxy says no</html>"));
+    try (DeltaSharingClient client = client()) {
+      assertThatThrownBy(() -> client.describeTable("share", "schema", "table"))
+          .isInstanceOf(DeltaSharingException.class)
+          .hasMessageContaining("proxy says no");
+    }
+  }
+
+  /**
+   * An element that is not a mode is refused, not coerced. asText answers an object with the empty
+   * string, which mapped to OTHER -- and OTHER alongside a readable value is the unsafe direction:
+   * this decoded to [OTHER, DIR], contains(DIR) answered true, and the table was treated as
+   * directory-accessible on the strength of a response this client could not read.
+   */
+  @Test
+  void anAccessModeThatIsNotATextValueIsRefused() throws Exception {
+    startServer(
+        exchange ->
+            respond(
+                exchange,
+                200,
+                "{\"items\":[{\"name\":\"t\",\"accessModes\":[{\"a\":1},\"dir\"]}]}"));
+    try (DeltaSharingClient client = client()) {
+      assertThatThrownBy(() -> client.listTables("share", "schema"))
+          .isInstanceOf(DeltaSharingException.class)
+          .hasMessageContaining("accessModes entry that is not a mode")
+          .extracting(e -> ((DeltaSharingException) e).failure())
+          .isEqualTo(DeltaSharingException.Failure.INVALID_RESPONSE);
+    }
+  }
+
+  /**
+   * A table stating only modes this client does not know is not a table stating none. Dropping the
+   * unknown value made the two indistinguishable, and the strict setting then refused such a table
+   * with a message saying it had stated no access modes at all.
+   */
+  @Test
+  void aTableStatingOnlyUnknownModesIsDistinguishableFromOneStatingNone() throws Exception {
+    startServer(
+        exchange ->
+            respond(
+                exchange,
+                200,
+                "{\"items\":[{\"name\":\"t\",\"accessModes\":[\"dir2\"]}," + "{\"name\":\"u\"}]}"));
+    try (DeltaSharingClient client = client()) {
+      var tables = client.listTables("s", "sc");
+      assertThat(tables.get(0).accessModes()).containsExactly(AccessMode.OTHER);
+      assertThat(tables.get(1).accessModes()).isEmpty();
+    }
+  }
+
+  /**
+   * A stated field that is not a scalar is malformed, not absent. asText answers an object with the
+   * empty string, so a location stated as an object read as missing and fell through to the
+   * credential endpoint, and a shareId stated as one downgraded a stable identity to a name.
+   */
+  @Test
+  void aNonStringStatedFieldIsRefusedRatherThanReadAsAbsent() throws Exception {
+    startServer(
+        exchange ->
+            respond(
+                exchange,
+                200,
+                "{\"items\":[{\"name\":\"t\",\"location\":{\"path\":\"s3://b/t\"}}]}"));
+    try (DeltaSharingClient client = client()) {
+      assertThatThrownBy(() -> client.listTables("share", "schema"))
+          .isInstanceOf(DeltaSharingException.class)
+          .hasMessageContaining("non-string location")
+          .hasMessageContaining("tables of share.schema")
+          .extracting(e -> ((DeltaSharingException) e).failure())
+          .isEqualTo(DeltaSharingException.Failure.INVALID_RESPONSE);
+    }
+  }
+
+  /**
+   * One action of each kind. A second overwrote the first, so a concatenated or malformed response
+   * materialised the later schema and location on a table that reconciled clean -- wrong data on a
+   * live table rather than a skip, which is the last-write-wins trap the strict parser settings
+   * close for duplicate keys but cannot reach across legal NDJSON lines.
+   */
+  @Test
+  void aSecondMetadataActionIsRefusedRatherThanOverwritingTheFirst() throws Exception {
+    startServer(
+        exchange ->
+            respond(
+                exchange,
+                200,
+                "{\"protocol\":{\"minReaderVersion\":1}}\n"
+                    + "{\"metaData\":{\"schemaString\":\"{}\",\"location\":\"s3://b/first\"}}\n"
+                    + "{\"metaData\":{\"schemaString\":\"{}\",\"location\":\"s3://b/second\"}}"));
+    try (DeltaSharingClient client = client()) {
+      assertThatThrownBy(() -> client.describeTable("share", "schema", "table"))
+          .isInstanceOf(DeltaSharingException.class)
+          .hasMessageContaining("more than one metaData action")
+          .extracting(e -> ((DeltaSharingException) e).failure())
+          .isEqualTo(DeltaSharingException.Failure.INVALID_RESPONSE);
+    }
+  }
+
+  /** The same for a repeated protocol action. */
+  @Test
+  void aSecondProtocolActionIsRefused() throws Exception {
+    startServer(
+        exchange ->
+            respond(
+                exchange,
+                200,
+                "{\"protocol\":{\"minReaderVersion\":1}}\n"
+                    + "{\"protocol\":{\"minReaderVersion\":3}}\n"
+                    + "{\"metaData\":{\"schemaString\":\"{}\"}}"));
+    try (DeltaSharingClient client = client()) {
+      assertThatThrownBy(() -> client.describeTable("share", "schema", "table"))
+          .isInstanceOf(DeltaSharingException.class)
+          .hasMessageContaining("more than one protocol action");
+    }
+  }
+
+  /**
+   * Order is not enforced. The wire format states protocol then metaData, but accepting the reverse
+   * costs nothing and refusing it would fail a server that is otherwise correct.
+   */
+  @Test
+  void actionsInTheReverseOrderAreStillAccepted() throws Exception {
+    startServer(
+        exchange ->
+            respond(
+                exchange,
+                200,
+                "{\"metaData\":{\"schemaString\":\"{}\"}}\n"
+                    + "{\"protocol\":{\"minReaderVersion\":1}}"));
+    try (DeltaSharingClient client = client()) {
+      assertThat(client.describeTable("share", "schema", "table").protocol().minReaderVersion())
+          .isEqualTo(1);
+    }
+  }
+
+  private interface Handler {
+    void handle(HttpExchange exchange) throws IOException;
+  }
+
+  private void startServer(Handler handler) throws IOException {
+    server = HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+    server.createContext(
+        "/",
+        exchange -> {
+          requestPaths.add(exchange.getRequestURI().toString());
+          capabilityHeaders.add(
+              exchange.getRequestHeaders().getFirst("delta-sharing-capabilities"));
+          authorizationHeaders.add(exchange.getRequestHeaders().getFirst("Authorization"));
+          acceptHeaders.add(exchange.getRequestHeaders().getFirst("Accept"));
+          handler.handle(exchange);
+        });
+    server.start();
+  }
+
+  private URI endpoint() {
+    return URI.create("http://localhost:" + server.getAddress().getPort() + "/delta-sharing");
+  }
+
+  private DeltaSharingClient client() {
+    return new HttpDeltaSharingClient(
+        endpoint(), "token", Duration.ofSeconds(2), Duration.ofSeconds(2));
+  }
+
+  private static void respond(HttpExchange exchange, int status, String body) throws IOException {
+    byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+    exchange.sendResponseHeaders(status, bytes.length);
+    exchange.getResponseBody().write(bytes);
+    exchange.close();
+  }
+}

--- a/connectors/clients/unity-catalog/src/main/java/ai/floedb/floecat/client/unity/HttpUnityCatalogClient.java
+++ b/connectors/clients/unity-catalog/src/main/java/ai/floedb/floecat/client/unity/HttpUnityCatalogClient.java
@@ -16,12 +16,13 @@
 
 package ai.floedb.floecat.client.unity;
 
+import ai.floedb.floecat.http.guards.HttpEndpointGuards;
+import ai.floedb.floecat.http.guards.HttpResponseSnippets;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.InetAddress;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.net.http.HttpClient;
@@ -39,7 +40,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.regex.Pattern;
 
 /** JDK HTTP implementation of the small Unity Catalog client boundary. */
 public final class HttpUnityCatalogClient implements UnityCatalogClient {
@@ -89,8 +89,6 @@ public final class HttpUnityCatalogClient implements UnityCatalogClient {
 
   private static final ObjectMapper JSON = new ObjectMapper();
 
-  private static final Pattern BEARER_TOKEN = Pattern.compile("(?i)bearer\\s+[A-Za-z0-9._~+/=-]+");
-
   /**
    * Page limit for one listing. The repeated-token check in {@link #listAll} catches a server that
    * reuses a token, not one that mints a new token per page, and nothing else bounds the loop:
@@ -109,10 +107,7 @@ public final class HttpUnityCatalogClient implements UnityCatalogClient {
    * floecat.security.allow-loopback-token-endpoints}. Read from system properties and the
    * environment at construction; this module does not depend on the connector config layer.
    */
-  static final String ALLOW_LOOPBACK_PROPERTY = "floecat.security.allow-loopback-catalog-endpoints";
-
-  private static final String ALLOW_LOOPBACK_ENV =
-      "FLOECAT_SECURITY_ALLOW_LOOPBACK_CATALOG_ENDPOINTS";
+  static final String ALLOW_LOOPBACK_PROPERTY = HttpEndpointGuards.ALLOW_LOOPBACK_PROPERTY;
 
   /**
    * Cap on a single response body, in bytes. Override with {@code floecat.unity.max-response-bytes}
@@ -123,10 +118,7 @@ public final class HttpUnityCatalogClient implements UnityCatalogClient {
   private static final int DEFAULT_MAX_RESPONSE_BYTES = 32 * 1024 * 1024;
 
   /** Opt-in for a base URI naming a private (site-local) address literal. Deny by default. */
-  static final String ALLOW_PRIVATE_PROPERTY = "floecat.security.allow-private-catalog-endpoints";
-
-  private static final String ALLOW_PRIVATE_ENV =
-      "FLOECAT_SECURITY_ALLOW_PRIVATE_CATALOG_ENDPOINTS";
+  static final String ALLOW_PRIVATE_PROPERTY = HttpEndpointGuards.ALLOW_PRIVATE_PROPERTY;
 
   private final String baseUri;
   private final String credentialsPath;
@@ -165,7 +157,9 @@ public final class HttpUnityCatalogClient implements UnityCatalogClient {
     // Arguments evaluate left to right; every check runs before newHttpClient allocates a
     // transport.
     this(
-        stripTrailingSlash(validateBaseUri(baseUri).toString()),
+        stripTrailingSlash(
+            HttpEndpointGuards.requireAllowedEndpoint(baseUri, "Unity Catalog base URI")
+                .toString()),
         requirePositive(requestTimeout, "requestTimeout"),
         Objects.requireNonNull(authentication, "authentication"),
         requireAbsolutePath(credentialsPath),
@@ -194,7 +188,9 @@ public final class HttpUnityCatalogClient implements UnityCatalogClient {
       String credentialsPath,
       HttpClient httpClient) {
     this(
-        stripTrailingSlash(validateBaseUri(baseUri).toString()),
+        stripTrailingSlash(
+            HttpEndpointGuards.requireAllowedEndpoint(baseUri, "Unity Catalog base URI")
+                .toString()),
         requirePositive(requestTimeout, "requestTimeout"),
         Objects.requireNonNull(authentication, "authentication"),
         requireAbsolutePath(credentialsPath),
@@ -247,7 +243,7 @@ public final class HttpUnityCatalogClient implements UnityCatalogClient {
             + "&schema_name="
             + encode(schemaName),
         "tables",
-        HttpUnityCatalogClient::listedTable);
+        this::listedTable);
   }
 
   @Override
@@ -306,7 +302,7 @@ public final class HttpUnityCatalogClient implements UnityCatalogClient {
    * present but unusable value -- {@code {}}, half a tuple, or a non-object -- is {@code
    * INVALID_RESPONSE}. Only a missing field or an explicit JSON null means no AWS credentials.
    */
-  private static TemporaryTableCredentials.AwsCredentials awsCredentials(JsonNode awsNode) {
+  private TemporaryTableCredentials.AwsCredentials awsCredentials(JsonNode awsNode) {
     if (awsNode.isMissingNode() || awsNode.isNull()) {
       return null;
     }
@@ -504,7 +500,9 @@ public final class HttpUnityCatalogClient implements UnityCatalogClient {
     // release it.
     byte[] bytes;
     try {
-      bytes = readWithin(stream, maxResponseBytes, requestTimeout);
+      bytes =
+          HttpResponseSnippets.readWithin(
+              stream, maxResponseBytes, requestTimeout, "Unity Catalog");
     } finally {
       closeQuietly(stream);
     }
@@ -512,45 +510,6 @@ public final class HttpUnityCatalogClient implements UnityCatalogClient {
     // means nothing -- the status already answered. Throwing here would classify a permanent 403
     // whose error page happens to be large as a retryable INVALID_RESPONSE.
     return bytes.length > maxResponseBytes ? null : new String(bytes, StandardCharsets.UTF_8);
-  }
-
-  /**
-   * Reads {@code stream} up to {@code limit + 1} bytes, giving up after {@code deadline}.
-   *
-   * <p>On a virtual thread of its own, not {@code CompletableFuture.supplyAsync}'s common pool. The
-   * read blocks for the whole download, and {@code ForkJoinPool.commonPool()} has parallelism one
-   * on a small container -- so two concurrent calls queued behind each other and the waiting one
-   * failed on this deadline while the server had already answered. Every caller here is itself on a
-   * virtual thread, so there is no pool to starve.
-   *
-   * <p>Closing the stream is what releases a genuinely stalled read; abandoning the future alone
-   * would leave the reader blocked in {@code readNBytes}.
-   */
-  private static byte[] readWithin(InputStream stream, int limit, Duration deadline)
-      throws IOException {
-    var body = new java.util.concurrent.CompletableFuture<byte[]>();
-    Thread.ofVirtual()
-        .start(
-            () -> {
-              try {
-                body.complete(stream.readNBytes(limit + 1));
-              } catch (Throwable failure) {
-                body.completeExceptionally(failure);
-              }
-            });
-    try {
-      return body.get(deadline.toMillis(), java.util.concurrent.TimeUnit.MILLISECONDS);
-    } catch (java.util.concurrent.TimeoutException stalled) {
-      closeQuietly(stream);
-      throw new IOException("Unity Catalog response body stalled after " + deadline, stalled);
-    } catch (InterruptedException interrupted) {
-      Thread.currentThread().interrupt();
-      closeQuietly(stream);
-      throw new IOException("Interrupted reading the Unity Catalog response body", interrupted);
-    } catch (java.util.concurrent.ExecutionException failure) {
-      Throwable cause = failure.getCause();
-      throw cause instanceof IOException io ? io : new IOException(cause);
-    }
   }
 
   private static void closeQuietly(InputStream stream) {
@@ -634,14 +593,14 @@ public final class HttpUnityCatalogClient implements UnityCatalogClient {
     return path + " (redirected to " + effectiveUri + ")";
   }
 
-  private static UnityCatalogTable listedTable(JsonNode node) {
+  private UnityCatalogTable listedTable(JsonNode node) {
     // Null rather than a throw: listAll drops an unmapped entry, so one null or scalar element in
     // the array cannot lose the rest of the page. getTable stays strict, where the caller asked
     // for one specific table and an unreadable answer is a failure.
     return node.isObject() ? table(node, false) : null;
   }
 
-  private static UnityCatalogTable table(JsonNode node, boolean strictColumns) {
+  private UnityCatalogTable table(JsonNode node, boolean strictColumns) {
     if (!node.isObject()) {
       throw invalidResponse("Expected a table object from Unity Catalog", null);
     }
@@ -657,7 +616,7 @@ public final class HttpUnityCatalogClient implements UnityCatalogClient {
         tableProperties(node));
   }
 
-  private static List<UnityCatalogTable.Column> parseColumns(JsonNode node, boolean strict) {
+  private List<UnityCatalogTable.Column> parseColumns(JsonNode node, boolean strict) {
     // Jackson iterates an object's values as though it were an array and yields nothing for a
     // scalar, so a detail response must reject either shape. A listing can still identify its
     // other entries without that schema, so only the malformed entry gets an empty column list.
@@ -689,7 +648,7 @@ public final class HttpUnityCatalogClient implements UnityCatalogClient {
     return columns;
   }
 
-  private static List<UnityCatalogTable.Column> malformedColumns(boolean strict, String message) {
+  private List<UnityCatalogTable.Column> malformedColumns(boolean strict, String message) {
     if (strict) {
       throw invalidResponse(message, null);
     }
@@ -743,7 +702,7 @@ public final class HttpUnityCatalogClient implements UnityCatalogClient {
    * <p>An unlisted 4xx is permanent only when it carries the {@code error_code} envelope. Without
    * one it may be an error page from a proxy rather than the workspace, so it stays {@code OTHER}.
    */
-  private static UnityCatalogException httpFailure(
+  private UnityCatalogException httpFailure(
       int status, String path, String body, boolean includeResponseBody) {
     String responseBody = includeResponseBody ? truncate(body) : "";
     // Capped like the body: error_code comes from that body but is interpolated outside the
@@ -887,7 +846,7 @@ public final class HttpUnityCatalogClient implements UnityCatalogClient {
     };
   }
 
-  private static UnityCatalogException invalidResponse(String message, Throwable cause) {
+  private UnityCatalogException invalidResponse(String message, Throwable cause) {
     return new UnityCatalogException(
         UnityCatalogException.Failure.INVALID_RESPONSE, -1, message, cause);
   }
@@ -896,7 +855,7 @@ public final class HttpUnityCatalogClient implements UnityCatalogClient {
    * An {@code INVALID_RESPONSE} that keeps what the catalog actually sent. The status and a snippet
    * of the body identify which proxy is answering when a body never becomes JSON.
    */
-  private static UnityCatalogException invalidResponse(
+  private UnityCatalogException invalidResponse(
       int status, String message, String body, Throwable cause) {
     String snippet = truncate(body);
     return new UnityCatalogException(
@@ -906,26 +865,18 @@ public final class HttpUnityCatalogClient implements UnityCatalogClient {
         cause);
   }
 
-  private static String truncate(String body) {
+  private String truncate(String body) {
     return truncate(body, MAX_BODY_SNIPPET_CHARS);
   }
 
-  private static String truncate(String value, int maxChars) {
-    return value == null
-        ? ""
-        : redactBearerTokens(value.substring(0, Math.min(value.length(), maxChars)));
-  }
-
-  /**
-   * Removes bearer tokens from text on its way into a failure message.
-   *
-   * <p>The Authorization header goes out on every request, and a debug handler or a misconfigured
-   * gateway will echo request headers in an error body. That body is interpolated into the
-   * exception for every route except vending, so without this the tenant's token reaches operator
-   * logs.
-   */
-  private static String redactBearerTokens(String text) {
-    return BEARER_TOKEN.matcher(text).replaceAll("Bearer <redacted>");
+  private String truncate(String value, int maxChars) {
+    // The token this client sends, by value. The generic pattern matches the token68 alphabet a
+    // bearer token is supposed to use, and this one is operator-supplied and under no obligation to
+    // -- so a token carrying a colon was matched only that far and the remainder survived into a
+    // message that reaches validation output and operator logs. The Delta Sharing client was wired
+    // to the by-value overload when it was added here; this caller of the same control was not.
+    return HttpResponseSnippets.bounded(
+        value, maxChars, authentication.redactableSecret().orElse(null));
   }
 
   private static String text(JsonNode node, String field) {
@@ -953,154 +904,6 @@ public final class HttpUnityCatalogClient implements UnityCatalogClient {
   }
 
   /**
-   * Whether the authority embeds userinfo that {@link URI#getUserInfo()} does not report. {@code
-   * java.net.URI} populates it only for a server-based authority; a host it rejects as a hostname
-   * -- an underscore, a non-numeric port -- yields a registry-based authority with the credential
-   * still in the raw string. {@code @} delimits userinfo and has no other role there.
-   */
-  private static boolean authorityCarriesUserInfo(URI baseUri) {
-    String authority = baseUri.getRawAuthority();
-    return authority != null && authority.indexOf('@') >= 0;
-  }
-
-  /**
-   * The base URI as it may appear in a rejection message: scheme, authority and path only.
-   *
-   * <p>A query is a common place for a token, and the userinfo guard covers only credentials in the
-   * authority. Every gate here reports the value it rejected, so the display form drops the two
-   * components that carry data rather than address the endpoint.
-   */
-  private static String display(URI baseUri) {
-    if (baseUri == null) {
-      return "null";
-    }
-    StringBuilder shown = new StringBuilder();
-    if (baseUri.getScheme() != null) {
-      shown.append(baseUri.getScheme()).append("://");
-    }
-    // Parsed components only, never the raw authority. URI reports a host it cannot parse as
-    // server-based -- an underscore, a bad port, or a percent-encoded delimiter such as
-    // alice:s3cr3t%40host -- by leaving getHost() and both userinfo accessors null while the raw
-    // authority keeps the credential. Echoing that here would undo the userinfo guard for exactly
-    // the inputs it cannot recognise.
-    if (baseUri.getHost() == null) {
-      shown.append("<unparseable-authority>");
-    } else {
-      shown.append(baseUri.getHost());
-      if (baseUri.getPort() != -1) {
-        shown.append(':').append(baseUri.getPort());
-      }
-    }
-    if (baseUri.getRawPath() != null) {
-      shown.append(baseUri.getRawPath());
-    }
-    return shown.isEmpty() ? "<empty>" : shown.toString();
-  }
-
-  private static URI validateBaseUri(URI baseUri) {
-    Objects.requireNonNull(baseUri, "baseUri");
-    // Before any check whose message interpolates the URI. Credentials belong in
-    // UnityCatalogAuthentication, and the JDK client does not transmit them.
-    if (baseUri.getUserInfo() != null
-        || baseUri.getRawUserInfo() != null
-        || authorityCarriesUserInfo(baseUri)) {
-      throw new IllegalArgumentException(
-          "Unity Catalog base URI must not contain userinfo; supply credentials through "
-              + "UnityCatalogAuthentication instead");
-    }
-    if (!baseUri.isAbsolute()) {
-      throw new IllegalArgumentException(
-          "Unity Catalog base URI must be absolute: " + display(baseUri));
-    }
-    String scheme = baseUri.getScheme();
-    boolean https = "https".equalsIgnoreCase(scheme);
-    boolean loopbackHttp =
-        "http".equalsIgnoreCase(scheme)
-            && allowLoopbackCleartext()
-            && isLoopbackHost(baseUri.getHost());
-    if (!https && !loopbackHttp) {
-      throw new IllegalArgumentException(
-          "Unity Catalog base URI must use HTTPS, except HTTP is allowed for loopback hosts when "
-              + ALLOW_LOOPBACK_PROPERTY
-              + " is set: "
-              + display(baseUri));
-    }
-    if (baseUri.getHost() == null) {
-      throw new IllegalArgumentException(
-          "Unity Catalog base URI must include a host: " + display(baseUri));
-    }
-    if (baseUri.getRawQuery() != null || baseUri.getRawFragment() != null) {
-      throw new IllegalArgumentException(
-          "Unity Catalog base URI must not include a query or fragment: " + display(baseUri));
-    }
-    // -1 is absent. URI and HttpRequest.Builder both accept 65536; InetSocketAddress rejects it at
-    // send time, where it is reported as TRANSPORT.
-    int port = baseUri.getPort();
-    if (port != -1 && (port < 1 || port > 65535)) {
-      throw new IllegalArgumentException(
-          "Unity Catalog base URI port must be between 1 and 65535: " + display(baseUri));
-    }
-    assertAddressClassAllowed(baseUri);
-    return baseUri;
-  }
-
-  /**
-   * Rejects address classes a tenant-supplied connector URI must not name.
-   *
-   * <p>Link-local, wildcard, multicast, broadcast and {@code 0.0.0.0/8} literals are refused
-   * outright; no catalog is reachable at one, and {@code https://169.254.169.254} is otherwise a
-   * well-formed HTTPS URI for a cloud metadata service. Site-local literals require {@link
-   * #ALLOW_PRIVATE_PROPERTY}, since an internal catalog is an ordinary deployment. Loopback is
-   * allowed; cleartext to it is governed by {@link #ALLOW_LOOPBACK_PROPERTY}.
-   *
-   * <p>Literals only: resolving a hostname here would disagree with the resolution {@code
-   * HttpClient} performs at connect time, so a hostname is out of scope.
-   */
-  private static void assertAddressClassAllowed(URI baseUri) {
-    String host = unbracket(baseUri.getHost());
-    // A zone id names a local interface, and ofLiteral cannot parse one. Left to the catch below a
-    // scoped literal reads as a hostname and skips this gate entirely, so fe80::1%eth0 admits a
-    // link-local address. The transport cannot carry one either.
-    if (host.indexOf('%') >= 0) {
-      throw new IllegalArgumentException(
-          "Unity Catalog base URI must not name a zone-scoped address: " + display(baseUri));
-    }
-    InetAddress address;
-    try {
-      address = InetAddress.ofLiteral(host);
-    } catch (IllegalArgumentException notALiteral) {
-      // A host of only digits and dots is not a hostname -- a DNS name cannot be entirely numeric
-      // -- and the resolver the transport uses accepts these modulo 2^32 even though ofLiteral
-      // refuses them: 7147006462 resolves to 169.254.169.254 and 4294967296 to 0.0.0.0. Returning
-      // here would hand the transport a link-local or wildcard target this gate refuses by name.
-      if (isNumericHost(host)) {
-        throw new IllegalArgumentException(
-            "Unity Catalog base URI must not name a numeric host that is not an address literal: "
-                + display(baseUri));
-      }
-      return;
-    }
-    if (address.isLoopbackAddress()) {
-      return;
-    }
-    if (address.isLinkLocalAddress()
-        || address.isAnyLocalAddress()
-        || address.isMulticastAddress()
-        || isBroadcastOrThisNetwork(address)) {
-      throw new IllegalArgumentException(
-          "Unity Catalog base URI must not name a link-local, wildcard or multicast address: "
-              + display(baseUri));
-    }
-    if (isSiteLocal(address) && !allowPrivateAddresses()) {
-      throw new IllegalArgumentException(
-          "Unity Catalog base URI names a private address, which requires "
-              + ALLOW_PRIVATE_PROPERTY
-              + ": "
-              + display(baseUri));
-    }
-  }
-
-  /**
    * The same address-class policy, for another tenant-supplied endpoint in this module's care.
    *
    * <p>Exposed rather than copied: {@code UnityOAuthTokenProvider} POSTs the integration's OAuth
@@ -1109,46 +912,7 @@ public final class HttpUnityCatalogClient implements UnityCatalogClient {
    * implementation of this rule is how the two drift apart.
    */
   public static void assertEndpointAddressAllowed(URI endpoint) {
-    assertAddressClassAllowed(Objects.requireNonNull(endpoint, "endpoint"));
-  }
-
-  /** Whether every character is an ASCII digit or a dot. Deliberately not {@code isDigit}. */
-  private static boolean isNumericHost(String host) {
-    if (host.isEmpty()) {
-      return false;
-    }
-    for (int i = 0; i < host.length(); i++) {
-      char c = host.charAt(i);
-      if ((c < '0' || c > '9') && c != '.') {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  /**
-   * IPv4 limited broadcast and {@code 0.0.0.0/8}. {@code isMulticastAddress} covers 224/4 and
-   * {@code isAnyLocalAddress} only the exact wildcard, so neither address is caught by them.
-   */
-  private static boolean isBroadcastOrThisNetwork(InetAddress address) {
-    byte[] bytes = address.getAddress();
-    if (bytes.length != 4) {
-      return false;
-    }
-    boolean broadcast = true;
-    for (byte octet : bytes) {
-      broadcast &= octet == (byte) 0xFF;
-    }
-    return broadcast || bytes[0] == 0;
-  }
-
-  /** IPv4 RFC 1918 and IPv6 unique-local, which {@code isSiteLocalAddress} misses for fc00::/7. */
-  private static boolean isSiteLocal(InetAddress address) {
-    if (address.isSiteLocalAddress()) {
-      return true;
-    }
-    byte[] bytes = address.getAddress();
-    return bytes.length == 16 && (bytes[0] & 0xFE) == 0xFC;
+    HttpEndpointGuards.assertEndpointAddressAllowed(endpoint);
   }
 
   private static int configuredMaxPages() {
@@ -1181,20 +945,6 @@ public final class HttpUnityCatalogClient implements UnityCatalogClient {
       throw new IllegalArgumentException(name + " must be a positive integer: " + configured);
     }
     return value;
-  }
-
-  private static boolean allowPrivateAddresses() {
-    return Boolean.parseBoolean(
-        System.getProperty(
-            ALLOW_PRIVATE_PROPERTY, System.getenv().getOrDefault(ALLOW_PRIVATE_ENV, "false")));
-  }
-
-  private static String unbracket(String host) {
-    String value = host == null ? "" : host.trim();
-    if (value.startsWith("[") && value.endsWith("]")) {
-      value = value.substring(1, value.length() - 1);
-    }
-    return value.endsWith(".") ? value.substring(0, value.length() - 1) : value;
   }
 
   private static HttpClient newHttpClient(Duration connectTimeout) {
@@ -1258,42 +1008,6 @@ public final class HttpUnityCatalogClient implements UnityCatalogClient {
    * catalog request beside it was allowed.
    */
   public static boolean isCleartextLoopbackAllowed(URI endpoint) {
-    Objects.requireNonNull(endpoint, "endpoint");
-    return allowLoopbackCleartext() && isLoopbackHost(endpoint.getHost());
-  }
-
-  private static boolean allowLoopbackCleartext() {
-    return Boolean.parseBoolean(
-        System.getProperty(
-            ALLOW_LOOPBACK_PROPERTY, System.getenv().getOrDefault(ALLOW_LOOPBACK_ENV, "false")));
-  }
-
-  private static boolean isLoopbackHost(String host) {
-    if (host == null) {
-      return false;
-    }
-    String normalized = host.toLowerCase(Locale.ROOT);
-    if (normalized.startsWith("[") && normalized.endsWith("]")) {
-      normalized = normalized.substring(1, normalized.length() - 1);
-    }
-    if (normalized.endsWith(".")) {
-      normalized = normalized.substring(0, normalized.length() - 1);
-    }
-    // Exactly "localhost", not any *.localhost name. RFC 6761 says such names should resolve to
-    // loopback, but nothing here enforces that and this gate does not resolve: a zone the tenant
-    // controls can point catalog.localhost at a public address, and the Authorization header would
-    // then go out in cleartext to it. CredentialResolverSupport, which this mirrors, has no suffix
-    // rule either -- it resolves and requires every answer to be loopback.
-    if (normalized.equals("localhost")) {
-      return true;
-    }
-    // ofLiteral, never getByName: a host this cannot decide is denied, not resolved. A resolver
-    // here disagrees with the one HttpClient uses at connect time. Character-shape pre-filters are
-    // no substitute: "4294967296" and "1." are all digits and dots yet parse as no address.
-    try {
-      return InetAddress.ofLiteral(normalized).isLoopbackAddress();
-    } catch (IllegalArgumentException notAnAddressLiteral) {
-      return false;
-    }
+    return HttpEndpointGuards.isCleartextLoopbackAllowed(endpoint);
   }
 }

--- a/connectors/clients/unity-catalog/src/main/java/ai/floedb/floecat/client/unity/UnityCatalogAuthentication.java
+++ b/connectors/clients/unity-catalog/src/main/java/ai/floedb/floecat/client/unity/UnityCatalogAuthentication.java
@@ -17,9 +17,28 @@
 package ai.floedb.floecat.client.unity;
 
 import java.util.Map;
+import java.util.Optional;
 
 /** Supplies fresh authentication headers for each Unity Catalog request. */
 @FunctionalInterface
 public interface UnityCatalogAuthentication {
   Map<String, String> headers();
+
+  /**
+   * The secret this puts on the wire, where it is a fixed value worth redacting by name.
+   *
+   * <p>The generic bearer pattern matches the RFC token68 alphabet, and a header value permits more
+   * -- so an operator-supplied token carrying a colon is matched only as far as the colon and the
+   * remainder survives into an error message that reaches validation output and operator logs. A
+   * client that knows its own secret can redact it exactly, which is what the shared snippet
+   * helper's by-value overload is for.
+   *
+   * <p>Empty by default, and empty for a rotating token: reading one here would mean asking the
+   * token provider for a value on a failure path, where a refresh is the last thing wanted. A
+   * rotating access token is issued in the token68 shape anyway, so the pattern covers it; the gap
+   * is the operator-supplied one.
+   */
+  default Optional<String> redactableSecret() {
+    return Optional.empty();
+  }
 }

--- a/connectors/clients/unity-catalog/src/test/java/ai/floedb/floecat/client/unity/HttpUnityCatalogClientTest.java
+++ b/connectors/clients/unity-catalog/src/test/java/ai/floedb/floecat/client/unity/HttpUnityCatalogClientTest.java
@@ -55,6 +55,48 @@ class HttpUnityCatalogClientTest {
             () -> Map.of("Authorization", "Bearer catalog-token"));
   }
 
+  /**
+   * A token carrying a character outside the token68 alphabet is redacted by value, not by pattern.
+   * The generic pattern matches what a bearer token is supposed to be; this one is
+   * operator-supplied and need not be, so a colon-bearing token was matched only that far and the
+   * remainder survived into a message that reaches validation output and operator logs. The Delta
+   * Sharing client was wired to the by-value overload when it was added; this caller of the same
+   * control was not.
+   */
+  @Test
+  void anEchoedTokenOutsideTheGrammarIsRedactedInFull() throws Exception {
+    String token = "abc:SECRET-TAIL";
+    server.createContext(
+        "/api/2.1/unity-catalog/catalogs",
+        exchange -> {
+          byte[] body =
+              ("upstream echoed: Authorization: Bearer " + token)
+                  .getBytes(java.nio.charset.StandardCharsets.UTF_8);
+          exchange.sendResponseHeaders(500, body.length);
+          exchange.getResponseBody().write(body);
+          exchange.close();
+        });
+    try (HttpUnityCatalogClient tokenClient =
+        new HttpUnityCatalogClient(
+            URI.create("http://127.0.0.1:" + server.getAddress().getPort()),
+            Duration.ofSeconds(1),
+            Duration.ofSeconds(5),
+            new UnityCatalogAuthentication() {
+              @Override
+              public Map<String, String> headers() {
+                return Map.of("Authorization", "Bearer " + token);
+              }
+
+              @Override
+              public java.util.Optional<String> redactableSecret() {
+                return java.util.Optional.of(token);
+              }
+            })) {
+      assertThatThrownBy(tokenClient::listCatalogs)
+          .satisfies(e -> assertThat(e.getMessage()).doesNotContain("SECRET-TAIL"));
+    }
+  }
+
   @AfterEach
   void tearDown() {
     if (previousAllowLoopback == null) {
@@ -1116,7 +1158,11 @@ class HttpUnityCatalogClientTest {
             UnityCatalogException.class,
             failure -> {
               assertThat(failure.getMessage()).doesNotContain("catalog-token");
-              assertThat(failure.getMessage()).contains("Bearer <redacted>");
+              // The whole header value goes, scheme included: the pass recognises the header name
+              // rather than the token's shape, so how the value was encoded stops mattering. The
+              // name survives, so the message still says which header was echoed.
+              assertThat(failure.getMessage()).contains("Authorization");
+              assertThat(failure.getMessage()).contains("<redacted>");
               // The rest of the body still reaches the message.
               assertThat(failure.getMessage()).contains("bad request");
             });
@@ -1943,7 +1989,7 @@ class HttpUnityCatalogClientTest {
   @Test
   void anEmptyTwoHundredBodyKeepsItsStatusSoItStaysRetryable() {
     // Headers then a close -- a sidecar restarting, a proxy that dropped the payload. Jackson
-    // parses "" to a missing node instead of throwing, so this used to reach the caller's shape
+    // parses "" to a missing node instead of throwing, so this reaches the caller's shape
     // check and be reported with no status, which a consumer reads as a permanent shape rejection.
     // The same connection truncated one byte later throws from readNBytes and is retryable; these
     // two must not disagree.

--- a/core/catalog-access-spi/src/main/java/ai/floedb/floecat/catalog/access/CatalogProtocol.java
+++ b/core/catalog-access-spi/src/main/java/ai/floedb/floecat/catalog/access/CatalogProtocol.java
@@ -20,5 +20,6 @@ package ai.floedb.floecat.catalog.access;
 public enum CatalogProtocol {
   ICEBERG_REST,
   UNITY_CATALOG,
+  DELTA_SHARING,
   AWS_GLUE
 }

--- a/core/http-endpoint-guards/pom.xml
+++ b/core/http-endpoint-guards/pom.xml
@@ -23,23 +23,12 @@
     <groupId>ai.floedb.floecat</groupId>
     <artifactId>floecat</artifactId>
     <version>0.1.0-SNAPSHOT</version>
-    <relativePath>../../..</relativePath>
+    <relativePath>../..</relativePath>
   </parent>
 
-  <artifactId>floecat-unity-catalog-client</artifactId>
+  <artifactId>floecat-http-endpoint-guards</artifactId>
 
   <dependencies>
-    <dependency>
-      <groupId>ai.floedb.floecat</groupId>
-      <artifactId>floecat-http-endpoint-guards</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <version>${version.jackson}</version>
-    </dependency>
-
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>

--- a/core/http-endpoint-guards/src/main/java/ai/floedb/floecat/http/guards/HttpEndpointGuards.java
+++ b/core/http-endpoint-guards/src/main/java/ai/floedb/floecat/http/guards/HttpEndpointGuards.java
@@ -1,0 +1,417 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.http.guards;
+
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * Transport gates for an operator-supplied catalog endpoint, shared by every client that accepts
+ * one.
+ *
+ * <p>Deny by default. HTTPS is required; cleartext to a loopback host and a base URI naming a
+ * private address literal each need an explicit opt-in; link-local, wildcard and multicast literals
+ * are always refused, the cloud metadata address among them.
+ *
+ * <p>The checks are deliberately literal-only. Deciding them for a hostname means resolving it, and
+ * a resolver here disagrees with the resolution {@code HttpClient} performs at connect time. A
+ * hostname pointing at a private address is therefore network policy rather than something this
+ * class claims to prevent.
+ *
+ * <p>Extracted from {@code HttpUnityCatalogClient}, which held the only copy. The subtleties are
+ * why this is shared rather than reimplemented per client: a zone-scoped literal parses as a
+ * hostname and would skip the address-class gate, an all-numeric host is resolved modulo 2^32 by
+ * the transport so {@code 7147006462} reaches the metadata address, and {@code localhost} matches
+ * exactly rather than as a suffix because a tenant-controlled zone can point {@code x.localhost} at
+ * a public address that would then receive an Authorization header in cleartext.
+ */
+public final class HttpEndpointGuards {
+
+  /** Property permitting cleartext HTTP to a loopback host. */
+  public static final String ALLOW_LOOPBACK_PROPERTY =
+      "floecat.security.allow-loopback-catalog-endpoints";
+
+  private static final String ALLOW_LOOPBACK_ENV =
+      "FLOECAT_SECURITY_ALLOW_LOOPBACK_CATALOG_ENDPOINTS";
+
+  /** Property permitting a base URI that names a private address literal. */
+  public static final String ALLOW_PRIVATE_PROPERTY =
+      "floecat.security.allow-private-catalog-endpoints";
+
+  private static final String ALLOW_PRIVATE_ENV =
+      "FLOECAT_SECURITY_ALLOW_PRIVATE_CATALOG_ENDPOINTS";
+
+  private HttpEndpointGuards() {}
+
+  public static URI requireAllowedEndpoint(URI baseUri, String subject) {
+    Objects.requireNonNull(baseUri, "baseUri");
+    // Before any check whose message interpolates the URI. Credentials belong in
+    // UnityCatalogAuthentication, and the JDK client does not transmit them.
+    if (baseUri.getUserInfo() != null
+        || baseUri.getRawUserInfo() != null
+        || authorityCarriesUserInfo(baseUri)) {
+      throw new IllegalArgumentException(
+          subject + " must not contain userinfo; supply credentials out of band");
+    }
+    if (!baseUri.isAbsolute()) {
+      throw new IllegalArgumentException(subject + " must be absolute: " + display(baseUri));
+    }
+    String scheme = baseUri.getScheme();
+    boolean https = "https".equalsIgnoreCase(scheme);
+    boolean loopbackHttp =
+        "http".equalsIgnoreCase(scheme)
+            && allowLoopbackCleartext()
+            && isLoopbackHost(baseUri.getHost());
+    if (!https && !loopbackHttp) {
+      throw new IllegalArgumentException(
+          subject
+              + " must use HTTPS, except HTTP is allowed for loopback hosts when "
+              + ALLOW_LOOPBACK_PROPERTY
+              + " is set: "
+              + display(baseUri));
+    }
+    if (baseUri.getHost() == null) {
+      throw new IllegalArgumentException(subject + " must include a host: " + display(baseUri));
+    }
+    if (baseUri.getRawQuery() != null || baseUri.getRawFragment() != null) {
+      throw new IllegalArgumentException(
+          subject + " must not include a query or fragment: " + display(baseUri));
+    }
+    // -1 is absent. URI and HttpRequest.Builder both accept 65536; InetSocketAddress rejects it at
+    // send time, where it is reported as TRANSPORT.
+    int port = baseUri.getPort();
+    if (port != -1 && (port < 1 || port > 65535)) {
+      throw new IllegalArgumentException(
+          subject + " port must be between 1 and 65535: " + display(baseUri));
+    }
+    assertAddressClassAllowed(baseUri, subject);
+    return baseUri;
+  }
+
+  /**
+   * Rejects address classes a tenant-supplied connector URI must not name.
+   *
+   * <p>Link-local, wildcard, multicast, broadcast and {@code 0.0.0.0/8} literals are refused
+   * outright; no catalog is reachable at one, and {@code https://169.254.169.254} is otherwise a
+   * well-formed HTTPS URI for a cloud metadata service. Site-local literals require {@link
+   * #ALLOW_PRIVATE_PROPERTY}, since an internal catalog is an ordinary deployment. Loopback is
+   * allowed; cleartext to it is governed by {@link #ALLOW_LOOPBACK_PROPERTY}.
+   *
+   * <p>Literals only: resolving a hostname here would disagree with the resolution {@code
+   * HttpClient} performs at connect time, so a hostname is out of scope.
+   */
+  private static void assertAddressClassAllowed(URI baseUri, String subject) {
+    String host = unbracket(baseUri.getHost());
+    // A zone id names a local interface, and ofLiteral cannot parse one. Left to the catch below a
+    // scoped literal reads as a hostname and skips this gate entirely, so fe80::1%eth0 admits a
+    // link-local address. The transport cannot carry one either.
+    if (host.indexOf('%') >= 0) {
+      throw new IllegalArgumentException(
+          subject + " must not name a zone-scoped address: " + display(baseUri));
+    }
+    InetAddress address;
+    try {
+      address = InetAddress.ofLiteral(host);
+    } catch (IllegalArgumentException notALiteral) {
+      // A host of only digits and dots is not a hostname -- a DNS name cannot be entirely numeric
+      // -- and the resolver the transport uses accepts these modulo 2^32 even though ofLiteral
+      // refuses them: 7147006462 resolves to 169.254.169.254 and 4294967296 to 0.0.0.0. Returning
+      // here would hand the transport a link-local or wildcard target this gate refuses by name.
+      if (isNumericHost(host)) {
+        throw new IllegalArgumentException(
+            subject
+                + " must not name a numeric host that is not an address literal: "
+                + display(baseUri));
+      }
+      return;
+    }
+    if (address.isLoopbackAddress()) {
+      return;
+    }
+    if (address.isLinkLocalAddress()
+        || address.isAnyLocalAddress()
+        || address.isMulticastAddress()
+        || isBroadcastOrThisNetwork(address)) {
+      throw new IllegalArgumentException(
+          subject
+              + " must not name a link-local, wildcard or multicast address: "
+              + display(baseUri));
+    }
+    if (isSiteLocal(address) && !allowPrivateAddresses()) {
+      throw new IllegalArgumentException(
+          subject
+              + " names a private address, which requires "
+              + ALLOW_PRIVATE_PROPERTY
+              + ": "
+              + display(baseUri));
+    }
+  }
+
+  private static boolean isLoopbackHost(String host) {
+    if (host == null) {
+      return false;
+    }
+    String normalized = host.toLowerCase(Locale.ROOT);
+    if (normalized.startsWith("[") && normalized.endsWith("]")) {
+      normalized = normalized.substring(1, normalized.length() - 1);
+    }
+    if (normalized.endsWith(".")) {
+      normalized = normalized.substring(0, normalized.length() - 1);
+    }
+    // Exactly "localhost", not any *.localhost name. RFC 6761 says such names should resolve to
+    // loopback, but nothing here enforces that and this gate does not resolve: a zone the tenant
+    // controls can point catalog.localhost at a public address, and the Authorization header would
+    // then go out in cleartext to it. CredentialResolverSupport, which this mirrors, has no suffix
+    // rule either -- it resolves and requires every answer to be loopback.
+    if (normalized.equals("localhost")) {
+      return true;
+    }
+    // ofLiteral, never getByName: a host this cannot decide is denied, not resolved. A resolver
+    // here disagrees with the one HttpClient uses at connect time. Character-shape pre-filters are
+    // no substitute: "4294967296" and "1." are all digits and dots yet parse as no address.
+    try {
+      return InetAddress.ofLiteral(normalized).isLoopbackAddress();
+    } catch (IllegalArgumentException notAnAddressLiteral) {
+      return false;
+    }
+  }
+
+  /**
+   * Whether the authority embeds userinfo that {@link URI#getUserInfo()} does not report. {@code
+   * java.net.URI} populates it only for a server-based authority; a host it rejects as a hostname
+   * -- an underscore, a non-numeric port -- yields a registry-based authority with the credential
+   * still in the raw string. {@code @} delimits userinfo and has no other role there.
+   */
+  private static boolean authorityCarriesUserInfo(URI baseUri) {
+    String authority = baseUri.getRawAuthority();
+    return authority != null && authority.indexOf('@') >= 0;
+  }
+
+  /**
+   * The base URI as it may appear in a rejection message: scheme, authority and path only.
+   *
+   * <p>A query is a common place for a token, and the userinfo guard covers only credentials in the
+   * authority. Every gate here reports the value it rejected, so the display form drops the two
+   * components that carry data rather than address the endpoint.
+   */
+  private static String display(URI baseUri) {
+    if (baseUri == null) {
+      return "null";
+    }
+    StringBuilder shown = new StringBuilder();
+    if (baseUri.getScheme() != null) {
+      shown.append(baseUri.getScheme()).append("://");
+    }
+    // Parsed components only, never the raw authority. URI reports a host it cannot parse as
+    // server-based -- an underscore, a bad port, or a percent-encoded delimiter such as
+    // alice:s3cr3t%40host -- by leaving getHost() and both userinfo accessors null while the raw
+    // authority keeps the credential. Echoing that here would undo the userinfo guard for exactly
+    // the inputs it cannot recognise.
+    if (baseUri.getHost() == null) {
+      shown.append("<unparseable-authority>");
+    } else {
+      shown.append(baseUri.getHost());
+      if (baseUri.getPort() != -1) {
+        shown.append(':').append(baseUri.getPort());
+      }
+    }
+    if (baseUri.getRawPath() != null) {
+      shown.append(baseUri.getRawPath());
+    }
+    return shown.isEmpty() ? "<empty>" : shown.toString();
+  }
+
+  private static String unbracket(String host) {
+    String value = host == null ? "" : host.trim();
+    if (value.startsWith("[") && value.endsWith("]")) {
+      value = value.substring(1, value.length() - 1);
+    }
+    return value.endsWith(".") ? value.substring(0, value.length() - 1) : value;
+  }
+
+  /** Whether every character is an ASCII digit or a dot. Deliberately not {@code isDigit}. */
+  private static boolean isNumericHost(String host) {
+    if (host.isEmpty()) {
+      return false;
+    }
+    for (int i = 0; i < host.length(); i++) {
+      char c = host.charAt(i);
+      if ((c < '0' || c > '9') && c != '.') {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /** IPv4 RFC 1918 and IPv6 unique-local, which {@code isSiteLocalAddress} misses for fc00::/7. */
+  private static boolean isSiteLocal(InetAddress address) {
+    if (address.isSiteLocalAddress()) {
+      return true;
+    }
+    byte[] bytes = address.getAddress();
+    return bytes.length == 16 && (bytes[0] & 0xFE) == 0xFC;
+  }
+
+  /**
+   * IPv4 limited broadcast and {@code 0.0.0.0/8}. {@code isMulticastAddress} covers 224/4 and
+   * {@code isAnyLocalAddress} only the exact wildcard, so neither address is caught by them.
+   */
+  private static boolean isBroadcastOrThisNetwork(InetAddress address) {
+    byte[] bytes = address.getAddress();
+    if (bytes.length != 4) {
+      return false;
+    }
+    boolean broadcast = true;
+    for (byte octet : bytes) {
+      broadcast &= octet == (byte) 0xFF;
+    }
+    return broadcast || bytes[0] == 0;
+  }
+
+  private static boolean allowPrivateAddresses() {
+    return Boolean.parseBoolean(
+        System.getProperty(
+            ALLOW_PRIVATE_PROPERTY, System.getenv().getOrDefault(ALLOW_PRIVATE_ENV, "false")));
+  }
+
+  private static boolean allowLoopbackCleartext() {
+    return Boolean.parseBoolean(
+        System.getProperty(
+            ALLOW_LOOPBACK_PROPERTY, System.getenv().getOrDefault(ALLOW_LOOPBACK_ENV, "false")));
+  }
+
+  /**
+   * The address-class policy alone, for a second tenant-supplied endpoint in a client's care.
+   *
+   * <p>A client that derives a token endpoint from a catalog URI POSTs credentials to a URI the
+   * tenant chose, which is the one request in such a path carrying a secret. It has to answer this
+   * question the same way the catalog endpoint does.
+   */
+  public static void assertEndpointAddressAllowed(URI endpoint) {
+    assertAddressClassAllowed(Objects.requireNonNull(endpoint, "endpoint"), "Catalog endpoint");
+  }
+
+  /**
+   * HTTPS unless a deployment says otherwise: {@value #ALLOW_CLEARTEXT_S3_PROPERTY}, or the
+   * environment variable {@value #ALLOW_CLEARTEXT_S3_ENV}.
+   */
+  public static final String ALLOW_CLEARTEXT_S3_PROPERTY =
+      "floecat.security.allow-cleartext-s3-endpoints";
+
+  public static final String ALLOW_CLEARTEXT_S3_ENV =
+      "FLOECAT_SECURITY_ALLOW_CLEARTEXT_S3_ENDPOINTS";
+
+  /**
+   * Rejects a storage endpoint that names somewhere the service should not be made to reach.
+   *
+   * <p>Checked when a client is opened, before anything connects. The value is tenant-supplied and
+   * reaches {@code endpointOverride}, so validation would otherwise issue signed S3 requests
+   * wherever it pointed, and the same value travels on as client-safe routing to reconcile and
+   * query workers.
+   *
+   * <p>HTTPS unless a deployment says otherwise. An S3 request carries a SigV4 signature rather
+   * than a bearer secret, which would make cleartext defensible -- except that a provider vending
+   * storage credentials publishes a session token, every signed request then carries it in {@code
+   * X-Amz-Security-Token}, and a session token is replayable against the table's prefix by anyone
+   * who sees it for as long as it lives.
+   *
+   * <p>The escape hatch stays, because an S3-compatible endpoint on a private network commonly is
+   * HTTP -- MinIO and LocalStack both -- but it is a deployment saying so rather than a default.
+   * The address-class rule still applies on top of either scheme: it is the one that refuses {@code
+   * 169.254.169.254}.
+   *
+   * @param subject how the endpoint is named in a refusal, such as {@code "Unity Catalog
+   *     s3.endpoint"}
+   * @throws IllegalArgumentException naming what was refused, for a caller to wrap in whatever its
+   *     own contract raises
+   */
+  public static void requireUsableStorageEndpoint(String endpoint, String subject) {
+    Objects.requireNonNull(subject, "subject");
+    if (endpoint == null || endpoint.isBlank()) {
+      return;
+    }
+    URI uri;
+    try {
+      uri = URI.create(endpoint);
+    } catch (IllegalArgumentException malformed) {
+      // The cause is never attached, and neither is the value. URI.create quotes the whole input in
+      // its message and again in the nested URISyntaxException, so an endpoint carrying userinfo or
+      // a signed query -- which is what the checks below exist to refuse -- put that secret into
+      // the chain a validation failure logs, on the one path where the value was never parseable
+      // enough to be redacted. A parse position says where without saying what.
+      throw new IllegalArgumentException(
+          subject + " is not a valid URI: " + parsePosition(malformed));
+    }
+    String scheme = uri.getScheme();
+    if (!uri.isAbsolute()
+        || uri.getHost() == null
+        || !("https".equalsIgnoreCase(scheme) || "http".equalsIgnoreCase(scheme))
+        || uri.getRawUserInfo() != null
+        || uri.getRawQuery() != null
+        || uri.getRawFragment() != null) {
+      throw new IllegalArgumentException(
+          subject + " must be an absolute http or https URI with no userinfo, query or fragment");
+    }
+    if ("http".equalsIgnoreCase(scheme) && !allowCleartextS3Endpoints()) {
+      throw new IllegalArgumentException(
+          subject
+              + " must use HTTPS: a vended credential carries a session token, which travels in a"
+              + " header and is replayable. Set "
+              + ALLOW_CLEARTEXT_S3_ENV
+              + "=true to allow cleartext on a trusted network");
+    }
+    assertAddressClassAllowed(uri, subject);
+  }
+
+  /**
+   * Where a parse failed, never what failed to parse.
+   *
+   * <p>{@code URI.create} reports "Malformed escape pair at index 34: <the whole input>". The index
+   * is the diagnostic; the input is the secret.
+   */
+  private static String parsePosition(IllegalArgumentException malformed) {
+    Throwable cause = malformed.getCause();
+    String message =
+        cause instanceof URISyntaxException syntax
+            ? syntax.getReason() + " at index " + syntax.getIndex()
+            : "could not be parsed";
+    return message;
+  }
+
+  private static boolean allowCleartextS3Endpoints() {
+    return Boolean.parseBoolean(
+        System.getProperty(
+            ALLOW_CLEARTEXT_S3_PROPERTY,
+            System.getenv().getOrDefault(ALLOW_CLEARTEXT_S3_ENV, "false")));
+  }
+
+  /**
+   * Whether cleartext is permitted to this endpoint because it is loopback and the opt-in is set.
+   *
+   * <p>Exposed so a derived token endpoint can answer it the same way. An integration against an
+   * HTTP loopback catalog, the ordinary local-dev shape, derives its token endpoint from the
+   * catalog URI and inherits the {@code http} scheme; holding that endpoint to HTTPS with no escape
+   * hatch makes client-credentials authentication impossible to run locally while the catalog
+   * request beside it is allowed.
+   */
+  public static boolean isCleartextLoopbackAllowed(URI endpoint) {
+    Objects.requireNonNull(endpoint, "endpoint");
+    return allowLoopbackCleartext() && isLoopbackHost(endpoint.getHost());
+  }
+}

--- a/core/http-endpoint-guards/src/main/java/ai/floedb/floecat/http/guards/HttpResponseSnippets.java
+++ b/core/http-endpoint-guards/src/main/java/ai/floedb/floecat/http/guards/HttpResponseSnippets.java
@@ -1,0 +1,317 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.http.guards;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Duration;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.regex.Pattern;
+
+/**
+ * Turns an upstream response body into something safe to put in a failure message.
+ *
+ * <p>A catalog client sends {@code Authorization} on every request, and a debug handler or a
+ * misconfigured gateway will echo request headers back in an error body. That body is interpolated
+ * into an exception, which reaches validation responses and operator logs, so without this the
+ * tenant's own token travels with the diagnosis.
+ *
+ * <p>Shared rather than copied because it is a security control with two callers. A second copy
+ * drifts, and the copy that drifts is the one nobody reads.
+ */
+public final class HttpResponseSnippets {
+
+  /**
+   * How many encoding layers {@link #couldStillHold} will peel before withholding outright.
+   *
+   * <p>Bounds the work on a body that decodes to something new indefinitely. Ordinary bodies cost
+   * one pass: a text holding no {@code %} and no backslash is returned unchanged by both decoders,
+   * so the loop stops on its first comparison.
+   */
+  private static final int MAX_DECODE_LAYERS = 4;
+
+  private static final Pattern BEARER_TOKEN = Pattern.compile("(?i)bearer\\s+[A-Za-z0-9._~+/=-]+");
+
+  /**
+   * The value following an {@code Authorization} header name, whatever shape it is in.
+   *
+   * <p>Every other pass here has to recognise the credential: the caller's literal, its JSON
+   * escapes, the token68 grammar. Each one has been defeated in turn by a rendering nobody
+   * enumerated -- a colon, an escaped solidus, a backslash-u escape, and percent-encoding, which is
+   * how {@code abc/SECRET} reflected as {@code abc%2FSECRET} kept its tail. This pass recognises
+   * the header *name* instead and discards everything after it up to the first delimiter, so the
+   * encoding of the value stops mattering. An echoed Authorization header is the case all of this
+   * exists for, and its value is never worth reading.
+   */
+  private static final Pattern AUTHORIZATION_VALUE =
+      Pattern.compile("(?i)(authorization[\"']?\\s*[:=]\\s*[\"']?)([^\"',}\\]\\n]*)");
+
+  private HttpResponseSnippets() {}
+
+  /**
+   * Reads a response body under a deadline, closing the stream if it stalls.
+   *
+   * <p>{@code HttpRequest.timeout} only gates receipt of the headers, because {@code ofInputStream}
+   * returns as soon as they arrive. A server that sends headers and then stops leaves the read
+   * blocked with nothing to interrupt it, which occupies a reconcile worker indefinitely.
+   *
+   * <p>On a virtual thread of its own rather than the common pool: the read blocks for the whole
+   * download, and {@code ForkJoinPool.commonPool()} has parallelism one on a small container, so
+   * two concurrent calls queue behind each other and the waiting one fails on this deadline while
+   * the server has already answered.
+   *
+   * <p>Closing the stream is what releases a genuinely stalled read; abandoning the future alone
+   * would leave the reader blocked in {@code readNBytes}.
+   *
+   * @param subject how the upstream is named in the failure, such as {@code "Unity Catalog"}
+   */
+  public static byte[] readWithin(InputStream stream, int limit, Duration deadline, String subject)
+      throws IOException {
+    var body = new CompletableFuture<byte[]>();
+    Thread.ofVirtual()
+        .start(
+            () -> {
+              try {
+                body.complete(stream.readNBytes(limit + 1));
+              } catch (Throwable failure) {
+                body.completeExceptionally(failure);
+              }
+            });
+    try {
+      return body.get(deadline.toMillis(), TimeUnit.MILLISECONDS);
+    } catch (TimeoutException stalled) {
+      closeQuietly(stream);
+      throw new IOException(subject + " response body stalled after " + deadline, stalled);
+    } catch (InterruptedException interrupted) {
+      Thread.currentThread().interrupt();
+      closeQuietly(stream);
+      throw new IOException("Interrupted reading the " + subject + " response body", interrupted);
+    } catch (ExecutionException failure) {
+      Throwable cause = failure.getCause();
+      throw cause instanceof IOException io ? io : new IOException(cause);
+    }
+  }
+
+  private static void closeQuietly(InputStream stream) {
+    try {
+      stream.close();
+    } catch (IOException ignored) {
+      // Closing is how a stalled read is released; a failure to close adds nothing to report.
+    }
+  }
+
+  /** Removes bearer tokens from text on its way into a failure message. */
+  public static String redactBearerTokens(String text) {
+    if (text == null) {
+      return "";
+    }
+    // The header's whole value first, then the grammar. The first does not care how the value was
+    // encoded; the second still covers a token quoted without its header name beside it.
+    String withoutHeader = AUTHORIZATION_VALUE.matcher(text).replaceAll("$1<redacted>");
+    return BEARER_TOKEN.matcher(withoutHeader).replaceAll("Bearer <redacted>");
+  }
+
+  /**
+   * {@link #redactBearerTokens} plus the caller's own token, wherever it appears.
+   *
+   * <p>The pattern above matches the RFC token68 alphabet, which is what a bearer token is supposed
+   * to be. A caller may hold one that is not: any character that a header value permits is accepted
+   * and sent, so a token carrying a colon matched only up to it and the remainder reached the
+   * message unredacted -- defeating the control in exactly the echoed-header case it exists for. A
+   * caller that knows its own secret can say so, and then nothing depends on guessing the shape.
+   */
+  public static String redactSecrets(String text, String secret) {
+    if (text == null) {
+      return "";
+    }
+    // The caller's own value first. The pattern below rewrites the part of a token that does match
+    // the grammar, which destroys the literal it would then be searched for: redacting the pattern
+    // first turned "Bearer part1:part2" into "Bearer <redacted>:part2" and left the suffix behind.
+    String withoutSecret = text;
+    if (secret != null && !secret.isBlank()) {
+      // The escaped form first, then the raw one. A server echoing the Authorization header into a
+      // JSON body escapes the quotes and backslashes in it, so a token holding either -- both are
+      // legal in a header value, and this client accepts what the header permits -- appears as
+      // \" or \\ and the literal search misses it. The pattern misses it too, since a quote is
+      // outside the token68 alphabet, so the tail of such a token survived both passes.
+      // The escaped renderings first, longest-transformed first, then the raw one. A serializer
+      // may escape any subset of these three, so each is tried on its own as well as together:
+      // the solidus matters most, because it is inside the token68 alphabet and common in real
+      // tokens, so "abc/SECRET" echoed as "abc\\/SECRET" was missed by the literal search and cut
+      // at the backslash by the pattern -- leaving most of the token in the message.
+      for (String escaped : escapedForms(secret)) {
+        withoutSecret = withoutSecret.replace(escaped, "<redacted>");
+      }
+      withoutSecret = withoutSecret.replace(secret, "<redacted>");
+    }
+    // Then fail closed. The forms above are the ones worth enumerating; a serializer is free to
+    // escape in a way none of them match, so rather than grow that list until one entry is wrong,
+    // ask whether anything the body could de-escape to still holds the secret and withhold it if
+    // so. A false positive costs a diagnostic; a false negative costs the credential.
+    //
+    // Asked before the pattern runs, not after: the pattern rewrites the part of a token that does
+    // match the grammar, so once "Bearer abc/SECRET" has become "Bearer <redacted>" plus a tail,
+    // the literal this looks for no longer exists. The same ordering mistake as bounding before
+    // redacting, one layer further in.
+    if (secret != null && !secret.isBlank() && couldStillHold(withoutSecret, secret)) {
+      return "<withheld: the response echoed the credential>";
+    }
+    return redactBearerTokens(withoutSecret);
+  }
+
+  /** The ways a JSON serializer may render the secret, each escape applied and combined. */
+  private static List<String> escapedForms(String secret) {
+    LinkedHashSet<String> forms = new LinkedHashSet<>();
+    forms.add(secret.replace("\\", "\\\\").replace("\"", "\\\"").replace("/", "\\/"));
+    forms.add(secret.replace("\\", "\\\\").replace("\"", "\\\""));
+    forms.add(secret.replace("/", "\\/"));
+    forms.add(secret.replace("\"", "\\\""));
+    forms.add(secret.replace("\\", "\\\\"));
+    forms.remove(secret);
+    return List.copyOf(forms);
+  }
+
+  /**
+   * Whether any de-escaping of this text would reveal the secret.
+   *
+   * <p>Deliberately a superset of a real JSON unescape: every backslash is dropped and every {@code
+   * a backslash-u escape} decoded, which can join characters an unescape would not. That direction
+   * is the safe one -- it can only withhold a body that was in fact clean, never publish one that
+   * was not.
+   */
+  private static boolean couldStillHold(String text, String secret) {
+    // Layer by layer, until the text stops changing. One pass leaves a value encoded twice intact:
+    // "abc%252FSECRET" decodes once to "abc%2FSECRET", which holds no secret to find, and the log
+    // then carries something a reader decodes again to recover the credential.
+    //
+    // Both sides are de-escaped the same way. Stripping backslashes from the body alone destroys
+    // the evidence for a secret that contains one: "\\SECRET" strips to "SECRET" and would be
+    // compared against the raw "\\SECRET". Comparing like with like errs towards withholding.
+    String bare = decodeUnicodeEscapes(secret).replace("\\", "");
+    String current = text;
+    for (int layer = 0; layer < MAX_DECODE_LAYERS; layer++) {
+      String stripped = current.replace("\\", "");
+      if (stripped.contains(secret) || stripped.contains(bare)) {
+        return true;
+      }
+      String next = decodePercentEscapes(decodeUnicodeEscapes(current));
+      if (next.equals(current)) {
+        return false;
+      }
+      current = next;
+    }
+    // Still decoding to something new after the bound. Whatever that is, it is not a body worth
+    // publishing to find out.
+    return true;
+  }
+
+  /** Percent escapes decoded, so the net sees a value a proxy reflected in encoded form. */
+  private static String decodePercentEscapes(String text) {
+    if (text.indexOf('%') < 0) {
+      return text;
+    }
+    StringBuilder out = new StringBuilder(text.length());
+    for (int i = 0; i < text.length(); i++) {
+      if (text.charAt(i) == '%' && i + 2 < text.length()) {
+        try {
+          out.append((char) Integer.parseInt(text.substring(i + 1, i + 3), 16));
+          i += 2;
+          continue;
+        } catch (NumberFormatException notAnEscape) {
+          // Not an escape after all; copy the percent verbatim.
+        }
+      }
+      out.append(text.charAt(i));
+    }
+    return out.toString();
+  }
+
+  private static String decodeUnicodeEscapes(String text) {
+    if (text.indexOf('\\') < 0) {
+      return text;
+    }
+    StringBuilder out = new StringBuilder(text.length());
+    for (int i = 0; i < text.length(); i++) {
+      if (text.charAt(i) == '\\'
+          && i + 5 < text.length()
+          && (text.charAt(i + 1) == 'u' || text.charAt(i + 1) == 'U')) {
+        try {
+          out.append((char) Integer.parseInt(text.substring(i + 2, i + 6), 16));
+          i += 5;
+          continue;
+        } catch (NumberFormatException notAnEscape) {
+          // Not an escape after all; fall through and copy the backslash verbatim.
+        }
+      }
+      out.append(text.charAt(i));
+    }
+    return out.toString();
+  }
+
+  /**
+   * A bounded, redacted snippet of a response body.
+   *
+   * <p>Redacted first and bounded after. The reverse cut a secret in half before anything looked
+   * for it: the remaining fragment no longer matched a caller's literal token, and for a token
+   * outside the {@code token68} grammar the pattern stopped at the first character it does not
+   * accept, so the suffix between there and the bound survived into the snippet.
+   *
+   * <p>Redacting only a window around the bound is not enough either, which is why the whole body
+   * is scanned. A replacement is shorter than what it replaces, so redacting pulls later text
+   * forward into the bounded range -- text that a window would not have reached, and that can hold
+   * another occurrence of the same secret.
+   *
+   * <p>The cost is a scan of the whole body on a failure path. It is bounded by the caller's own
+   * response cap, and a failure that is about to be logged is not where a copy matters.
+   */
+  public static String bounded(String value, int maxChars) {
+    return bounded(value, maxChars, null);
+  }
+
+  /** {@link #bounded} that also removes the caller's own token, by value. */
+  public static String bounded(String value, int maxChars, String secret) {
+    if (value == null) {
+      return "";
+    }
+    String redacted = redactSecrets(value, secret);
+    return redacted.substring(0, Math.min(redacted.length(), maxChars));
+  }
+
+  /**
+   * {@link #bounded} for a body that reaches a single-line message, with an ellipsis where the
+   * bound cut it.
+   */
+  public static String boundedSingleLine(String body, int maxChars) {
+    return boundedSingleLine(body, maxChars, null);
+  }
+
+  /** {@link #boundedSingleLine} that also removes the caller's own token. */
+  public static String boundedSingleLine(String body, int maxChars, String secret) {
+    if (body == null) {
+      return "";
+    }
+    String flattened = body.replace('\n', ' ').replace('\r', ' ').trim();
+    // Redact, then bound. See bounded() for why the order is this way round and why the whole body
+    // is scanned rather than a window at the cut.
+    String redacted = redactSecrets(flattened, secret);
+    return redacted.length() <= maxChars ? redacted : redacted.substring(0, maxChars) + "...";
+  }
+}

--- a/core/http-endpoint-guards/src/test/java/ai/floedb/floecat/http/guards/HttpEndpointGuardsTest.java
+++ b/core/http-endpoint-guards/src/test/java/ai/floedb/floecat/http/guards/HttpEndpointGuardsTest.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.http.guards;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.net.URI;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The gates, tested where they live.
+ *
+ * <p>This module exists because a security control with two callers drifts when it is copied. The
+ * same argument reaches its tests: with coverage only in the consumers, a change here is checked by
+ * whichever consumer happens to exercise the branch, and {@code mvn -pl} on this module proves
+ * nothing. Both of these have since been broken and repaired with the failing test living in
+ * another module.
+ */
+class HttpEndpointGuardsTest {
+
+  private static final String SUBJECT = "Catalog endpoint";
+
+  /**
+   * A zone id makes a literal parse as a hostname, which skips the address-class gate entirely.
+   * {@code fe80::1%eth0} would otherwise reach a link-local interface with the Authorization header
+   * attached.
+   */
+  @Test
+  void refusesAZoneScopedLiteral() {
+    assertThatThrownBy(
+            () ->
+                HttpEndpointGuards.requireAllowedEndpoint(
+                    URI.create("https://[fe80::1%25eth0]/api"), SUBJECT))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("zone-scoped");
+  }
+
+  /**
+   * An all-numeric host is not a hostname, and the transport resolves one modulo 2^32 -- so {@code
+   * 7147006462} reaches 169.254.169.254, the cloud metadata address.
+   */
+  @Test
+  void refusesAnAllNumericHostThatIsNotAnAddressLiteral() {
+    assertThatThrownBy(
+            () ->
+                HttpEndpointGuards.requireAllowedEndpoint(
+                    URI.create("https://7147006462/api"), SUBJECT))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("numeric host");
+  }
+
+  /** Cleartext is refused, since the Authorization header goes out on every request. */
+  @Test
+  void refusesCleartextForANonLoopbackHost() {
+    assertThatThrownBy(
+            () ->
+                HttpEndpointGuards.requireAllowedEndpoint(
+                    URI.create("http://sharing.example.com/api"), SUBJECT))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatCode(
+            () ->
+                HttpEndpointGuards.requireAllowedEndpoint(
+                    URI.create("https://sharing.example.com/api"), SUBJECT))
+        .doesNotThrowAnyException();
+  }
+
+  /** Credentials belong in the header, not in a URI that reaches logs and error messages. */
+  @Test
+  void refusesUserInfo() {
+    assertThatThrownBy(
+            () ->
+                HttpEndpointGuards.requireAllowedEndpoint(
+                    URI.create("https://user:pass@sharing.example.com/api"), SUBJECT))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("userinfo");
+  }
+
+  /**
+   * The caller's own token is removed before the character bound, not after.
+   *
+   * <p>Bounding first cut a token in half before either pass looked for it: the literal no longer
+   * matched, and the pattern stops at the first character outside the token68 grammar, so
+   * everything between a colon and the cut survived into a message that reaches operator logs.
+   */
+  @Test
+  void redactsACallerTokenThatStraddlesTheBound() {
+    String secret = "part1:part2-SECRETSUFFIX";
+    String body = "x".repeat(1980) + "Bearer " + secret + " trailing";
+
+    String snippet = HttpResponseSnippets.boundedSingleLine(body, 2_000, secret);
+
+    assertThat(snippet).doesNotContain("part2").doesNotContain("SECRETSUFFIX");
+  }
+
+  /**
+   * Every occurrence, not only the one inside the bound. A replacement is shorter than what it
+   * replaces, so redacting pulls later text forward into the bounded range -- which is why the
+   * whole body is scanned rather than a window around the cut.
+   */
+  @Test
+  void redactsAnOccurrenceThatRedactionPullsIntoRange() {
+    String secret = "part1:part2-SECRETSUFFIX";
+    String body =
+        "y".repeat(1900) + "Bearer " + secret + "z".repeat(60) + secret + "z".repeat(60) + secret;
+
+    assertThat(HttpResponseSnippets.boundedSingleLine(body, 2_000, secret))
+        .doesNotContain("part1:");
+  }
+
+  /** A token shaped the way the grammar says is still covered when the caller names none. */
+  @Test
+  void redactsABearerTokenWithNoCallerSecretGiven() {
+    assertThat(HttpResponseSnippets.boundedSingleLine("echo Bearer abc123.def", 2_000, null))
+        .contains("Bearer <redacted>")
+        .doesNotContain("abc123");
+  }
+
+  /**
+   * The parser's own exception is the leak. {@code URI.create} quotes the whole input in its
+   * message and again in the nested {@code URISyntaxException}, so an endpoint carrying userinfo --
+   * which is what this method exists to refuse -- put that secret into the chain a validation
+   * failure logs, on the one path where the value was never parseable enough to be redacted.
+   */
+  @Test
+  void aMalformedEndpointDoesNotCarryItsValueIntoTheCauseChain() {
+    String endpoint = "https://user:s3cr3t-PASSWORD@host/%ZZ";
+
+    assertThatThrownBy(() -> HttpEndpointGuards.requireUsableStorageEndpoint(endpoint, SUBJECT))
+        .isInstanceOf(IllegalArgumentException.class)
+        .satisfies(
+            e -> {
+              for (Throwable t = e; t != null; t = t.getCause()) {
+                assertThat(String.valueOf(t.getMessage()))
+                    .doesNotContain("s3cr3t-PASSWORD")
+                    .doesNotContain(endpoint);
+              }
+            });
+  }
+
+  /** The position still reaches the message, since it is the half that diagnoses anything. */
+  @Test
+  void aMalformedEndpointStillSaysWhereItFailed() {
+    assertThatThrownBy(
+            () -> HttpEndpointGuards.requireUsableStorageEndpoint("https://host/%ZZ", SUBJECT))
+        .hasMessageContaining("index");
+  }
+
+  /**
+   * A token holding a quote or a backslash appears escaped inside a JSON body, so the literal
+   * search missed it -- and the pattern missed it too, because a quote is outside the token68
+   * alphabet. Both characters are legal in a header value and this control accepts what a header
+   * permits.
+   */
+  @Test
+  void redactsATokenThatAJsonBodyEscaped() {
+    String secret = "abc\"def";
+    String body = "{\"error\":\"upstream sent Authorization: Bearer abc\\\"def\"}";
+
+    assertThat(HttpResponseSnippets.boundedSingleLine(body, 2_000, secret))
+        .doesNotContain("abc")
+        .doesNotContain("def");
+  }
+
+  /**
+   * The solidus is the one that matters most: it is inside the token68 alphabet and common in real
+   * tokens, so {@code abc/SECRET} echoed as {@code abc\\/SECRET} was missed by the literal search
+   * and cut at the backslash by the pattern -- leaving most of the token in the message.
+   */
+  @Test
+  void redactsATokenWhoseSolidusAJsonBodyEscaped() {
+    String secret = "abc/SECRET";
+    String body = "{\"echo\":\"Authorization: Bearer abc\\/SECRET\"}";
+
+    assertThat(HttpResponseSnippets.boundedSingleLine(body, 2_000, secret))
+        .doesNotContain("SECRET");
+  }
+
+  /**
+   * And an escaping none of the named forms match is withheld rather than partly redacted. A false
+   * positive costs a diagnostic; a false negative costs the credential.
+   */
+  @Test
+  void aBodyEscapedInAnUnrecognisedWayIsWithheldRatherThanPartlyRedacted() {
+    String secret = "abc/SECRET";
+    // Every character escaped individually, which no form in the list constructs.
+    String body = "{\"echo\":\"Bearer a\\bc\\/SE\\CRET\"}";
+
+    assertThat(HttpResponseSnippets.boundedSingleLine(body, 2_000, secret))
+        .doesNotContain("SECRET")
+        .contains("withheld");
+  }
+
+  /** The same for a backslash, which a JSON body doubles. */
+  @Test
+  void redactsATokenWhoseBackslashAJsonBodyDoubled() {
+    String secret = "abc\\def";
+    String body = "{\"echo\":\"Bearer abc\\\\def\"}";
+
+    assertThat(HttpResponseSnippets.boundedSingleLine(body, 2_000, secret)).doesNotContain("def");
+  }
+
+  /**
+   * A secret that itself contains a backslash. Stripping backslashes from the body alone destroyed
+   * the evidence: the decoded body strips to {@code SECRET} and was compared against the raw {@code
+   * \\SECRET}, so nothing matched and nothing was withheld -- while the pattern missed it too, the
+   * token beginning with a backslash. The whole credential stayed reconstructable.
+   */
+  @Test
+  void aBackslashBearingSecretRenderedAsAUnicodeEscapeIsWithheld() {
+    String secret = "\\SECRET-TAIL";
+    String body = "{\"echo\":\"Bearer \\u005cSECRET-TAIL\"}";
+
+    assertThat(HttpResponseSnippets.boundedSingleLine(body, 2_000, secret))
+        .doesNotContain("SECRET-TAIL")
+        .contains("withheld");
+  }
+
+  /**
+   * A percent-encoded reflection. Every pass that has to recognise the credential has been defeated
+   * in turn by a rendering nobody enumerated -- a colon, an escaped solidus, a backslash-u escape,
+   * and this. Recognising the header name instead makes the encoding of the value stop mattering.
+   */
+  @Test
+  void anAuthorizationValueIsRedactedWhateverEncodingItArrivesIn() {
+    for (String body :
+        new String[] {
+          "upstream echoed Authorization: Bearer abc%2FSECRET-TAIL",
+          "{\"Authorization\":\"Bearer abc%2FSECRET-TAIL\"}",
+          "headers={Authorization=Bearer abc%2FSECRET-TAIL, Accept=*/*}",
+          // Deliberately not base64. The scheme is what this case is about -- the pass matches the
+          // header name, so the value's encoding is beside the point -- and a fixture that decodes
+          // to a credential pair is one a secret scanner reports, correctly, as a credential.
+          "Authorization: Basic NOT-A-REAL-CREDENTIAL-FIXTURE"
+        }) {
+      assertThat(HttpResponseSnippets.bounded(body, 500))
+          .as(body)
+          .doesNotContain("SECRET-TAIL")
+          .doesNotContain("NOT-A-REAL-CREDENTIAL-FIXTURE");
+    }
+  }
+
+  /** The header name survives, so the message still says what was echoed. */
+  @Test
+  void redactingTheValueLeavesTheHeaderNameReadable() {
+    assertThat(HttpResponseSnippets.bounded("Authorization: Bearer abc%2FSECRET", 500))
+        .contains("Authorization")
+        .contains("<redacted>");
+  }
+
+  /** A token quoted without its header name beside it is still covered by the grammar pass. */
+  @Test
+  void aBareBearerTokenIsStillRedacted() {
+    assertThat(HttpResponseSnippets.bounded("the token was Bearer abc123.def", 500))
+        .contains("Bearer <redacted>")
+        .doesNotContain("abc123");
+  }
+
+  /** A null secret is a caller with nothing to name, not a failure. */
+  @Test
+  void toleratesANullOrBlankSecret() {
+    assertThatCode(
+            () -> {
+              HttpResponseSnippets.redactSecrets("body", null);
+              HttpResponseSnippets.redactSecrets("body", "");
+              HttpResponseSnippets.redactSecrets(null, "secret");
+            })
+        .doesNotThrowAnyException();
+  }
+}

--- a/core/proto/src/main/proto/floecat/integration/catalog_integration.proto
+++ b/core/proto/src/main/proto/floecat/integration/catalog_integration.proto
@@ -27,6 +27,9 @@ enum CatalogIntegrationType {
   CIT_UNSPECIFIED = 0;
   CIT_ICEBERG_REST = 1;
   CIT_UNITY = 2;
+  // A Delta Sharing recipient. Directory access only: url mode returns presigned per-file URLs
+  // rather than credentials, which the storage contract cannot represent.
+  CIT_DELTA_SHARING = 3;
 }
 
 message OAuthClientCredentialsAuthentication {

--- a/docker/delta-sharing/stub_server.py
+++ b/docker/delta-sharing/stub_server.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+# Copyright 2026 Yellowbrick Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""A Delta Sharing recipient endpoint, for smoke coverage of directory access.
+
+The reference server implements directory access, but no published image does: the server-side
+change landed in March 2026 and the last deltaio/delta-sharing-server tag is from April 2024. This
+serves the four endpoints the Floecat client calls, over a fixture the harness has already written
+to LocalStack, so the vend has something to be checked against locally.
+
+Deliberately not a Delta Sharing server. It does not implement the query endpoint, paging, or url
+access, and it reads no Delta log: the schema and location it answers with are handed to it by the
+harness. What it exists to exercise is the recipient path -- bearer authorization, discovery, and a
+temporary credential over a location -- against the real client.
+
+Configuration, all through the environment:
+
+  SHARING_SHARE, SHARING_SCHEMA, SHARING_TABLE  the one table it shares
+  SHARING_TABLE_LOCATION                        s3:// prefix the credential is scoped to
+  SHARING_SCHEMA_JSON_FILE                      file holding the table's Delta schemaString, read
+                                                per request so the harness can write it after the
+                                                stack is up and the fixture exists
+  SHARING_BEARER_TOKEN                          the recipient token it accepts
+  SHARING_VENDED_ACCESS_KEY_ID                  the triad it vends
+  SHARING_VENDED_SECRET_ACCESS_KEY
+  SHARING_VENDED_SESSION_TOKEN
+  SHARING_ACCESS_MODES                          comma-separated, empty to send no field at all
+  SHARING_STATE_LOCATION                        whether the listing and metaData action name the
+                                                table's location. The reference server names it on
+                                                neither, only on the credential response, so "false"
+                                                reproduces the shape a real recipient meets.
+  SHARING_RESPONSE_FORMAT                       delta (default) or parquet, selecting whether the
+                                                metaData action nests the table's fields under
+                                                deltaMetadata the way a server honouring the
+                                                capability header does
+  SHARING_TLS_CERT, SHARING_TLS_KEY             PEM paths; the client requires HTTPS
+  SHARING_PORT                                  default 8443
+"""
+
+import json
+import os
+import ssl
+import sys
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+SHARE = os.environ.get("SHARING_SHARE", "floecat_smoke")
+SCHEMA = os.environ.get("SHARING_SCHEMA", "sharing")
+TABLE = os.environ.get("SHARING_TABLE", "call_center")
+TABLE_LOCATION = os.environ.get("SHARING_TABLE_LOCATION", "")
+SCHEMA_JSON_FILE = os.environ.get("SHARING_SCHEMA_JSON_FILE", "/etc/sharing/conf/schema.json")
+BEARER_TOKEN = os.environ.get("SHARING_BEARER_TOKEN", "")
+ACCESS_KEY_ID = os.environ.get("SHARING_VENDED_ACCESS_KEY_ID", "test")
+SECRET_ACCESS_KEY = os.environ.get("SHARING_VENDED_SECRET_ACCESS_KEY", "test")
+SESSION_TOKEN = os.environ.get("SHARING_VENDED_SESSION_TOKEN", "smoke-session-token")
+CREDENTIAL_VALIDITY_SECONDS = int(os.environ.get("SHARING_CREDENTIAL_VALIDITY_SECONDS", "3600"))
+PORT = int(os.environ.get("SHARING_PORT", "8443"))
+
+# Empty means the field is omitted entirely, which is what the reference server does and what the
+# client's ask-rather-than-refuse default exists for.
+ACCESS_MODES = [m.strip() for m in os.environ.get("SHARING_ACCESS_MODES", "url,dir").split(",") if m.strip()]
+
+# The client asks for responseformat=delta, so answering in that shape is what a conforming server
+# does. Answering flat is the legacy shape a server ignoring the header returns, and both are worth
+# being able to point the smoke at.
+RESPONSE_FORMAT = os.environ.get("SHARING_RESPONSE_FORMAT", "delta").strip().lower()
+STATE_LOCATION = os.environ.get("SHARING_STATE_LOCATION", "true").strip().lower() != "false"
+
+TABLE_PREFIX = f"/shares/{SHARE}/schemas/{SCHEMA}/tables/{TABLE}"
+
+# Every request this server answered, so a smoke run can assert the vend was actually reached
+# rather than inferring it from a check that passed.
+_requests_lock = threading.Lock()
+_requests = []
+
+
+def _record(method, path):
+    with _requests_lock:
+        _requests.append(f"{method} {path}")
+
+
+class Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, fmt, *args):
+        sys.stderr.write("[delta-sharing-stub] %s\n" % (fmt % args))
+
+    def do_GET(self):
+        path = self.path.split("?", 1)[0]
+        _record("GET", path)
+
+        # Not part of the protocol. The harness reads it to prove the credential endpoint was
+        # reached, and it carries no secret.
+        if path == "/_smoke/requests":
+            with _requests_lock:
+                self._json({"requests": list(_requests)})
+            return
+
+        if not self._authorized():
+            return
+
+        if path == "/shares":
+            self._json({"items": [{"name": SHARE, "id": "share-0001"}]})
+        elif path == f"/shares/{SHARE}/schemas":
+            self._json({"items": [{"name": SCHEMA}]})
+        elif path == f"/shares/{SHARE}/schemas/{SCHEMA}/tables":
+            self._json({"items": [self._table_item()]})
+        elif path == f"{TABLE_PREFIX}/metadata":
+            try:
+                with open(SCHEMA_JSON_FILE, "r", encoding="utf-8") as handle:
+                    schema_string = handle.read().strip()
+            except OSError as missing:
+                # Read per request rather than at startup: the schema comes off the fixture, which
+                # the harness copies into place after this container is running.
+                self._error(503, f"schema not yet available: {missing}")
+                return
+            table_fields = {
+                "id": "table-0001",
+                "name": TABLE,
+                "format": {"provider": "parquet"},
+                "schemaString": schema_string,
+                "partitionColumns": [],
+                "configuration": {},
+            }
+            wrapper = {"version": 0}
+            if STATE_LOCATION:
+                wrapper["location"] = TABLE_LOCATION
+            if ACCESS_MODES:
+                wrapper["accessModes"] = ACCESS_MODES
+            if RESPONSE_FORMAT == "delta":
+                wrapper["deltaMetadata"] = table_fields
+                protocol = {"deltaProtocol": {"minReaderVersion": 1, "readerFeatures": []}}
+            else:
+                wrapper.update(table_fields)
+                protocol = {"minReaderVersion": 1, "readerFeatures": []}
+            self._ndjson([{"protocol": protocol}, {"metaData": wrapper}])
+        else:
+            self._error(404, "not found")
+
+    def do_POST(self):
+        path = self.path.split("?", 1)[0]
+        _record("POST", path)
+        # Drained whether or not it is used: leaving it unread wedges a keep-alive connection.
+        length = int(self.headers.get("Content-Length") or 0)
+        if length:
+            self.rfile.read(length)
+
+        if not self._authorized():
+            return
+
+        if path == f"{TABLE_PREFIX}/temporary-table-credentials":
+            self._json(
+                {
+                    "credentials": {
+                        "location": TABLE_LOCATION,
+                        "expirationTime": int((time.time() + CREDENTIAL_VALIDITY_SECONDS) * 1000),
+                        "awsTempCredentials": {
+                            "accessKeyId": ACCESS_KEY_ID,
+                            "secretAccessKey": SECRET_ACCESS_KEY,
+                            "sessionToken": SESSION_TOKEN,
+                        },
+                    }
+                }
+            )
+        else:
+            self._error(404, "not found")
+
+    def _table_item(self):
+        item = {
+            "name": TABLE,
+            "share": SHARE,
+            "schema": SCHEMA,
+            "id": "table-0001",
+            "shareId": "share-0001",
+        }
+        if STATE_LOCATION:
+            item["location"] = TABLE_LOCATION
+        if ACCESS_MODES:
+            item["accessModes"] = ACCESS_MODES
+        return item
+
+    def _authorized(self):
+        # 401 rather than 403: the token is absent or wrong, which is what the client reports as
+        # UNAUTHENTICATED and what a smoke run asserts a wrong token produces.
+        if self.headers.get("Authorization") != f"Bearer {BEARER_TOKEN}":
+            self._error(401, "recipient token not accepted")
+            return False
+        return True
+
+    def _json(self, payload):
+        self._respond(200, "application/json; charset=utf-8", json.dumps(payload).encode("utf-8"))
+
+    def _ndjson(self, actions):
+        body = "\n".join(json.dumps(a) for a in actions).encode("utf-8")
+        self._respond(200, "application/x-ndjson; charset=utf-8", body)
+
+    def _error(self, status, message):
+        self._respond(
+            status, "application/json; charset=utf-8", json.dumps({"message": message}).encode("utf-8")
+        )
+
+    def _respond(self, status, content_type, body):
+        self.send_response(status)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+def main():
+    cert = os.environ.get("SHARING_TLS_CERT")
+    key = os.environ.get("SHARING_TLS_KEY")
+    if not cert or not key:
+        sys.stderr.write("[delta-sharing-stub] SHARING_TLS_CERT and SHARING_TLS_KEY are required\n")
+        return 2
+    if not TABLE_LOCATION:
+        sys.stderr.write("[delta-sharing-stub] SHARING_TABLE_LOCATION is required\n")
+        return 2
+
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    context.load_cert_chain(certfile=cert, keyfile=key)
+    server = ThreadingHTTPServer(("0.0.0.0", PORT), Handler)
+    server.socket = context.wrap_socket(server.socket, server_side=True)
+    sys.stderr.write(
+        "[delta-sharing-stub] sharing %s.%s.%s at %s on :%d (accessModes=%s)\n"
+        % (SHARE, SCHEMA, TABLE, TABLE_LOCATION, PORT, ACCESS_MODES or "<absent>")
+    )
+    server.serve_forever()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -319,6 +319,43 @@ services:
     networks:
       - floecat
 
+  # A Delta Sharing recipient endpoint over a fixture in LocalStack. The reference server
+  # implements directory access, but no published image does -- the server-side change landed in
+  # March 2026 and the last deltaio/delta-sharing-server tag is from April 2024 -- so the vend has
+  # nothing local to be checked against without this.
+  delta-sharing-stub:
+    image: ${FLOECAT_DELTA_SHARING_STUB_IMAGE:-python:3.12-alpine}
+    pull_policy: if_not_present
+    command: ["python3", "/opt/sharing/stub_server.py"]
+    ports:
+      - "${FLOECAT_DELTA_SHARING_HOST_PORT:-8445}:8443"
+    environment:
+      SHARING_SHARE: ${FLOECAT_DELTA_SHARING_SHARE:-floecat_smoke}
+      SHARING_SCHEMA: ${FLOECAT_DELTA_SHARING_SCHEMA:-sharing}
+      SHARING_TABLE: ${FLOECAT_DELTA_SHARING_TABLE:-call_center}
+      SHARING_TABLE_LOCATION: ${FLOECAT_DELTA_SHARING_TABLE_LOCATION:-}
+      SHARING_BEARER_TOKEN: ${FLOECAT_DELTA_SHARING_BEARER_TOKEN:-}
+      # Not :- like its neighbours. An empty value is meaningful here -- it is how the stub is
+      # told to omit accessModes altogether, the way the reference server does -- and :-
+      # substitutes the default for an empty value as well as an unset one, so the variant
+      # that exercises the unstated shape silently ran with url,dir.
+      SHARING_ACCESS_MODES: ${FLOECAT_DELTA_SHARING_ACCESS_MODES-url,dir}
+      SHARING_STATE_LOCATION: ${FLOECAT_DELTA_SHARING_STATE_LOCATION:-true}
+      SHARING_RESPONSE_FORMAT: ${FLOECAT_DELTA_SHARING_RESPONSE_FORMAT:-delta}
+      SHARING_VENDED_ACCESS_KEY_ID: ${FLOECAT_STORAGE_AWS_ACCESS_KEY_ID:-test}
+      SHARING_VENDED_SECRET_ACCESS_KEY: ${FLOECAT_STORAGE_AWS_SECRET_ACCESS_KEY:-test}
+      SHARING_TLS_CERT: /etc/sharing/tls/server.crt
+      SHARING_TLS_KEY: /etc/sharing/tls/server.key
+    volumes:
+      - ./delta-sharing/stub_server.py:/opt/sharing/stub_server.py:ro
+      - ${FLOECAT_DELTA_SHARING_CONFIG_DIR:-./delta-sharing}:/etc/sharing/conf:ro
+      - ${FLOECAT_DELTA_SHARING_TLS_CERT_FILE:-./unity/server.crt}:/etc/sharing/tls/server.crt:ro
+      - ${FLOECAT_DELTA_SHARING_TLS_KEY_FILE:-./unity/server.key}:/etc/sharing/tls/server.key:ro
+    profiles:
+      - delta-sharing
+    networks:
+      - floecat
+
   unity:
     image: ${FLOECAT_UNITY_IMAGE:-unitycatalog/unitycatalog:v0.6.0}
     pull_policy: if_not_present

--- a/docker/localstack-init.sh
+++ b/docker/localstack-init.sh
@@ -25,6 +25,7 @@ awslocal s3api create-bucket --bucket "floecat" --region "${REGION}" >/dev/null 
 awslocal s3api create-bucket --bucket "staged-fixtures" --region "${REGION}" >/dev/null 2>&1 || true
 awslocal s3api create-bucket --bucket "floecat-delta" --region "${REGION}" >/dev/null 2>&1 || true
 awslocal s3api create-bucket --bucket "floecat-delta-vended" --region "${REGION}" >/dev/null 2>&1 || true
+awslocal s3api create-bucket --bucket "floecat-sharing-vended" --region "${REGION}" >/dev/null 2>&1 || true
 
 # OSS Unity Catalog assumes this role when its temporary-table-credentials endpoint is called.
 # Keep the vended bucket out of COMPOSE_SMOKE_LOCALSTACK_BUCKETS: that list creates Floecat storage

--- a/docs/catalog-integration-design.md
+++ b/docs/catalog-integration-design.md
@@ -92,10 +92,19 @@ protocol-specific values such as the Iceberg REST warehouse; secret-bearing prop
 Its immutable resource ID is operational identity; its display name is mutable metadata and must be
 unique among integrations in the account.
 
-The API initially supports Iceberg REST and Unity integration types. Authentication is required and
-represented by typed protobuf messages for OAuth client credentials, bearer tokens, AWS assume role,
-AWS access keys, and AWS SigV4. Unity initially accepts only OAuth client credentials or bearer
-authentication. The base service validates structural compatibility; endpoint and provider support
+The API supports Iceberg REST, Unity, and Delta Sharing integration types. Authentication is
+required and represented by typed protobuf messages for OAuth client credentials, bearer tokens, AWS
+assume role, AWS access keys, and AWS SigV4. Unity initially accepts only OAuth client credentials or
+bearer authentication. Delta Sharing accepts only bearer authentication, the recipient token its
+provider issued, because the sharing protocol defines no other scheme. A Delta Sharing table is
+usable only where its provider offers directory access; a share that offers url access alone returns
+presigned per-file URLs rather than credentials, which the storage contract cannot represent, and the
+vend refuses it by name. A table that states no access modes at all is asked rather than refused: the
+protocol reads an absent field as url only, and the reference server implements the credential
+endpoint while never sending the field, so holding to that reading would refuse every table on a
+server that would have answered. Setting the connection property
+`delta.sharing.strict-access-modes` to `true` restores the protocol reading and refuses without
+asking. The base service validates structural compatibility; endpoint and provider support
 remain the responsibility of the catalog-access adapter and provider.
 
 Integration type is immutable through update. The catalog URI and connection properties are mutable

--- a/docs/catalog-integrations.md
+++ b/docs/catalog-integrations.md
@@ -95,6 +95,28 @@ integration objects databricks main.sales --kinds table,view
 overlay reconcile delta-sales
 ```
 
+For a Delta Sharing recipient, the share and schema are the namespace:
+
+```text
+integration create partner delta-sharing https://sharing.example/delta-sharing \
+  --auth-type bearer --cred token=recipient-token \
+  --props s3.region=us-east-1
+overlay create partner-tables partner local-catalog --include acme_share.gold
+integration validate partner
+integration namespaces partner
+integration namespaces partner --parent acme_share
+integration objects partner acme_share.gold
+overlay reconcile partner-tables
+```
+
+Delta Sharing accepts bearer authentication only, because the protocol defines no other scheme. A
+table is usable where its provider offers directory access; one offering url access alone returns
+presigned per-file URLs rather than credentials, and is refused when the overlay reconciles rather
+than materialized as a table nothing can open. A table stating no
+access modes is asked rather than refused -- see
+[`docs/operations.md`](operations.md#delta-sharing-access-modes) for why, and for
+`delta.sharing.strict-access-modes`.
+
 Unity OAuth client credentials use the same `oauth-client-credentials` CLI form as Iceberg REST.
 The configured token URI is optional; when omitted, the Unity provider uses `/oidc/v1/token` on the
 catalog host. Unity Integration discovery currently exposes Delta tables and Unity views. Table
@@ -168,6 +190,15 @@ authority has to be removed there: that fixture is copied to a bucket deliberate
 namespace has two levels, so the URL uses the `%1F` separator the gateway's own `/v1/config`
 advertises.
 
+The Delta Sharing scenario runs beside them, against a recipient endpoint served by
+`docker/delta-sharing/stub_server.py`. It is a stub rather than the reference server because no
+published `deltaio/delta-sharing-server` image implements directory access: that landed upstream in
+March 2026 and the last image tag is from April 2024. It serves the same Delta fixture from a third
+bucket, also absent from `COMPOSE_SMOKE_LOCALSTACK_BUCKETS`, and records every request it answered so
+the scenario can assert the share was actually asked for credentials rather than inferring it from a
+check that passed. It finishes with the same gateway `loadTable` check, and separately asserts that a
+recipient token the share does not accept fails validation.
+
 Authentication types and their properties are:
 
 | `--auth-type` | `--auth` properties | `--cred` properties |
@@ -186,6 +217,12 @@ properties instead of silently dropping them.
 Polaris, `warehouse=<catalog-name>` selects the upstream catalog without putting a query parameter in
 the base URI. Updating properties replaces the complete map; passing `--props` with no values clears
 it.
+
+For Delta Sharing, supported properties are `http.connect.ms`, `http.read.ms`,
+`delta.sharing.strict-access-modes`, `delta.sharing.reader-features`, `s3.region`, `s3.endpoint`,
+`client.region`, and `s3.path-style-access`. The S3 properties route reads of credentials the share
+vends; they do not supply storage credentials. `s3.endpoint` is held to the same rule as Unity's,
+below, for the same reason: a Delta Sharing vend also carries an AWS session token.
 
 For Unity Catalog, supported properties are `http.connect.ms`, `http.read.ms`,
 `unity.temporary-table-vend-path`, `s3.region`, `s3.endpoint`, and `s3.path-style-access`. The S3

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -84,7 +84,7 @@ query fetch-scan <query_id> <table_id>
 integrations
 integration list
 integration get <name|id>
-integration create <name> <iceberg-rest|unity> <uri> --auth-type <type>
+integration create <name> <iceberg-rest|unity|delta-sharing> <uri> --auth-type <type>
   [--auth k=v ...] [--cred k=v ...] [--props k=v ...]
 integration update <name|id> [--display <name>] [--uri <uri>] [--props k=v ...] [--etag <etag>]
 integration update-auth <name|id> --auth-type <type>

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -92,11 +92,12 @@ Important behavior:
 
 ### Cleartext S3 endpoints
 
-A Unity Catalog Integration may set `s3.endpoint` to reach an S3-compatible store. Floecat requires
-HTTPS there by default, because a Unity storage vend is only published when it carries an AWS
-session token: that token travels in the `X-Amz-Security-Token` header on every signed request, and
-anyone who observes it can replay it against the table's storage prefix until it expires. The value
-is also republished to reconcile and query workers, so the exposure is not limited to validation.
+A Unity Catalog or Delta Sharing Integration may set `s3.endpoint` to reach an S3-compatible store.
+Floecat requires HTTPS there by default, because a storage vend on either is only published when it
+carries an AWS session token: that token travels in the `X-Amz-Security-Token` header on every signed
+request, and anyone who observes it can replay it against the table's storage prefix until it
+expires. The value is also republished to reconcile and query workers, so the exposure is not limited
+to validation.
 
 - `FLOECAT_SECURITY_ALLOW_CLEARTEXT_S3_ENDPOINTS=true` – permits an `http://` `s3.endpoint`. Set
   this only where the network between Floecat, its workers, and the object store is trusted; MinIO
@@ -115,6 +116,81 @@ As with the catalog URI, these checks apply only to address *literals*: a hostna
 during validation, so an endpoint written as a hostname passes the address guard regardless of what
 it resolves to. That is why the bundled Compose stack, which addresses LocalStack as `localstack`,
 needs only the cleartext setting.
+
+### Delta Sharing access modes
+
+A Delta Sharing table is readable through this integration only where its provider offers directory
+access. A table that offers `url` access alone returns presigned per-file URLs rather than
+credentials, which the storage contract cannot represent, and the vend refuses it by name.
+
+A table that states no access modes at all is asked rather than refused. The protocol reads an absent
+field as `url` only, but the reference server implements the `temporary-table-credentials` endpoint
+while never sending the field, so holding to that reading refuses every table on a server that would
+have answered. Floecat attempts the vend and reports what the server says: a refusal or a missing
+endpoint becomes `CIVI_CREDENTIAL_VENDING_UNSUPPORTED` on validation, while a rejected token or an
+unreachable server is reported as itself.
+
+A table this Integration cannot read is refused when the overlay reconciles, and counted in
+`objects_skipped`, rather than materialized and left to fail at query time. That covers a table
+offering `url` access alone; a table stating no access modes under
+`delta.sharing.strict-access-modes`; a table reporting `auxiliaryLocations` on either surface, since
+the storage contract carries one credential over one scope prefix and vending only the root would
+fail at scan time on the files it does not reach; a table whose location is on a cloud this
+provider cannot vend for, meaning `abfss://`, `gs://`, or an `s3://` whose bucket cannot be read;
+and a table whose location no surface states, where the credential endpoint then refuses with a 404
+or the protocol's own 400.
+
+Two shapes nearby are not skips. Where the credential endpoint answers 200 without a location, or
+with a location the stated one is not under, the result is a classified failure rather than a
+skipped table -- a response this client cannot read is not a property of one table. And where the
+storage probe finds no Delta log object under the location, validation reports
+`CIVI_STORAGE_ACCESS_FAILED`: that means the location is not a table root -- a wrong region, a wrong
+prefix, a broadly scoped credential -- which is correctable, unlike a capability the provider does
+not have. The reason for refusing the rest is
+that a table reconciled without a storage location keeps the Integration's own catalog URI as its
+upstream reference, so it exists in the catalog and cannot be opened by anything reading object
+storage. A share offering only `url` access is therefore unsupported here, not partially supported.
+
+A table's access modes are reported by `integration validate`, which names the table and the reason
+when it refuses one. They are not stored on the reconciled table: the overlay reconciler builds a
+table's properties from the Integration and Overlay identities and the storage location, and does
+not carry the upstream properties a provider reports. That is true of every provider, not only this
+one, so reading a share's access modes means validating the Integration rather than describing the
+materialized table.
+
+- `delta.sharing.strict-access-modes=true` -- a connection property that restores the protocol
+  reading, refusing a table that states no modes without asking. Set it against a server known to
+  advertise its modes correctly, where a doomed request per table is waste. It carries a cost on
+  the vend, and against a large schema the cost is the wrong way round. Where the metaData action
+  states no modes, strict mode consults the table listing before refusing, because the listing is
+  where the protocol defines `accessModes` and the metaData spelling is the newer one -- refusing
+  without looking there would refuse a conforming table. A credential is vended on every
+  storage-authority resolve with a client that lives for that one resolve, so that fallback pages
+  the whole schema listing once per read. It is bounded by
+  `floecat.delta-sharing.max-listing-bytes` rather than unbounded, but it is a listing per read.
+  Leave this off for a share whose schemas hold many tables, or set it only against a server that
+  states modes on the metaData action, where the fallback never runs.
+- `delta.sharing.reader-features` -- a comma-separated list of Delta reader features this deployment
+  can process, empty by default. The capability header tells the server what the client can handle,
+  and claiming a feature the read path cannot process turns a refusal the server would have made
+  into a failure partway through a scan. Enforcement is the server's: the list is sent on the
+  metadata call and is not compared against the features the server reports back, so a server that
+  ignores the header is not caught here.
+- `floecat.delta-sharing.max-pages` (system property) -- maximum pages fetched by one listing,
+  default 10,000. A repeated page token is refused outright; this bound is what stops a server
+  minting a fresh one forever. Exceeding it is reported as `INVALID_RESPONSE`.
+- `floecat.delta-sharing.max-response-bytes` (system property) -- cap on a single response body,
+  default 32 MiB. A larger body is refused rather than buffered, since the endpoint is named by
+  tenant configuration.
+- `floecat.delta-sharing.max-listing-bytes` (system property) -- cap on everything one client
+  lists, across pages and across listings, default 32 MiB. The other two bounds do not compose into
+  a memory bound: ten thousand pages of thirty-two mebibytes is past any heap, and a reconcile pass
+  keeps each schema's tables for the whole of its life, so a per-listing cap would not bound the
+  pass. A table entry runs roughly three hundred bytes of JSON, nearer six hundred with a deep
+  prefix, so the default admits above sixty thousand tables across a whole share where a large real
+  share holds thousands, and the decoded records cost about as much again. Raise it for a genuinely
+  larger share; exceeding it fails the reconcile as `INVALID_RESPONSE`, which is not retried and
+  ends the pass rather than being recorded as one skipped schema.
 
 ### Reconciler deployment modes
 

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,7 @@
       <!-- Connectors -->
       <module>connectors/catalogs/iceberg</module>
       <module>connectors/clients/unity-catalog</module>
+      <module>connectors/clients/delta-sharing</module>
       <module>connectors/catalogs/delta</module>
 
       <!-- Storage -->

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,7 @@
 
       <!-- Catalog access -->
       <module>catalog-access/iceberg-rest</module>
+      <module>catalog-access/delta-common</module>
       <module>catalog-access/unity</module>
       
       <!-- Connectors -->

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,7 @@
       <module>core/metadata-admission-runtime</module>
       <module>core/stats</module>
       <module>core/catalog</module>
+      <module>core/http-endpoint-guards</module>
       <module>core/catalog-access-spi</module>
       <module>core/scanner</module>
       <module>core/metagraph</module>

--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,7 @@
       <module>catalog-access/iceberg-rest</module>
       <module>catalog-access/delta-common</module>
       <module>catalog-access/unity</module>
+      <module>catalog-access/delta-sharing</module>
       
       <!-- Connectors -->
       <module>connectors/catalogs/iceberg</module>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -244,6 +244,12 @@
 
     <dependency>
       <groupId>ai.floedb.floecat</groupId>
+      <artifactId>floecat-catalog-access-delta-sharing</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>ai.floedb.floecat</groupId>
       <artifactId>floecat-flight</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/service/src/main/java/ai/floedb/floecat/service/integration/CatalogIntegrationAccess.java
+++ b/service/src/main/java/ai/floedb/floecat/service/integration/CatalogIntegrationAccess.java
@@ -121,6 +121,7 @@ public class CatalogIntegrationAccess {
         switch (integration.getType()) {
           case CIT_ICEBERG_REST -> CatalogProtocol.ICEBERG_REST;
           case CIT_UNITY -> CatalogProtocol.UNITY_CATALOG;
+          case CIT_DELTA_SHARING -> CatalogProtocol.DELTA_SHARING;
           case CIT_UNSPECIFIED, UNRECOGNIZED ->
               throw new CatalogAccessException(
                   CatalogAccessException.Code.INVALID_CONFIGURATION,
@@ -223,13 +224,25 @@ public class CatalogIntegrationAccess {
       List.of("s3.region", "region", "client.region", "aws.region");
 
   /**
-   * The integration's properties with {@code s3.region} resolved, for Unity.
+   * Protocols whose provider probes storage itself and so needs a resolved {@code s3.region}.
    *
-   * <p>Unity only. The Iceberg REST provider reads the same map and turns {@code s3.region} into
-   * {@code client.region}, so defaulting it there would pin a region on an integration that
-   * deliberately set none and was relying on the AWS SDK's own resolution chain -- replacing a
-   * provider-managed default with this deployment's. Unity's storage validator has no such chain:
-   * without a region it assumed {@code us-east-1} and disagreed with the read path.
+   * <p>Both run the same Delta log probe, which falls back to {@code us-east-1} when the region is
+   * absent. A share whose table lives elsewhere then has its validation read answered with
+   * PermanentRedirect while the read path, which consults the endpoint, succeeds -- an Integration
+   * permanently reporting a storage-access failure that does not exist in practice.
+   */
+  private static final java.util.Set<CatalogProtocol> RESOLVES_STORAGE_REGION =
+      java.util.EnumSet.of(CatalogProtocol.UNITY_CATALOG, CatalogProtocol.DELTA_SHARING);
+
+  /**
+   * The integration's properties with {@code s3.region} resolved.
+   *
+   * <p>Only for {@link #RESOLVES_STORAGE_REGION}. The Iceberg REST provider reads the same map and
+   * turns {@code s3.region} into {@code client.region}, so defaulting it there would pin a region
+   * on an integration that deliberately set none and was relying on the AWS SDK's own resolution
+   * chain -- replacing a provider-managed default with this deployment's. The Delta log probe those
+   * two protocols share has no such chain: without a region it assumed {@code us-east-1} and
+   * disagreed with the read path.
    *
    * <p>Resolved across every spelling, not just {@code s3.region}. The provider reads only that key
    * and the validation probe builds its S3 client from it, so a region written another way has to
@@ -248,7 +261,7 @@ public class CatalogIntegrationAccess {
   private Map<String, String> withDefaultRegion(
       CatalogIntegration integration, CatalogProtocol protocol) {
     Map<String, String> properties = integration.getPropertiesMap();
-    if (protocol != CatalogProtocol.UNITY_CATALOG) {
+    if (!RESOLVES_STORAGE_REGION.contains(protocol)) {
       return properties;
     }
     String stated = null;

--- a/service/src/main/java/ai/floedb/floecat/service/integration/CatalogIntegrationDiscovery.java
+++ b/service/src/main/java/ai/floedb/floecat/service/integration/CatalogIntegrationDiscovery.java
@@ -248,7 +248,9 @@ public class CatalogIntegrationDiscovery {
           failed(
               CatalogIntegrationValidationCheckType.CIVCT_STORAGE_ACCESS,
               credentialIssue(
-                  failure.failure(), CatalogIntegrationValidationIssue.CIVI_STORAGE_ACCESS_FAILED),
+                  failure.failure(),
+                  CatalogIntegrationValidationIssue.CIVI_STORAGE_ACCESS_FAILED,
+                  CatalogIntegrationValidationIssue.CIVI_STORAGE_ACCESS_UNSUPPORTED),
               safeSummary("Storage access validation failed.", failure.failure())));
       return new ValidationResult(false, checks, capabilities);
     } catch (CredentialVendingFailure failure) {
@@ -261,7 +263,8 @@ public class CatalogIntegrationDiscovery {
               CatalogIntegrationValidationCheckType.CIVCT_CREDENTIAL_VENDING,
               credentialIssue(
                   failure.failure(),
-                  CatalogIntegrationValidationIssue.CIVI_CREDENTIAL_VENDING_FAILED),
+                  CatalogIntegrationValidationIssue.CIVI_CREDENTIAL_VENDING_FAILED,
+                  CatalogIntegrationValidationIssue.CIVI_CREDENTIAL_VENDING_UNSUPPORTED),
               safeSummary("Storage credential vending failed.", failure.failure())));
       addStorageNotRun(checks);
       return new ValidationResult(false, checks, capabilities);
@@ -310,7 +313,9 @@ public class CatalogIntegrationDiscovery {
           failed(
               CatalogIntegrationValidationCheckType.CIVCT_STORAGE_ACCESS,
               credentialIssue(
-                  failure, CatalogIntegrationValidationIssue.CIVI_STORAGE_ACCESS_FAILED),
+                  failure,
+                  CatalogIntegrationValidationIssue.CIVI_STORAGE_ACCESS_FAILED,
+                  CatalogIntegrationValidationIssue.CIVI_STORAGE_ACCESS_UNSUPPORTED),
               safeSummary("Storage access validation failed.", failure)));
       return new ValidationResult(false, checks, capabilities);
     }
@@ -932,12 +937,24 @@ public class CatalogIntegrationDiscovery {
         || failure.code() == CatalogAccessException.Code.PERMISSION_DENIED;
   }
 
+  /**
+   * The issue an upstream refusal is reported as.
+   *
+   * <p>{@code unsupported} is separate from {@code fallback} because a capability can be per table
+   * rather than per integration: a Delta Sharing recipient vends credentials for a share offering
+   * directory access and cannot for one offering url access alone, and answers UNSUPPORTED for the
+   * second. Reporting that as a failure tells an operator to fix something, when what the provider
+   * said is that it will never do this.
+   */
   private static CatalogIntegrationValidationIssue credentialIssue(
-      CatalogAccessException failure, CatalogIntegrationValidationIssue fallback) {
+      CatalogAccessException failure,
+      CatalogIntegrationValidationIssue fallback,
+      CatalogIntegrationValidationIssue unsupported) {
     return switch (failure.code()) {
       case CREDENTIAL_EXPIRED -> CatalogIntegrationValidationIssue.CIVI_CREDENTIAL_EXPIRED;
       case CREDENTIAL_SCOPE_INVALID ->
           CatalogIntegrationValidationIssue.CIVI_CREDENTIAL_SCOPE_INVALID;
+      case UNSUPPORTED -> unsupported;
       default -> fallback;
     };
   }

--- a/service/src/main/java/ai/floedb/floecat/service/integration/CatalogIntegrationsImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/integration/CatalogIntegrationsImpl.java
@@ -900,7 +900,9 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
   }
 
   private static void validateType(CatalogIntegrationType type, String corr) {
-    if (type != CatalogIntegrationType.CIT_ICEBERG_REST && type != CatalogIntegrationType.CIT_UNITY)
+    if (type != CatalogIntegrationType.CIT_ICEBERG_REST
+        && type != CatalogIntegrationType.CIT_UNITY
+        && type != CatalogIntegrationType.CIT_DELTA_SHARING)
       throw GrpcErrors.invalidArgument(corr, FIELD, Map.of("field", "type"));
   }
 
@@ -908,6 +910,14 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
       CatalogIntegrationType integrationType, CatalogAuthentication authentication, String corr) {
     var configuration = authentication.getConfigurationCase();
     if (configuration == CatalogAuthentication.ConfigurationCase.CONFIGURATION_NOT_SET) return;
+    // A Delta Sharing recipient authenticates with the token its provider issued and nothing else.
+    // The protocol defines no other scheme, so an AWS or OAuth block on one is a configuration
+    // error rather than an unused field.
+    if (integrationType == CatalogIntegrationType.CIT_DELTA_SHARING
+        && configuration != CatalogAuthentication.ConfigurationCase.BEARER) {
+      throw GrpcErrors.invalidArgument(
+          corr, FIELD, Map.of("field", "authentication.configuration"));
+    }
     if (integrationType == CatalogIntegrationType.CIT_UNITY
         && configuration != CatalogAuthentication.ConfigurationCase.OAUTH_CLIENT_CREDENTIALS
         && configuration != CatalogAuthentication.ConfigurationCase.BEARER) {

--- a/service/src/test/java/ai/floedb/floecat/service/integration/CatalogIntegrationAccessTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/integration/CatalogIntegrationAccessTest.java
@@ -66,6 +66,20 @@ class CatalogIntegrationAccessTest {
   }
 
   /**
+   * Delta Sharing runs the same Delta log probe as Unity, which falls back to us-east-1 when the
+   * region is absent. A share whose table lives elsewhere would have its validation read answered
+   * with PermanentRedirect while the read path, which consults the endpoint, succeeds.
+   */
+  @Test
+  void fillsInTheDeploymentRegionForADeltaSharingIntegrationToo() {
+    var integration = bearerIntegration(Map.of(), CatalogIntegrationType.CIT_DELTA_SHARING);
+
+    var resolved = access.resolve(integration);
+
+    assertEquals("eu-west-1", resolved.config().properties().get("s3.region"));
+  }
+
+  /**
    * Unity only. The Iceberg REST provider reads the same map and turns s3.region into
    * client.region, so defaulting it there would pin a region on an integration that deliberately
    * set none and was relying on the AWS SDK's own resolution chain.
@@ -331,6 +345,33 @@ class CatalogIntegrationAccessTest {
         assertThrows(CatalogAccessException.class, () -> access.open(integration));
 
     assertEquals(CatalogAccessException.Code.INTERNAL, error.code());
+  }
+
+  @Test
+  void resolvesADeltaSharingRecipientOntoItsProtocolAndBearerToken() {
+    var authentication =
+        CatalogAuthentication.newBuilder()
+            .setBearer(BearerAuthentication.getDefaultInstance())
+            .setCredentialsConfigured(true)
+            .setCredentialGeneration(1L)
+            .build();
+    CatalogIntegration integration =
+        integration(authentication).toBuilder()
+            .setType(CatalogIntegrationType.CIT_DELTA_SHARING)
+            .build();
+    when(credentials.resolve(integration))
+        .thenReturn(
+            Optional.of(
+                CatalogIntegrationCredentials.newBuilder()
+                    .setBearerToken(SecretValue.newBuilder().setValue("recipient"))
+                    .build()));
+
+    var resolved = access.resolve(integration);
+
+    assertEquals(CatalogProtocol.DELTA_SHARING, resolved.config().protocol());
+    assertEquals(CatalogAuthenticationScheme.OAUTH2, resolved.config().authentication().scheme());
+    assertEquals("recipient", resolved.credentials().properties().get("token"));
+    assertFalse(resolved.config().properties().containsKey("token"));
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/integration/CatalogIntegrationDiscoveryTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/integration/CatalogIntegrationDiscoveryTest.java
@@ -699,6 +699,71 @@ class CatalogIntegrationDiscoveryTest {
   }
 
   /**
+   * A provider that vends for some tables and refuses others by capability.
+   *
+   * <p>A Delta Sharing recipient does exactly this: it vends for a share offering directory access
+   * and answers UNSUPPORTED for one offering url access alone, where the server returns presigned
+   * per-file URLs rather than credentials. Reporting that as a vending failure tells an operator to
+   * fix something, when what the provider said is that it will never do this.
+   */
+  @Test
+  void aVendTheProviderCallsUnsupportedIsReportedAsUnsupportedNotFailed() {
+    NamespacePath sales = NamespacePath.of("main", "sales");
+    when(client.capabilities()).thenReturn(validationCapabilities());
+    when(client.listTables(NamespacePath.root())).thenReturn(List.of());
+    when(client.listNamespaces(NamespacePath.root())).thenReturn(List.of(NamespacePath.of("main")));
+    when(client.listNamespaces(NamespacePath.of("main"))).thenReturn(List.of(sales));
+    when(client.listTables(sales)).thenReturn(List.of(new CatalogObjectName(sales, "a")));
+    when(client.vendStorageCredentials(any()))
+        .thenThrow(
+            new CatalogAccessException(
+                CatalogAccessException.Code.UNSUPPORTED,
+                "share.schema.a offers url access only, which cannot be vended"));
+
+    var result = discovery.validate(integration);
+
+    assertFalse(result.valid());
+    assertEquals(
+        CatalogIntegrationValidationStatus.CIVS_PASSED,
+        result.checks().get(2).getStatus(),
+        "the share enumerated, so discovery must not be reported as the failure");
+    assertEquals(
+        CatalogIntegrationValidationIssue.CIVI_CREDENTIAL_VENDING_UNSUPPORTED,
+        result.checks().get(3).getIssue());
+    assertEquals(
+        "share.schema.a offers url access only, which cannot be vended",
+        result.checks().get(3).getSummary(),
+        "the provider named the table and the reason, and that is what an operator needs");
+  }
+
+  @Test
+  void aStorageProbeTheProviderCallsUnsupportedIsReportedAsUnsupportedNotFailed() {
+    NamespacePath sales = NamespacePath.of("main", "sales");
+    var vended = new VendedStorageCredentials(Map.of("key", "value"), "", Optional.empty());
+    when(client.capabilities()).thenReturn(validationCapabilities());
+    when(client.listTables(NamespacePath.root())).thenReturn(List.of());
+    when(client.listNamespaces(NamespacePath.root())).thenReturn(List.of(NamespacePath.of("main")));
+    when(client.listNamespaces(NamespacePath.of("main"))).thenReturn(List.of(sales));
+    when(client.listTables(sales)).thenReturn(List.of(new CatalogObjectName(sales, "a")));
+    when(client.vendStorageCredentials(any())).thenReturn(Optional.of(vended));
+    doThrow(
+            new CatalogAccessException(
+                CatalogAccessException.Code.UNSUPPORTED,
+                "share.schema.a reports no location to validate access against"))
+        .when(client)
+        .validateStorageAccess(any(), any());
+
+    var result = discovery.validate(integration);
+
+    assertFalse(result.valid());
+    assertEquals(
+        CatalogIntegrationValidationStatus.CIVS_PASSED, result.checks().get(3).getStatus());
+    assertEquals(
+        CatalogIntegrationValidationIssue.CIVI_STORAGE_ACCESS_UNSUPPORTED,
+        result.checks().get(4).getIssue());
+  }
+
+  /**
    * A storage failure that will answer the same for every table stops the search where it stands,
    * rather than paying for a probe per sampled table to collect it again.
    */

--- a/service/src/test/java/ai/floedb/floecat/service/integration/CatalogIntegrationsImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/integration/CatalogIntegrationsImplTest.java
@@ -557,6 +557,63 @@ class CatalogIntegrationsImplTest {
   }
 
   @Test
+  void deltaSharingAcceptsARecipientBearerToken() {
+    var response =
+        service
+            .createCatalogIntegration(
+                CreateCatalogIntegrationRequest.newBuilder()
+                    .setSpec(
+                        CatalogIntegrationSpec.newBuilder()
+                            .setDisplayName("Partner Share")
+                            .setType(CatalogIntegrationType.CIT_DELTA_SHARING)
+                            .setCatalogUri("https://sharing.example/delta-sharing")
+                            .setAuthentication(
+                                CatalogAuthentication.newBuilder()
+                                    .setBearer(BearerAuthentication.getDefaultInstance())))
+                    .setCredentials(
+                        CatalogIntegrationCredentials.newBuilder()
+                            .setBearerToken(SecretValue.newBuilder().setValue("recipient")))
+                    .build())
+            .await()
+            .indefinitely();
+
+    assertEquals(CatalogIntegrationType.CIT_DELTA_SHARING, response.getIntegration().getType());
+    verify(service.integrations).createWithMeta(any());
+  }
+
+  @Test
+  void deltaSharingRejectsEveryAuthenticationExceptBearer() {
+    var schemes =
+        List.of(
+            oauthAuthentication(),
+            CatalogAuthentication.newBuilder()
+                .setAwsSigv4(AwsSigV4Authentication.newBuilder().setRegion("us-east-1"))
+                .build());
+    for (var authentication : schemes) {
+      var error =
+          assertThrows(
+              StatusRuntimeException.class,
+              () ->
+                  service
+                      .createCatalogIntegration(
+                          CreateCatalogIntegrationRequest.newBuilder()
+                              .setSpec(
+                                  CatalogIntegrationSpec.newBuilder()
+                                      .setDisplayName("Partner Share")
+                                      .setType(CatalogIntegrationType.CIT_DELTA_SHARING)
+                                      .setCatalogUri("https://sharing.example/delta-sharing")
+                                      .setAuthentication(authentication))
+                              .setCredentials(oauthCredentials())
+                              .build())
+                      .await()
+                      .indefinitely());
+
+      assertEquals(Status.Code.INVALID_ARGUMENT, error.getStatus().getCode());
+    }
+    verify(service.integrations, never()).createWithMeta(any());
+  }
+
+  @Test
   void createRejectsBlankTopLevelAssumeRoleExternalId() {
     var error =
         assertThrows(

--- a/tools/compose-smoke.sh
+++ b/tools/compose-smoke.sh
@@ -52,6 +52,17 @@ COMPOSE_SMOKE_UNITY_HEALTH_PATH=${COMPOSE_SMOKE_UNITY_HEALTH_PATH:-/api/2.1/unit
 COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_STORAGE_LOCATION=${COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_STORAGE_LOCATION:-s3://floecat-delta-vended/call_center}
 COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_S3_ENDPOINT=${COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_S3_ENDPOINT:-http://localstack:4566}
 COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_S3_REGION=${COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_S3_REGION:-us-east-1}
+# A Delta Sharing recipient over the same Delta fixture, served by the stub in docker/delta-sharing.
+# The storage location is a bucket deliberately absent from COMPOSE_SMOKE_LOCALSTACK_BUCKETS, so no
+# Floecat storage authority can make the validation read pass without the share vending credentials.
+COMPOSE_SMOKE_DELTA_SHARING_IMPORT=${COMPOSE_SMOKE_DELTA_SHARING_IMPORT:-true}
+COMPOSE_SMOKE_DELTA_SHARING_URI=${COMPOSE_SMOKE_DELTA_SHARING_URI:-https://delta-sharing-stub:8443}
+COMPOSE_SMOKE_DELTA_SHARING_SHARE=${COMPOSE_SMOKE_DELTA_SHARING_SHARE:-floecat_smoke}
+COMPOSE_SMOKE_DELTA_SHARING_SCHEMA=${COMPOSE_SMOKE_DELTA_SHARING_SCHEMA:-sharing}
+COMPOSE_SMOKE_DELTA_SHARING_TABLE=${COMPOSE_SMOKE_DELTA_SHARING_TABLE:-call_center}
+COMPOSE_SMOKE_DELTA_SHARING_TOKEN=${COMPOSE_SMOKE_DELTA_SHARING_TOKEN:-smoke-recipient-token}
+COMPOSE_SMOKE_DELTA_SHARING_STORAGE_LOCATION=${COMPOSE_SMOKE_DELTA_SHARING_STORAGE_LOCATION:-s3://floecat-sharing-vended/call_center}
+COMPOSE_SMOKE_DELTA_SHARING_DEST_CATALOG=${COMPOSE_SMOKE_DELTA_SHARING_DEST_CATALOG:-sharing_import}
 COMPOSE_SMOKE_LOCALSTACK_BUCKETS="${COMPOSE_SMOKE_LOCALSTACK_BUCKETS:-bucket floecat floecat-delta floecat-dev staged-fixtures warehouse yb-iceberg-tpcds}"
 COMPOSE_SMOKE_ICEBERG_FORMAT_MATRIX=${COMPOSE_SMOKE_ICEBERG_FORMAT_MATRIX:-true}
 COMPOSE_SMOKE_STATS_RETRIES=${COMPOSE_SMOKE_STATS_RETRIES:-45}
@@ -452,6 +463,32 @@ assert_no_authority_covers() {
   echo "[PASS] $label no storage authority covers $location"
 }
 
+# Fails unless the Delta Sharing stub was asked for temporary credentials for one table.
+#
+# The stub records every request it answered and serves the list back. A validation run that passed
+# its storage read against a bucket no authority covers already implies a vend happened; this names
+# the request, so a pass cannot come from anywhere else.
+assert_stub_vended_credentials() {
+  local compose_project="$1"
+  local label="$2"
+  local share="$3"
+  local schema="$4"
+  local table="$5"
+  local expected="POST /shares/$share/schemas/$schema/tables/$table/temporary-table-credentials"
+
+  local requests
+  requests=$(docker run --rm --network "${compose_project}_floecat" \
+    curlimages/curl:8.12.1 -k -sS \
+    -X GET "https://delta-sharing-stub:8443/_smoke/requests")
+
+  if ! printf '%s' "$requests" | grep -qF "$expected"; then
+    echo "[FAIL] $label share was never asked for temporary credentials for $share.$schema.$table"
+    printf '%s\n' "$requests"
+    return 1
+  fi
+  echo "[PASS] $label share vended temporary credentials for $share.$schema.$table"
+}
+
 # Fails unless a gateway loadTable returns a complete vended session tuple.
 #
 # Shared by the Polaris and Unity checks, which differ only in label and URL. The body is never
@@ -629,7 +666,7 @@ cleanup_mode() {
   eval "$compose_cmd down --remove-orphans -v" >/dev/null 2>&1 || true
 }
 
-prepare_unity_tls() {
+prepare_smoke_tls() {
   local tls_dir="$1"
   local cert_file="$tls_dir/server.crt"
   local key_file="$tls_dir/server.key"
@@ -644,7 +681,7 @@ prepare_unity_tls() {
     -out "$cert_file" \
     -days 1 \
     -subj /CN=unity-proxy \
-    -addext 'subjectAltName=DNS:unity-proxy,DNS:localhost,IP:127.0.0.1,DNS:sts.us-east-1.amazonaws.com' \
+    -addext 'subjectAltName=DNS:unity-proxy,DNS:delta-sharing-stub,DNS:localhost,IP:127.0.0.1,DNS:sts.us-east-1.amazonaws.com' \
     >/dev/null 2>&1
   keytool -delete \
     -alias unity-proxy \
@@ -662,22 +699,23 @@ prepare_unity_tls() {
   chmod 644 "$cert_file" "$truststore_file"
 }
 
-cleanup_unity_tls() {
+cleanup_smoke_tls() {
   local tls_dir="$1"
   if [ -z "$tls_dir" ]; then
     return 0
   fi
   case "${tls_dir##*/}" in
-    floecat-unity-tls.*) ;;
+    floecat-smoke-tls.*) ;;
     *)
-      echo "refusing to clean unexpected Unity TLS directory: $tls_dir" >&2
+      echo "refusing to clean unexpected smoke TLS directory: $tls_dir" >&2
       return 1
       ;;
   esac
   rm -f \
     "$tls_dir/server.crt" \
     "$tls_dir/server.key" \
-    "$tls_dir/runtime-truststore.p12"
+    "$tls_dir/runtime-truststore.p12" \
+    "$tls_dir/schema.json"
   rmdir "$tls_dir" 2>/dev/null || true
 }
 
@@ -826,21 +864,27 @@ run_mode() {
   if [ "$smoke_scope" = "full" ] && [ "$profile" = "localstack" ] && is_truthy "$COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_IMPORT"; then
     compose_profiles="${compose_profiles},unity"
   fi
+  if [ "$smoke_scope" = "full" ] && [ "$profile" = "localstack" ] && is_truthy "$COMPOSE_SMOKE_DELTA_SHARING_IMPORT"; then
+    compose_profiles="${compose_profiles},delta-sharing"
+  fi
   if [ "$smoke_scope" = "full" ] && { [ "$profile" = "localstack" ] || [ "$profile" = "localstack-oidc" ]; } && should_run_client trino; then
     compose_profiles="${compose_profiles},trino"
   fi
 
-  local unity_tls_dir=""
-  local unity_tls_cert_file=""
-  local unity_tls_key_file=""
-  local unity_runtime_truststore_file=""
-  if [ "$smoke_scope" = "full" ] && [ "$profile" = "localstack" ] && is_truthy "$COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_IMPORT"; then
-    unity_tls_dir=$(mktemp -d "${TMPDIR:-/tmp}/floecat-unity-tls.XXXXXX")
-    unity_tls_cert_file="$unity_tls_dir/server.crt"
-    unity_tls_key_file="$unity_tls_dir/server.key"
-    unity_runtime_truststore_file="$unity_tls_dir/runtime-truststore.p12"
-    if ! prepare_unity_tls "$unity_tls_dir"; then
-      cleanup_unity_tls "$unity_tls_dir"
+  local smoke_tls_dir=""
+  local smoke_tls_cert_file=""
+  local smoke_tls_key_file=""
+  local smoke_runtime_truststore_file=""
+  # One certificate for both TLS endpoints in this stack: the Unity proxy and the Delta Sharing
+  # stub. Either scenario needs Floecat to trust it, and the truststore is a single file.
+  if [ "$smoke_scope" = "full" ] && [ "$profile" = "localstack" ] &&
+    { is_truthy "$COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_IMPORT" || is_truthy "$COMPOSE_SMOKE_DELTA_SHARING_IMPORT"; }; then
+    smoke_tls_dir=$(mktemp -d "${TMPDIR:-/tmp}/floecat-smoke-tls.XXXXXX")
+    smoke_tls_cert_file="$smoke_tls_dir/server.crt"
+    smoke_tls_key_file="$smoke_tls_dir/server.key"
+    smoke_runtime_truststore_file="$smoke_tls_dir/runtime-truststore.p12"
+    if ! prepare_smoke_tls "$smoke_tls_dir"; then
+      cleanup_smoke_tls "$smoke_tls_dir"
       return 1
     fi
   fi
@@ -851,11 +895,27 @@ run_mode() {
     "COMPOSE_PROJECT_NAME=$compose_project"
   )
 
-  if [ -n "$unity_tls_dir" ]; then
+  if [ -n "$smoke_tls_dir" ]; then
     mode_env_args+=(
-      "FLOECAT_RUNTIME_TRUSTSTORE_FILE=$unity_runtime_truststore_file"
-      "FLOECAT_UNITY_TLS_CERT_FILE=$unity_tls_cert_file"
-      "FLOECAT_UNITY_TLS_KEY_FILE=$unity_tls_key_file"
+      "FLOECAT_RUNTIME_TRUSTSTORE_FILE=$smoke_runtime_truststore_file"
+      "FLOECAT_UNITY_TLS_CERT_FILE=$smoke_tls_cert_file"
+      "FLOECAT_UNITY_TLS_KEY_FILE=$smoke_tls_key_file"
+      "FLOECAT_DELTA_SHARING_TLS_CERT_FILE=$smoke_tls_cert_file"
+      "FLOECAT_DELTA_SHARING_TLS_KEY_FILE=$smoke_tls_key_file"
+    )
+  fi
+
+  # Compose reads these when the service starts, so everything fixed about the share is set here.
+  # The schema is not: it comes off the fixture, which does not exist until the stack is up, so the
+  # stub reads it from a file in the configuration directory on each metadata request instead.
+  if [[ ",$compose_profiles," == *",delta-sharing,"* ]]; then
+    mode_env_args+=(
+      "FLOECAT_DELTA_SHARING_SHARE=$COMPOSE_SMOKE_DELTA_SHARING_SHARE"
+      "FLOECAT_DELTA_SHARING_SCHEMA=$COMPOSE_SMOKE_DELTA_SHARING_SCHEMA"
+      "FLOECAT_DELTA_SHARING_TABLE=$COMPOSE_SMOKE_DELTA_SHARING_TABLE"
+      "FLOECAT_DELTA_SHARING_TABLE_LOCATION=$COMPOSE_SMOKE_DELTA_SHARING_STORAGE_LOCATION"
+      "FLOECAT_DELTA_SHARING_BEARER_TOKEN=$COMPOSE_SMOKE_DELTA_SHARING_TOKEN"
+      "FLOECAT_DELTA_SHARING_CONFIG_DIR=$smoke_tls_dir"
     )
   fi
 
@@ -931,7 +991,7 @@ quit" 60 || true
         echo "==> [SMOKE][KEEP] preserving compose stack for mode=$label (COMPOSE_SMOKE_KEEP_ON_EXIT=$COMPOSE_SMOKE_KEEP_ON_EXIT)"
       else
         cleanup_mode "$compose_cmd"
-        cleanup_unity_tls "$unity_tls_dir"
+        cleanup_smoke_tls "$smoke_tls_dir"
       fi
     else
       save_mode_logs "$compose_cmd" "${label}-fail"
@@ -941,7 +1001,7 @@ quit" 60 || true
         echo "==> [SMOKE][KEEP] preserving compose stack for mode=$label (COMPOSE_SMOKE_KEEP_ON_FAIL=$COMPOSE_SMOKE_KEEP_ON_FAIL)"
       else
         cleanup_mode "$compose_cmd"
-        cleanup_unity_tls "$unity_tls_dir"
+        cleanup_smoke_tls "$smoke_tls_dir"
       fi
     fi
     return "$rc"
@@ -963,6 +1023,13 @@ quit" 60 || true
       pre_services="localstack unity unity-proxy"
     elif [[ ",$pre_services," != *",unity,"* ]]; then
       pre_services="$pre_services unity unity-proxy"
+    fi
+  fi
+  if [ "$smoke_scope" = "full" ] && [ "$profile" = "localstack" ] && is_truthy "$COMPOSE_SMOKE_DELTA_SHARING_IMPORT"; then
+    if [ -z "$pre_services" ]; then
+      pre_services="localstack delta-sharing-stub"
+    elif [[ ",$pre_services," != *",delta-sharing-stub,"* ]]; then
+      pre_services="$pre_services delta-sharing-stub"
     fi
   fi
 
@@ -992,7 +1059,15 @@ quit" 60 || true
       "https://localhost:${unity_https_host_port}${COMPOSE_SMOKE_UNITY_HEALTH_PATH}" \
       180 \
       "Unity Catalog TLS proxy health" \
-      "$unity_tls_cert_file"
+      "$smoke_tls_cert_file"
+  fi
+  if [ "$smoke_scope" = "full" ] && [ "$profile" = "localstack" ] && is_truthy "$COMPOSE_SMOKE_DELTA_SHARING_IMPORT"; then
+    # The request log, which needs no recipient token and so answers before anything is configured.
+    wait_for_url_with_ca \
+      "https://localhost:${FLOECAT_DELTA_SHARING_HOST_PORT:-8445}/_smoke/requests" \
+      180 \
+      "Delta Sharing stub health" \
+      "$smoke_tls_cert_file"
   fi
 
   local compose_up_cmd="$compose_cmd up -d"
@@ -1755,6 +1830,219 @@ quit")
     fi
   elif [ "$smoke_scope" = "full" ] && [ "$profile" = "localstack" ]; then
     echo "==> [SMOKE] skipping upstream delta unity import (set COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_IMPORT=true to enable)"
+  fi
+
+  if [ "$smoke_scope" = "full" ] && [ "$profile" = "localstack" ] && is_truthy "$COMPOSE_SMOKE_DELTA_SHARING_IMPORT"; then
+    echo "==> [SMOKE] Delta Sharing Catalog Integration overlay reconciliation"
+
+    local sharing_namespace="$COMPOSE_SMOKE_DELTA_SHARING_SHARE.$COMPOSE_SMOKE_DELTA_SHARING_SCHEMA"
+    local sharing_location="$COMPOSE_SMOKE_DELTA_SHARING_STORAGE_LOCATION"
+    local sharing_integration_name="smoke-delta-sharing-integration"
+    local sharing_overlay_name="smoke-delta-sharing-overlay"
+    local sharing_catalog="$COMPOSE_SMOKE_DELTA_SHARING_DEST_CATALOG"
+    local sharing_expected_table="$sharing_catalog.$sharing_namespace.$COMPOSE_SMOKE_DELTA_SHARING_TABLE"
+    local sharing_aws_cli
+    sharing_aws_cli="docker run --rm --network ${compose_project}_floecat -e AWS_ACCESS_KEY_ID=test -e AWS_SECRET_ACCESS_KEY=test -e AWS_DEFAULT_REGION=us-east-1 amazon/aws-cli:2.17.50"
+
+    # SeedRunner writes the canonical Delta fixture to floecat-delta. Copy it to a bucket that is
+    # deliberately absent from COMPOSE_SMOKE_LOCALSTACK_BUCKETS, so no Floecat storage authority
+    # can make the validation read or the gateway vend pass without the share issuing credentials.
+    $sharing_aws_cli --endpoint-url http://localstack:4566 s3 cp \
+      "s3://floecat-delta/$COMPOSE_SMOKE_DELTA_SHARING_TABLE/" \
+      "$sharing_location/" \
+      --recursive >/dev/null
+
+    # The stub answers metadata with the fixture's own schema, read from the log the copy above
+    # just placed. Written to the directory the stub reads per request, because the fixture does
+    # not exist until the stack is up and the container is already running by then.
+    local sharing_log_json
+    sharing_log_json=$($sharing_aws_cli --endpoint-url http://localstack:4566 s3 cp \
+      "$sharing_location/_delta_log/00000000000000000000.json" - 2>/dev/null)
+    if [ -z "$sharing_log_json" ]; then
+      echo "[FAIL] $label could not read the Delta log for $sharing_location"
+      return 1
+    fi
+    if [ -z "$smoke_tls_dir" ]; then
+      echo "[FAIL] $label Delta Sharing stub has no configuration directory"
+      return 1
+    fi
+    if ! printf '%s' "$sharing_log_json" | SHARING_SCHEMA_OUT="$smoke_tls_dir/schema.json" python3 -c '
+import json
+import os
+import sys
+
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    action = json.loads(line)
+    if "metaData" in action:
+        schema = action["metaData"].get("schemaString", "")
+        if not schema:
+            break
+        with open(os.environ["SHARING_SCHEMA_OUT"], "w", encoding="utf-8") as handle:
+            handle.write(schema)
+        sys.exit(0)
+sys.exit(1)
+' ; then
+      echo "[FAIL] $label Delta log for $sharing_location carried no metaData schemaString"
+      return 1
+    fi
+
+    # Before anything is created: the whole scenario rests on this bucket having no authority, and
+    # a seeded fixture that happened to cover it would make every assertion below vacuous.
+    assert_no_authority_covers "$compose_cmd" \
+      "$label Delta Sharing integration" "$sharing_location"
+
+    local sharing_setup_out
+    sharing_setup_out=$(run_cli_script "$compose_cmd" "account t-0001
+catalog create $sharing_catalog --desc compose-smoke-delta-sharing
+integration create $sharing_integration_name delta-sharing $COMPOSE_SMOKE_DELTA_SHARING_URI --auth-type bearer --cred token=$COMPOSE_SMOKE_DELTA_SHARING_TOKEN --props s3.endpoint=$COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_S3_ENDPOINT s3.path-style-access=true s3.region=$COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_S3_REGION
+overlay create $sharing_overlay_name $sharing_integration_name $sharing_catalog --include $sharing_namespace
+quit")
+    echo "$sharing_setup_out"
+    assert_contains "$label Delta Sharing integration setup" "$sharing_setup_out" "INTEGRATION_ID"
+    assert_contains "$label Delta Sharing overlay setup" "$sharing_setup_out" "OVERLAY_ID"
+    assert_not_contains "$label Delta Sharing setup reported no error" "$sharing_setup_out" "! "
+
+    local sharing_validation_out
+    sharing_validation_out=$(run_cli_script "$compose_cmd" "account t-0001
+integration validate $sharing_integration_name
+quit")
+    echo "$sharing_validation_out"
+    assert_contains "$label Delta Sharing integration validation" "$sharing_validation_out" "valid: true"
+    assert_contains "$label Delta Sharing discovery validation" "$sharing_validation_out" "DISCOVERY"
+    assert_contains "$label Delta Sharing credential vending validation" "$sharing_validation_out" "CREDENTIAL_VENDING"
+    assert_contains "$label Delta Sharing storage access validation" "$sharing_validation_out" "STORAGE_ACCESS"
+
+    # The share was asked, not merely reachable. STORAGE_ACCESS above reads the object store with
+    # whatever the vend returned, and no authority covers that bucket, so a pass already implies
+    # this -- but only this names the request, which is what distinguishes a vend from a fallback.
+    assert_stub_vended_credentials "$compose_project" "$label Delta Sharing" \
+      "$COMPOSE_SMOKE_DELTA_SHARING_SHARE" "$COMPOSE_SMOKE_DELTA_SHARING_SCHEMA" \
+      "$COMPOSE_SMOKE_DELTA_SHARING_TABLE"
+
+    # Split from the object listing for the reason the Unity block states: run_cli_script echoes
+    # the script it runs, so listing under the share makes the schema assertion a real check.
+    local sharing_namespace_out
+    sharing_namespace_out=$(run_cli_script "$compose_cmd" "account t-0001
+integration namespaces $sharing_integration_name
+integration namespaces $sharing_integration_name --parent $COMPOSE_SMOKE_DELTA_SHARING_SHARE
+quit")
+    echo "$sharing_namespace_out"
+    assert_contains "$label Delta Sharing share discovery" "$sharing_namespace_out" "$sharing_namespace"
+
+    local sharing_objects_out
+    sharing_objects_out=$(run_cli_script "$compose_cmd" "account t-0001
+integration objects $sharing_integration_name $sharing_namespace
+quit")
+    echo "$sharing_objects_out"
+    assert_contains "$label Delta Sharing object discovery" "$sharing_objects_out" "$COMPOSE_SMOKE_DELTA_SHARING_TABLE"
+    assert_contains "$label Delta Sharing table-kind discovery" "$sharing_objects_out" "TABLE"
+
+    local sharing_reconcile_out
+    sharing_reconcile_out=$(run_cli_script "$compose_cmd" "account t-0001
+overlay reconcile $sharing_overlay_name
+quit")
+    echo "$sharing_reconcile_out"
+    assert_contains "$label Delta Sharing overlay reconciliation" "$sharing_reconcile_out" "tables_created: 1"
+    assert_contains "$label Delta Sharing overlay completeness" "$sharing_reconcile_out" "branches_skipped: 0"
+    assert_contains "$label Delta Sharing overlay completeness" "$sharing_reconcile_out" "objects_skipped: 0"
+
+    local sharing_table_out
+    sharing_table_out=$(run_cli_script "$compose_cmd" "account t-0001
+resolve table $sharing_expected_table
+describe table $sharing_expected_table
+quit")
+    echo "$sharing_table_out"
+    assert_contains "$label Delta Sharing table materialized" "$sharing_table_out" "table id:"
+    assert_contains "$label Delta Sharing avoids Connector identity" "$sharing_table_out" "connector_id: -"
+    assert_contains "$label Delta Sharing carries Integration identity" "$sharing_table_out" "floecat.catalog-integration.id ="
+    assert_contains "$label Delta Sharing carries Overlay identity" "$sharing_table_out" "floecat.catalog-overlay.id ="
+
+    # A two-level upstream namespace, share then schema, so the Iceberg REST separator applies the
+    # same way the Unity block describes.
+    local sharing_ns_path="${sharing_namespace//./%1F}"
+    assert_gateway_vends_session_tuple "$compose_project" \
+      "$label Delta Sharing Catalog Integration" \
+      "http://iceberg-rest:9200/v1/${sharing_catalog}/namespaces/${sharing_ns_path}/tables/${COMPOSE_SMOKE_DELTA_SHARING_TABLE}"
+
+    # A recipient token the share does not accept must fail, or none of the above proves the token
+    # was ever checked. Its own integration, so the working one is left as it is.
+    local sharing_wrong_token_out
+    sharing_wrong_token_out=$(run_cli_script "$compose_cmd" "account t-0001
+integration create smoke-delta-sharing-wrong-token delta-sharing $COMPOSE_SMOKE_DELTA_SHARING_URI --auth-type bearer --cred token=not-the-recipient-token
+integration validate smoke-delta-sharing-wrong-token
+quit")
+    echo "$sharing_wrong_token_out"
+    assert_contains "$label Delta Sharing rejects a wrong recipient token" "$sharing_wrong_token_out" "valid: false"
+
+    # The reference-server shape, which is the one a real recipient meets and the one the stub was
+    # hiding by always answering generously: no accessModes, and no location on either the listing
+    # or the metaData action, so the credential response is the only surface that names it. This is
+    # where the ask-rather-than-refuse default and the credential-response location fallback are
+    # actually exercised; unit tests cover them, nothing end to end did.
+    echo "==> [SMOKE] Delta Sharing reference-server response shape"
+    local sharing_bare_catalog="${sharing_catalog}_bare"
+    local sharing_bare_integration="smoke-delta-sharing-bare"
+    local sharing_bare_overlay="smoke-delta-sharing-bare-overlay"
+    if ! FLOECAT_DELTA_SHARING_ACCESS_MODES="" \
+      FLOECAT_DELTA_SHARING_STATE_LOCATION=false \
+      eval "$compose_cmd up -d --force-recreate delta-sharing-stub" >/dev/null; then
+      echo "[FAIL] $label could not restate the Delta Sharing stub"
+      return 1
+    fi
+    wait_for_url_with_ca \
+      "https://localhost:${FLOECAT_DELTA_SHARING_HOST_PORT:-8445}/_smoke/requests" \
+      180 \
+      "Delta Sharing stub health after restatement" \
+      "$smoke_tls_cert_file"
+
+    local sharing_bare_out
+    sharing_bare_out=$(run_cli_script "$compose_cmd" "account t-0001
+catalog create $sharing_bare_catalog --desc compose-smoke-delta-sharing-bare
+integration create $sharing_bare_integration delta-sharing $COMPOSE_SMOKE_DELTA_SHARING_URI --auth-type bearer --cred token=$COMPOSE_SMOKE_DELTA_SHARING_TOKEN --props s3.endpoint=$COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_S3_ENDPOINT s3.path-style-access=true s3.region=$COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_S3_REGION
+overlay create $sharing_bare_overlay $sharing_bare_integration $sharing_bare_catalog --include $sharing_namespace
+integration validate $sharing_bare_integration
+overlay reconcile $sharing_bare_overlay
+quit")
+    echo "$sharing_bare_out"
+    # Validation has to reach the storage probe, which for this shape can only resolve the location
+    # from the credential response.
+    assert_contains "$label Delta Sharing bare-shape validation" "$sharing_bare_out" "valid: true"
+    assert_contains "$label Delta Sharing bare-shape storage access" "$sharing_bare_out" "STORAGE_ACCESS"
+    assert_contains "$label Delta Sharing bare-shape reconciliation" "$sharing_bare_out" "tables_created: 1"
+    assert_contains "$label Delta Sharing bare-shape completeness" "$sharing_bare_out" "objects_skipped: 0"
+
+    # And the table carries a location a reader can open, rather than the Integration's catalog URI.
+    local sharing_bare_table_out
+    sharing_bare_table_out=$(run_cli_script "$compose_cmd" "account t-0001
+describe table $sharing_bare_catalog.$sharing_namespace.$COMPOSE_SMOKE_DELTA_SHARING_TABLE
+quit")
+    echo "$sharing_bare_table_out"
+    assert_contains "$label Delta Sharing bare-shape storage location" \
+      "$sharing_bare_table_out" "$sharing_location"
+
+    # The flat legacy shape, which a server ignoring the capability header answers with.
+    echo "==> [SMOKE] Delta Sharing legacy response format"
+    if ! FLOECAT_DELTA_SHARING_RESPONSE_FORMAT=parquet \
+      eval "$compose_cmd up -d --force-recreate delta-sharing-stub" >/dev/null; then
+      echo "[FAIL] $label could not restate the Delta Sharing stub to the legacy format"
+      return 1
+    fi
+    wait_for_url_with_ca \
+      "https://localhost:${FLOECAT_DELTA_SHARING_HOST_PORT:-8445}/_smoke/requests" \
+      180 \
+      "Delta Sharing stub health after legacy restatement" \
+      "$smoke_tls_cert_file"
+    local sharing_flat_out
+    sharing_flat_out=$(run_cli_script "$compose_cmd" "account t-0001
+integration validate $sharing_integration_name
+quit")
+    echo "$sharing_flat_out"
+    assert_contains "$label Delta Sharing legacy-format validation" "$sharing_flat_out" "valid: true"
+  elif [ "$smoke_scope" = "full" ] && [ "$profile" = "localstack" ]; then
+    echo "==> [SMOKE] skipping Delta Sharing integration (set COMPOSE_SMOKE_DELTA_SHARING_IMPORT=true to enable)"
   fi
 
   if [ "$smoke_scope" = "full" ] && [ "$profile" = "localstack" ] && should_run_client trino; then


### PR DESCRIPTION
## Summary

Adds Delta Sharing as a Catalog Integration type, so a share a partner grants you can be reconciled into a Floecat catalog and read through vended storage credentials.

Integration type only, and directory access only. The protocol offers two ways to read a shared table: `dir` mode issues temporary cloud credentials over the table's location, and `url` mode returns presigned per-file URLs from a query endpoint. Only the first is expressible as a storage credential, so a share offering `url` alone is unsupported here rather than partially supported: such a table is discoverable and describable, and refused when the overlay reconciles rather than materialized as a table nothing can open.

Changes:

- `CIT_DELTA_SHARING` and its `CatalogProtocol.DELTA_SHARING` mapping. Bearer only, because the sharing protocol defines no other scheme.
- A recipient client under `connectors/clients/delta-sharing`: shares, schemas, tables, metadata and temporary table credentials, with paging, NDJSON, both metadata response shapes and three cloud credential shapes decoded in the transport. Deliberately no query method.
- A provider under `catalog-access/delta-sharing`. `share.schema.table` maps onto `NamespacePath` without translation, and the vend publishes the temporary-table-credentials session triad scoped to the location the server named.
- Two shared modules, both extracted from Unity because a second Delta-backed provider needs the same thing: `core/http-endpoint-guards` for the catalog and storage endpoint gates, and `catalog-access/delta-common` for the Delta log storage probe.
- A validation fix that is not Delta Sharing specific: a provider answering `UNSUPPORTED` now reports the `_UNSUPPORTED` issue rather than `_FAILED`, because a capability can be per table rather than per integration.
- A compose smoke scenario covering the vend end to end.

## Type of Change

- [x] feat (new functionality)
- [x] fix (bug fix)
- [ ] docs (documentation only)
- [x] refactor (no behavior change)
- [x] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

- [x] `make fmt`
- [ ] `make verify`
- [x] Added/updated tests for changed behavior

Full offline unit suite green across the repo, zero failures. Every behaviour this PR fixes has a test that fails without the fix.

**The compose smoke ran in CI and the Delta Sharing scenario passed**, with zero `[FAIL]` lines in the job and all four smoke modes green:

```
[PASS] Delta Sharing integration no storage authority covers s3://floecat-sharing-vended/call_center
[PASS] Delta Sharing integration validation        (valid: true)
[PASS] Delta Sharing credential vending validation
[PASS] Delta Sharing storage access validation
[PASS] Delta Sharing share vended temporary credentials for floecat_smoke.sharing.call_center
[PASS] Delta Sharing overlay reconciliation        tables_created: 1, branches_skipped: 0, objects_skipped: 0
[PASS] Delta Sharing Catalog Integration gateway credential vending
[PASS] Delta Sharing rejects a wrong recipient token
```

The fixture lives in a bucket absent from `COMPOSE_SMOKE_LOCALSTACK_BUCKETS` and the scenario asserts no authority covers it *before* creating anything; `CIVCT_STORAGE_ACCESS` is a real `ListObjectsV2` plus a ranged `GetObject` using only what the share vended; and the stub reports its own request log, so the credential call is named rather than inferred from a check that passed.

The scenario has two further variants, both green in CI: `bare-shape`, which recreates the stub in the reference server's shape and sends neither `accessModes` nor a location on any listing, and `legacy-format`, which answers in the flat `parquet` response format. Those are the end-to-end exercise of the three-surface location chain and the legacy shape argued for below:

```
[PASS] Delta Sharing bare-shape validation
[PASS] Delta Sharing bare-shape reconciliation
[PASS] Delta Sharing bare-shape storage location
[PASS] Delta Sharing bare-shape storage access
[PASS] Delta Sharing bare-shape completeness
[PASS] Delta Sharing legacy-format validation
```

What the smoke does not cover is a Delta scan through `S3V2FileSystemClient`: no fixture has a space in its object key, which is the shape the canonicalized location addresses.

The unstated-modes half of that variant did nothing until this round. It sets the stub's `SHARING_ACCESS_MODES` to empty, and the compose default was written `${VAR:-url,dir}`, which substitutes the default for an empty value as well as an unset one -- so the stub restarted advertising `url,dir` and kept sending the field. It is `${VAR-url,dir}` now, which `docker compose config` confirms: unset resolves to `url,dir`, explicitly empty resolves to empty. Its two neighbours keep `:-` deliberately, since an empty response format is not a shape the stub can serve.

## Deployment and Compatibility

- [x] No breaking changes
- [ ] Breaking changes (describe below)
- [x] Config/env var changes (describe below)

Additive. A new enum value, two new connection properties, and two new modules; no existing behaviour changes except the validation issue mapping below.

New connection properties, both optional:

- `delta.sharing.strict-access-modes` -- reads a table stating no access modes as `url` only, refusing without a round trip. Off by default; see the Reviewers note.
- `delta.sharing.reader-features` -- comma-separated Delta reader features this deployment can process. Empty by default.

`FLOECAT_SECURITY_ALLOW_CLEARTEXT_S3_ENDPOINTS` now governs the Delta Sharing `s3.endpoint` as well as Unity's, for the same reason: this vend also publishes an AWS session token.

Three system properties bound what one recipient client will pull: `floecat.delta-sharing.max-pages`, `floecat.delta-sharing.max-response-bytes` and `floecat.delta-sharing.max-listing-bytes`. All three are documented in `docs/operations.md` alongside the connection properties, matching how the Unity equivalents are already documented.

`s3.region` is now resolved for a Delta Sharing Integration the way it already was for Unity, from the stated region aliases or the deployment default. Both run the same Delta log probe, whose `us-east-1` fallback would otherwise answer PermanentRedirect for a share whose table lives elsewhere -- an Integration permanently reporting a storage-access failure that does not exist in practice.

**The `UNSUPPORTED` remapping also changed one signal it should not have, and that is corrected here. The storage probe's "no Delta log object" branch is not a capability boundary: an empty log prefix means the location is not a table root -- a wrong region, a wrong prefix, a broadly scoped credential -- all of which an operator can correct. It now reports `INVALID_CONFIGURATION`, so validation shows `CIVI_STORAGE_ACCESS_FAILED` rather than a terminal `..._UNSUPPORTED`, which is the signal that branch carried before this PR. `docs/operations.md` also lists the refusal shapes completely now: auxiliary locations and an unservable cloud were missing, and the no-location entry conflated a skip with a classified failure.

One behaviour change reaches Unity today.** `CatalogIntegrationDiscovery` now maps an upstream `UNSUPPORTED` to `CIVI_CREDENTIAL_VENDING_UNSUPPORTED` / `CIVI_STORAGE_ACCESS_UNSUPPORTED` instead of the `_FAILED` issue. `UnityCatalogAccessClient.vendStorageCredentials` already answers `UNSUPPORTED` on several paths -- a non-AWS cloud, a table the provider cannot vend for, an Integration that does not delegate -- and so does the storage probe when a table has no addressable S3 location or no Delta log object. A Unity Integration whose sampled tables all refuse that way previously validated as `CIVI_CREDENTIAL_VENDING_FAILED` and now validates as `..._UNSUPPORTED`. That is the intent of the fix rather than a side effect, but a UI keying on the issue enum will see the changed value. `valid: false` either way; the check status and summary are unchanged.

## Checklist

- [x] PR is scoped and focused
- [x] Commit messages follow conventional commit style where practical
- [x] Documentation updated where needed
- [x] No credentials, tokens, or secrets are included
- [x] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

## Reviewers

- **A table stating no access modes is asked rather than refused, and the default is deliberate.** The protocol reads an absent `accessModes` as `url` only. The reference server implements `temporary-table-credentials` against a real `AwsCredentialVendor` and never sends the field -- a repository-wide search finds `accessModes` only in `PROTOCOL.md`, and PR delta-io/delta-sharing#845, which added directory access to the protocol, changed exactly that one file. Holding to the protocol reading refuses every table on a server that would have answered. So the vend asks and reports what the server says: `NOT_FOUND` (no such endpoint) and `INVALID_REQUEST` (the protocol's own refusal for a table not offering `dir`) become `UNSUPPORTED`, while a rejected token or an unreachable server is reported as itself. That mapping is not gated on whether the table stated its modes. The vend applied it only to an unstated table, so one HTTP 400 was a capability boundary on the load path and a configuration error on the vend path; the server's refusal settles it either way, since a table whose listing claims `dir` and whose credential endpoint refuses does not have directory access. Both paths now reach the server through one classifier, which is also what makes the two answers impossible to drift apart. A table that explicitly says `["url"]` is refused either way -- the knob only governs the ambiguous case. The modes are read from the `metaData` action as well as the listing, because the delta response format carries them there and a server may use either. A refusal on either surface is decisive, and that is a change: the load preferred the listing while the vend reads the metaData action alone, so a server saying `dir` on one and `url` on the other reconciled at the load and was refused at the vend on every read for the life of the table. The load cannot be more permissive than the vend, and the vend sees one surface, so both are consulted here and either one refusing settles it. The opposite disagreement is refused too, which costs only a table that nothing could have read through this path. The load path prefers the listing; the vend reads the metadata action and, under the strict setting only, falls back to the listing before refusing -- strict refuses without asking the server, so it must not refuse on a half-consulted answer.

- **The vend checks the credential covers the table, and validation probes it.** Only validation calls `validateStorageAccess`, so a check made solely there left every runtime resolve unguarded against a server returning a credential scoped somewhere unrelated or far broader; the vend now makes the same check the Unity provider makes in its own -- and so does the load, for the surface the vend cannot see. Where a surface states a location and the credential endpoint has also answered, the two are compared: reconciling a stated location the answered credential does not reach materialises a table every read of which is scoped elsewhere, and validation is optional, so nothing else need catch it. A credential scoped *above* the stated location still reaches it and is left alone. It is not quite the same check on every server shape, and the difference is worth stating: the vend reads the location from the metadata action alone, while the load resolves the listing first, so a server stating a location only on its listing reconciles and then has nothing for the vend to compare a scope against. The check is skipped rather than failed there, because the alternative is a schema listing per read -- the cost this path was changed to avoid. Validation consults both surfaces, so an operator sees a mis-scoped credential then; what is not caught is a server that begins mis-scoping afterwards. Closing it means carrying the load's location to the vend, and the vendor's fresh-client-per-resolve shape gives nowhere to put it. On the validation path, scope first, then probe. `covers()` answers without a network call and a credential scoped elsewhere is a provider bug rather than a permission an operator can grant. The probe then does the real read, because scope alone passes on a grant that cannot read -- the failure an operator otherwise finds at query time. Where the listing carries no location, which is exactly the unstated-access-modes case, it falls back to the metadata endpoint.

- **The smoke uses a stub, and the reason is upstream packaging rather than preference.** The OSS server does implement directory access -- PR delta-io/delta-sharing#854, merged March 2026 -- but no published image contains it: `deltaio/delta-sharing-server` tags stop at 0.7.8 from April 2024. Running the real server means building Scala from source in the harness. The stub answers in the delta response format by default, so the smoke exercises the shape a conforming server sends rather than the flat one that happened to parse. Separately, its STS client is AWS SDK v1 with no endpoint override, though the harness already solves that class of problem for Unity with a `sts.us-east-1.amazonaws.com` network alias.

- **The vend reads one table's metadata; it does not list the schema.** A credential is vended on every storage-authority resolve, so finding the table by listing paged the whole schema before every credential POST -- unbounded in the schema's table count, and quadratic across a reconcile that loads each listed table. The delta response format carries the access modes, location and auxiliary locations on the metadata action, which is everything the listing was consulted for, so `findTable` survives only in `loadTable`, where the share id is needed and no other source has it. That listing is memoised per schema for the client's lifetime, which is one reconcile pass: the reconciler lists a schema once and then loads every table in it, so looking each one up by paging the listing again made the pass quadratic. The vend pages nothing at all -- `SourceCatalogCredentialVendor` opens a fresh client per resolve and closes it in the same method, so a listing there is never absorbed by that memo. Tests assert the listing is never called on the vend or probe paths, and called once across three loads.

- **A table id is scoped to its share, so the identity is too.** The protocol makes a table id unique within its share and `shareId` unique across the server, so a bare table id collides between two shares -- including the same underlying table shared twice -- and the reconciler abandons an overlay over a duplicate stable identity. The identity is `shareId:tableId`, falling back to the metadata action's id before falling back to a name, and reported unstable when the share component is a name rather than an id.

- **A table with auxiliary locations is refused before it reconciles.** The protocol wants `temporary-table-credentials` called once per location, root and auxiliary alike, and tells a client that cannot read from several to fall back to url access or raise. The storage contract carries one credential over one scope prefix, so there is nothing to carry the rest; vending only the root would reconcile and validate cleanly and then fail at query time on the auxiliary files.

- **`Failure.OTHER` maps to `UNAVAILABLE`, not `UNSUPPORTED`.** A review suggested a new SPI code for unclassified upstream statuses. I used the existing one instead: a new enum value forces a decision at four consumer switches that have no distinct answer for it, and `INTERNAL` would have been worse because `GrpcErrors` hides an `INTERNAL` message, losing the HTTP status that makes the failure diagnosable. `UNAVAILABLE` already means the upstream stalled or fell over, keeps the status in the message, and reports `CIVI_CREDENTIAL_VENDING_FAILED` rather than the unsupported issue. The cost is that an unclassified 451 is treated as possibly-transient and ends the validation walk rather than skipping one table, which is the safer reading for a status likely to affect the whole share.

- **An envelope this client cannot use is a classified failure, not an IllegalArgumentException.** A credentials response missing its location, its expiry, a recognised cloud or part of its AWS session, and a metaData action missing its schema, all escaped unclassified -- most through the record's own `requireText` as an `IllegalArgumentException`, and the incomplete AWS session as `UNSUPPORTED`, which is a per-table skip meaning the provider will never do this -- past this transport's classification and past the catalog client's `translate`, arriving at the reconciler naming neither the table nor the server. The expiry is the one that mattered most: `SourceCatalogCredentialVendor` refuses a Catalog Integration session without one, while validation does not read an absent expiry as expired, so a share omitting it would have reported the integration valid and then failed every read. All three int64 fields -- `expirationTime`, `minReaderVersion` and `version` -- take one rule, and it parses with `Long`: an expiry in epoch milliseconds overflows an int, so a server rendering it as a JSON string, which is the standard protobuf encoding for int64, has to be accepted. It is type-checked as well, the way `version` and `minReaderVersion` are: `asLong` answers 1 for `true`, which clears both bounds and yields an expiry one millisecond after the epoch -- a session the vendor then refuses as expired, reported to an operator as an expired credential rather than a malformed response. It is bounded above as well, which it was not: a value past the last instant a proto `Timestamp` carries is a unit mismatch rather than a date -- microseconds where milliseconds were meant, which Unity deployments have been seen to send -- and without the bound it passes every downstream expiry check by looking far in the future and then throws inside `Timestamps.fromMillis` while the gRPC response is built, as an unclassified `RuntimeException` in a handler, on a share that validated clean, for every read. `MAX_EXPIRY_EPOCH_MILLIS` already existed in `FloecatConnector` and in the Unity client; this parser had only the lower half of the check.

- **The response cap cannot be the largest int.** The bounded reader asks for the cap plus one byte to spot an overrun, and that addition overflows at `Integer.MAX_VALUE` -- so a deployment setting `floecat.delta-sharing.max-response-bytes` to its largest allowed value got a negative length and every response failed as a transport error. The Unity client already refuses that value on the same property; this one copied the pattern without the guard.

- **A table reconciles with a storage location or not at all.** Five shapes are refused at the load and counted in `objects_skipped`: `url` access alone; no stated modes under `delta.sharing.strict-access-modes`; a server that will not vend for the table, which is `NOT_FOUND` or the protocol's own `INVALID_REQUEST` and is the shape a table with no obtainable location actually takes; a credential scoped to a whole bucket; and a location on a cloud this provider cannot vend for -- an `abfss://` or `gs://` table would otherwise load, reconcile, and fail at every scan when the vend refused its cloud. Strict mode applies only where the modes were genuinely absent, which is the ambiguous case it governs; an earlier revision refused a table stating `dir` with no location and told the operator it stated no modes. They were not always treated alike -- an earlier revision refused the third and let the first materialize, which is the same unreadable outcome by a different route -- and collapsing them into one rule is what made that visible. Strict mode consults the listing when the metaData action states nothing, matching the vend's own fallback, so it does not spend a credential request per table against a server stating its modes where the protocol defines them -- both surfaces are already in hand, so that costs nothing. It refuses without a request, since asking where an unstated table lives is the round trip the knob turns off, and answering would reconcile a table whose every vend then fails. It also refuses whether or not a location was found, which it did not before: the check sat below the load's early return on a stated location, so an unstated table whose listing named a location loaded and was then refused by the vend on the rule the load had skipped. That is the reconcile-then-fail-every-read outcome, arrived at by the two paths disagreeing rather than by either being wrong on its own. Knowing where a table lives says nothing about whether it may be read that way, which is the only question the knob answers, and a test now asserts both paths refuse the same shape.

- **A space in an object key is a location, and the location that reconciles has to be readable.** `java.net.URI` rejects a space and S3 permits it in a key, so `s3://bucket/db/my table` answered no parse at all: the shared probe read it as having no addressable bucket and this provider reported it as living on no addressable scheme -- pointing an operator at cloud support for a table that was fine, and counting it in `objects_skipped`. The space is percent-encoded before parsing, and `getPath` decodes it again so the key the probe asks S3 for is the key that was written. Other characters `URI` rejects and S3 permits still answer no parse; a space is the one that occurs, and the test says which is which. Listed paths are built by encoding the path alone, with no host for `URI` to validate: passing the bucket as a host makes `URI` reject exactly the names below, and the fallback then emits the raw key, losing the encoding for the one bucket shape this supports. The reader also derives a bucket the way the probe does, falling back to the authority where `getHost` answers null -- S3 permitted names `java.net.URI` will not parse as a host, an underscore being the one that survives in older regions. A name the probe accepts and the reader cannot address is a table that reconciles and then fails every scan. It also required a change to the reader, without which none of it worked. Encoding the root made the *table* parseable and not a scan of it: `S3V2FileSystemClient.listFrom` rebuilt every listed path as `"s3://" + bucket + "/" + S3Object.key()`, from the raw key, so the second Delta log entry arrived with the space restored and `URI.create` rejected it -- a table that reconciled, validated, and failed at scan, which is the outcome the canonicalisation exists to prevent. Listed paths are now built a segment at a time, and `getPath` decodes, so S3 is asked for the key that was written. Encoding the key as one path was wrong in exactly the shape `stripLeadingSlash` preserves: an S3 key may begin with a slash, so the string handed to `URI` opened `//`, which it read as an authority -- `getRawPath` answered without the first segment and raised nothing, so the fallback never ran and every entry listed under `s3://bucket//table` addressed a key missing its leading name. Splitting on the separator keeps the empty leading segment that slash stands for, and no single segment can hold a slash to re-parse. For a key holding nothing `URI` objects to the result is byte-identical to the concatenation it replaces, so only the paths that used to throw change at all. Refusing such tables instead was the alternative, and the wrong one: the consumers here are query workers and scan ingest, and they have to be able to read them. This reaches Unity too, through the same probe -- and for a while it reached Unity with only the probe half, which was worse than not fixing it. Unity kept publishing the raw string, so a table it used to refuse outright became one that validates clean and fails at scan. The rule now lives in `DeltaLogStorageProbe.canonicalLocation`, beside the probe whose encoding created the need for it, and both providers call it: Unity canonicalizes at its publish, its vend scope, its coverage comparison and its validation probe, with a regression test on the publish path. One rule, two callers, which is what this module is for.

  It preserves an `s3a://` scheme, folding only what the reader genuinely cannot parse -- `s3n` and any uppercase form, since `resolvePath` matches a literal lowercase `s3://` or `s3a://`. Folding `s3a` too would have put the stored location in a different scheme namespace from the prefix an operator registers: `StorageAuthorityResolver.matchesLocationPrefix` is a scheme-sensitive `startsWith` and `S3Location.parse` accepts an `s3a://` authority prefix, so a catalog reporting `s3a`, an authority registered as `s3a`, and a location stored as `s3` would never match. It also keeps a trailing space, since an S3 key may end in one and the probe does not trim either -- trimming published a different prefix from the one validation had just read. And it canonicalizes the scheme as well as the space, which it did not at first, and the gap had the same shape as the one it was written to close. `s3Serves` accepts what `StorageLocations.normalizeScheme` folds -- `s3`, `s3a`, `s3n` in any case -- while the reader's `resolvePath` matches a literal lowercase `s3://` or `s3a://` and throws on anything else. So `s3n://bucket/table` and `S3://bucket/table` validated, reconciled, and failed every scan. A helper named canonical was canonicalizing one of the two things that vary; a test now asserts everything `s3Serves` accepts is published as lowercase `s3://`.

  Encoding it only inside the probe was half a fix, and the half that was missing turned a clean refusal into a worse outcome. `requireServable` returned the string the server sent, so the table materialised as `s3://bucket/db/my table` -- and the read path calls `URI.create` on the resolved path at every site in `S3V2FileSystemClient`, which is what rejects a raw space. Before the encoding change such a table was refused at load and counted in `objects_skipped`; after it, the table reconciled, validated clean, and failed every scan. The canonical form is now what this provider publishes, vends and compares, on both sides of `covers()` -- a prefix test with one side encoded would make every such table look scoped elsewhere. Encoded rather than refused because the read path derives its key with `URI.getPath`, which decodes, so S3 is asked for the key that was written; and idempotent, since only a literal space is replaced.

- **A location does not establish directory access, and the default setting now asks even when one is stated.** The protocol permits a url-only server to state a location, so a legacy server that omits its access modes, names a location and refuses `temporary-table-credentials` is exactly the shape the ask exists to catch -- and the load's early return on a stated location was skipping it. That table reconciled and every read of it failed. An unstated table is now asked about whether or not a location is known, and the server's refusal arrives as `UNSUPPORTED` and skips it. This costs one credential request per unstated table at the load, which is the round trip the non-strict default is, and `delta.sharing.strict-access-modes` is still the way to refuse without it. A location a surface stated is what the table reconciles with; the credential's scope is only stood in for where no surface named one.

- **The credential request advertises the response type the protocol specifies, and reads both framings it offers. The whole body is parsed first, since a single-action ndjson body is itself valid JSON and that covers a server formatting its JSON across lines; line-by-line parsing is the fallback for a body genuinely carrying more than one document, which is exactly what a whole-body parse rejects. Offering ndjson while parsing a single document would fail a server that took the offer, since a second line is a trailing token -- and that arrives as `INVALID_RESPONSE`, which reaches the client as `INTERNAL` and ends the whole reconcile rather than skipping a table. A single JSON body is one line of ndjson, so both framings go through the same reader.** It sent `Accept: application/json` alone, and that response is specified as `application/x-ndjson` carrying a single JSON action -- so a server honouring content negotiation could answer 406 to every credential request, which is every reconcile and every read. It now advertises both. The parser is unaffected either way, since nothing here inspects a response content type and a one-action ndjson body is valid JSON; and the stub answers `application/json` while enforcing no negotiation, so nothing in the smoke would have caught this.

- **A location that carries a secret is not a location this serves.** `bucketOf` refuses an authority holding userinfo, but only on its fallback branch: `getHost()` answers `bucket` for `s3://user:password@bucket/table`, so that check never ran and the location was servable. A provider then stores it as the reconciled table's `storage_location` -- a password, or a signed query, in catalog metadata that anything able to read the table can read. Userinfo, query, fragment and a port are all refused now, the same set the endpoint gates already refuse on a catalog URI and none of which belong in an S3 object location.

- **The probe removes the URI separator, not every slash it finds.** An S3 object key may begin with one, so `s3://bucket//table` names the key `/table`. The read path strips exactly one and addresses that; this stripped all of them and probed a different prefix, so validation either rejected a readable table or read whatever Delta log sat at the stripped prefix and reported success for a location no scan would reach.

- **A table's location comes from three surfaces, and a table without one is refused.** The listing, then the metaData action, then the credential response. The reference server names it on neither of the first two -- both predate directory access, as its absent `accessModes` shows -- and only the credential response carries it. Without that third source the reconciler stores no `storage_location` and `setUri(source.metadataLocation().orElse(integration.getCatalogUri()))` leaves the Integration's own HTTPS catalog URI as the table's upstream reference, so the table materializes and cannot be opened by anything reading object storage. The credential call is made only when the first two are silent and neither earlier refusal applies. Validation consults the same three surfaces, ending at the scope the credential named, since on a server that states a location nowhere else that is the only one there is; without it validation refused every table before attempting a read. Taking the credential's scope as the table's root is sound because the protocol says a request naming no location answers for the table's main location, but nothing holds a server to that, so a bare bucket is refused outright. That is a narrower rule than the vend's scope check below, deliberately: tolerating a broad scope concerns a location some other surface already established, while here this is the only surface there is. Anything subtler than a whole bucket is left to validation, whose probe looks for a Delta log under the location and fails when the location is not a table -- a net rather than a proof, and named as one. The smoke stub can now withhold the location the way the reference server does, and both that and the response format are reachable from the harness, since always sending it is what hid this.

- **Nothing that carries a secret is attached as a cause or quoted in a message, and an echoed header is redacted by its name rather than by its value's shape. Every pass that had to recognise the credential was defeated in turn by a rendering nobody enumerated -- a colon, a JSON-escaped solidus, a backslash-u escape, percent-encoding -- so the redaction now matches the `Authorization` header *name* and discards everything after it to the first delimiter, whatever encoding the value arrived in. That covers a `Basic` credential too, which none of the token-shaped passes ever did. The token68 pattern stays behind it for a token quoted with no header name beside it, and the caller's own value stays as a third pass.** The token is validated when the client is constructed, because `HttpRequest.Builder.header` quotes the value it rejects and the send classifies anything it raises as `TRANSPORT` with the cause attached -- so a recipient token carrying a newline reached the cause chain the vendor logs, verbatim, on a request that never left the process. It is now refused by describing the character class and the index, never the value. That check stopped at the ASCII controls and the JDK's stops at `U+00FF`, so a token carrying an emoji passed construction and was refused by `HttpRequest.Builder.header` instead -- the same leak through the same channel, one character outside the range being checked. The range is now printable ASCII, narrower than the JDK's own `U+00FF` and deliberately so. A JSON serializer that escapes non-ASCII -- Python's default among them -- renders a token as `Bearer abc\u00e9SECRET` in an echoed body, where neither redaction pass reaches it: the literal is not present in that form and the pattern stops at the backslash. Closing that by unescaping, redacting and re-escaping would put more machinery in the one control that must not be subtly wrong, so the range is refused instead and the case disappears. A token outside printable ASCII is not a shape any deployment sends; the punctuation that does occur, a colon among it, still passes. Within that range the accepted set is the JDK's, and rather than restate another component's private rules construction also asks it directly: it builds the header it would send, discards it, and reports a refusal with no cause and no value. `0xFF` is pinned as still accepted, since that is where the JDK actually stops.

- **The shared storage-endpoint gate had it too.** `URI.create` quotes its whole input in its message and again in the nested `URISyntaxException`, and that exception was chained -- so a malformed endpoint carrying userinfo or a signed query put the secret into the chain a validation failure logs, on the one path where the value was never parseable enough to reach the userinfo check that exists to refuse it. The parse position is kept, the cause is dropped, and a test walks the whole chain.

- **A parser exception is never chained, on any path.** Jackson quotes the offending input in its message, so chaining a parse failure carried whatever the server echoed into the cause chain that `SourceCatalogCredentialVendor` logs. Withholding it only where the body was withheld was not enough: the recipient token that authorises the credential endpoint authorises the listing and metadata endpoints too, and those ask for the body. A redacted snippet is appended where the caller allows a body -- and the comment here claimed that already happened through `snippet()` while nothing called it, so a malformed 200 reached an operator as a parse position and nothing else, with the message hidden again at the gRPC boundary. The NDJSON path does the same, which it did not at first -- and that is the path a proxy error page arriving with a 200 actually lands on. It is withheld on the credential route, the one route that suppresses bodies: redaction covers the token this client sent, not the keys a credential response carries.

- **The redacted snippet names the token this client sent rather than guessing its shape.** The shared helper matched `Bearer` followed by the RFC token68 alphabet, which is what a bearer token is supposed to be. A recipient token need not be one: a header value permits characters the grammar does not, so a token carrying a colon matched only as far as it and the remainder reached the message -- in exactly the echoed-header case the control exists for. The client now passes the value it holds, and the literal is removed before the pattern runs, because the pattern rewrites the part that does match and so destroys the literal that would then be searched for. The token's JSON-escaped form is redacted alongside its raw one, because that is the form a body carries: a server echoing the header into JSON escapes the quotes and backslashes in it, both legal in a header value, so such a token survived the literal search -- and the pattern too, a quote being outside the token68 alphabet. The generic pattern stays as the backstop for a token the caller does not name -- and the Unity client, which is where this control started, is wired to the by-value form too. It had been left on the pattern alone: `bounded("Bearer abc:SECRET", 100)` answers `Bearer <redacted>:SECRET`, and a Unity bearer token is operator-supplied and under no obligation to match the grammar. Reaching it meant a `default Optional<String>` on `UnityCatalogAuthentication` for a fixed secret worth redacting, an override in the `bearer(token, ...)` factory, and nine methods in the client losing `static` so they can read it. The OAuth factory deliberately returns empty: reading a rotating token there means asking the provider for a value on a failure path, and a rotating access token is issued in the token68 shape the pattern already covers. The escaped renderings are covered too, the solidus most of all: `/` is inside the token68 alphabet and common in real tokens, so `abc/SECRET` echoed as `abc\/SECRET` was missed by the literal search and cut at the backslash by the pattern, leaving most of the token in the message. Its comparison de-escapes both sides the same way, which it did not at first: stripping backslashes from the body alone destroyed the evidence for a secret that contains one, so a token `\SECRET` echoed as a backslash-u escape stripped to `SECRET`, was compared against the raw `\SECRET`, matched nothing, and stayed reconstructable in the snippet -- while the pattern missed it too, the token beginning with a backslash. Behind those named forms is a check that fails closed -- if any de-escaping of the body would still reveal the secret, the body is withheld rather than published half-redacted. It de-escapes repeatedly rather than once, up to four layers, stopping as soon as a pass changes nothing: a doubly-escaped rendering survived a single pass, and a check that stops short of what the eventual reader will decode publishes the thing it was added to withhold. Reaching the layer bound withholds the body as well, so the bound fails closed too. It runs before the generic pattern, because that pattern rewrites the matching part of a token and would destroy the literal being looked for: the same ordering mistake as bounding before redacting, one layer further in. Redaction also had to move ahead of the character bound. Bounding first cut a token in half before anything looked for it, and the halves were covered by neither pass: the literal no longer matched, and the pattern stops at the first character outside the grammar, so a colon-bearing token echoed near the 2000-character bound left everything between the colon and the cut in the message. The whole body is scanned rather than a window around the cut, because a replacement is shorter than what it replaces and so pulls later text forward into the bounded range -- text a window would not have reached, and that can hold another occurrence.

- **The parser is strict where its defaults undid the guards.** Every shape check assumes the tree it inspects is what the server sent, and two Jackson defaults broke that before any check ran. `readTree` reads the first document and discards what follows, so `{"items":[]}{"items":[...]}` parsed as an empty page; and the last duplicate key wins, so a body naming tables and then restating `items` as empty parsed as empty. Both arrive looking well formed, and both land on the destructive side, since an empty inventory with no recorded skip is what the reconciler reads as the share having dropped its tables. `FAIL_ON_TRAILING_TOKENS` and `FAIL_ON_READING_DUP_TREE_KEY` are enabled, checked against the databind version this build resolves. The NDJSON path reads a line at a time, so a line carrying two concatenated actions is refused rather than half read.

- **One protocol action and one metaData action.** A second action of either kind silently overwrote the first, so a concatenated or malformed response materialised the later schema and location on a table that reconciled clean -- wrong data on a live table rather than a skipped one. That is the last-write-wins trap `FAIL_ON_READING_DUP_TREE_KEY` closes for duplicate keys, one level up at the action level, where multi-line framing is legal and so that setting does not reach it. Order is deliberately not enforced: the wire format states protocol then metaData, but accepting the reverse costs nothing and refusing it would fail a server that is otherwise correct.

- **The metaData action's scalars are held to the same rule as its arrays.** `version` is published as the `delta.sharing.version` property and `asLong` answers zero for a string or a container, so an unchecked malformed version is a table definition nobody sent rather than a failure; a `configuration` is a map of strings in this protocol: a stated value that is not an object leaves no properties at all, and a number, a boolean or a null coerces through `asText`, so the table carries metadata the server did not send. An object with string values, or nothing. The two `sendJson` overloads went with them -- nothing called either once every route read its body through `sendForBody`, `sendForBodyAndVersion` or `sendNdjson`, and a fourth body-reading path in a class whose argument is that framing and redaction must not drift between paths is surface worth removing.

- **An unrecognised access mode is a stated mode.** A value that is neither `url` nor `dir` was dropped, so `["dir2"]` decoded to the empty list -- the same value that means the server said nothing. Under `delta.sharing.strict-access-modes` such a table was then refused with a message saying it had stated no access modes, which is the misdiagnosis this PR removed for the dir-with-no-location case. An element that is not text is refused outright rather than mapped to `OTHER`, because `OTHER` beside a readable value runs the unsafe way: `[{"a":1}, "dir"]` decoded to `[OTHER, DIR]`, `contains(DIR)` answered true, and the table was treated as directory-accessible on a response this client could not read. An unrecognised *string* decodes to `OTHER`, which keeps the original intent, since a list holding `dir` and something unknown still holds `dir`, and the refusal for a table stating only unknown modes says that rather than claiming it offers url access. Both paths say it: validation's sampler sends names straight from `listTables` to the vend without loading them, so the vend's message is the one an operator running a validation actually sees.

- **A cursor has to be a scalar, an action has to be an action, a format provider has to be a name, an access mode has to be a mode, a stated field has to be a value, and only an empty cursor ends a listing.** `nextPageToken` was read with `asText("")`, which answers the empty string for a stated object or array, and an empty cursor reads as "no more pages" -- so a malformed cursor after a legitimate first page reported one page as the complete inventory, which is again what makes the reconciler retire the rest. A container is refused. Absent and null still mean the listing is done, since null is the ordinary idiom for it, and a numeric cursor is still accepted. `isBlank` was also the wrong test for the end of pagination: a cursor is opaque, the protocol ends on an absent, null or empty token and nothing else, so a whitespace token returned the first page as the complete authoritative inventory -- the retirement shape again. It needed its own encoder too, because `encode` refuses a blank string as an unusable path segment and would have raised an unclassified `IllegalArgumentException` out of a listing rather than send the token back. The metadata actions had the same hole in a third spelling: `has()` answers true for an explicit null and `parseProtocol` tolerates a null node, so `{"protocol":null}` satisfied the both-actions guard with a protocol action this client had invented -- a defaulted `minReaderVersion` and no reader features, for a body that stated neither. `hasNonNull` now, which is the test `parseCredentials` already used. `readerFeatures` was the fifth array field in that parser and the only one not held to the shape rule, which was easy to miss because nothing reads what it produces -- the `Protocol` record is written and never consulted, so a feature-negotiation reader added later would have treated an unsupported feature as absent. `minReaderVersion` is checked as a version too, accepting a number or a numeric string, since refusing `"2"` would fail a working share over a field no consumer reads. The credential envelope is also held to exactly one cloud rather than at least one: the decode takes the first branch that matches, so a response naming two silently became whichever is tested first, making the answer a property of the decoder's ordering rather than of the response. A stated field has to be a value, but an explicit null is not stated: `requireArrayWhereStated` refused a null array, and that refusal is `INVALID_RESPONSE`, which ends the whole reconcile pass rather than skipping one table -- over the rendering a serializer emits routinely for an absent list, and one every other optional field in this parser already reads as absent. Null counts as unstated at all four array sites now. The page's own `items` field still refuses it, because there an empty inventory is what the reconciler retires against.

- **A redirect is a wrong base URI, not a table without directory access.** The transport folds a refused 3xx into `INVALID_REQUEST`, which is also the protocol's own per-table refusal, and the credential path read every `INVALID_REQUEST` as the latter. An auth proxy or a trailing-slash redirect therefore reported each table as offering no directory access: a configuration error arriving table by table as a capability limit, leaving the integration looking partly healthy rather than misconfigured. The status is already on the exception, so only a 400 carries that meaning. The transport folds 400, 405 and 422 into one failure, and a 405 is a GET-only proxy or a gateway rule while a 422 is neither -- read as capability limits, they reported every table as lacking directory access while the real fault went unnamed. All of them stay a per-table skip, since `INVALID_CONFIGURATION` also describes one branch; what changes is the issue an operator is shown.

- **One location, whichever path asks.** The load resolved it listing-first while validation and the vend read the metaData action, so a server stating a location on both surfaces that differ reconciled the table at one, probed at another, and compared the credential's scope against that other -- a passing `CIVCT_STORAGE_ACCESS` check saying nothing about where a read would go. All three now agree on the metaData action. Aligning there rather than on the listing is what makes it three paths rather than two: the vend cannot see a listing without paging the schema on every read, the cost that path was changed to remove, and validation is asserted not to page it either.

- **Access modes are read from both surfaces, and a refusal on either is decisive.** The load preferred the listing and the vend reads the metaData action alone, so a server saying `dir` on one and `url` on the other loaded here and was refused there, on every read, for the life of the table. The load cannot be more permissive than the vend, and that had one surface pairing left: `statedModes` prefers the listing, so a table stating `dir` only there took the load's early return unprobed while the vend, reading the metaData action alone, saw nothing stated and asked -- so a server advertising `dir` on its listing and then refusing the credential endpoint reconciled and failed every read. Whether to probe is now decided on the metaData action, the surface the vend actually reads, rather than by giving the vend a listing it cannot afford. What both paths still share is trusting a `dir` the metaData action does state, without probing it: a stated `dir` followed by a refusal is a server contradicting itself, where an unstated table refusing is the ordinary case the probe exists for, and probing regardless would cost a credential request per table on the common shape. That is a shared assumption rather than a disagreement, and it is written down as one. The opposite disagreement is refused too, which costs only a table nothing could have read this way. Separately, an unstated table is now asked about whether or not a location is known: a location does not establish directory access -- the protocol lets a url-only server state one -- so a legacy server omitting its modes, naming a location and refusing the credential endpoint used to reconcile a table whose every read then failed.

- **The listing bounds are now a memory bound, which they were not.** A page cap of ten thousand and a per-response cap of thirty-two mebibytes multiply out past any heap, and the endpoint is named by tenant configuration, so a server answering enormous pages took the process down rather than failing its own reconcile. `floecat.delta-sharing.max-listing-bytes` bounds what one client pulls in total, defaulting to 32 MiB. Per client rather than per listing: a client's life is one reconcile pass, and a pass memoises each schema's tables for the whole of it, so a share of two hundred schemas would otherwise retain two hundred times the cap. The size is set from what a listing costs -- a table entry is around three hundred bytes of JSON, nearer six hundred with a deep prefix -- so it admits above sixty thousand tables across a share where a large real share holds thousands, and a pass peaks near twice that with the decoded records. Exceeding it is `INVALID_RESPONSE`, which reaches the catalog client as `INTERNAL`: outside `describesOneBranch`, so it ends the pass instead of being recorded as one skipped schema, and not shaped like something to retry. Items are also decoded as each page arrives rather than after the last one, so a listing no longer retains raw pages including the fields this client does not read, and a malformed item fails on the page it is on rather than after fetching every remaining one.

- **A malformed listing is a failure, not an empty share.** `paginate` read any non-array `items` as though the field were absent, so a malformed 200 from `/shares`, `/schemas` or `/tables` became a successful empty inventory. `retireStaleRelations` reads an empty inventory with no recorded skip as the share having dropped its tables and retires the overlay's, so the shape that should have failed loudly would instead have deleted what a classified failure preserves. A page must be an object, and `items` an array where it appears. A required string must be a string, not merely coercible: `schemaString` is persisted as the table's Delta schema without being parsed here, and the credential's location and its three AWS fields are published as a tuple, so `17` reaching any of them is a table or a credential that fails at first use rather than at this boundary. A name must be a string, too: `asText` answers `"17"` for a number and `"true"` for a boolean, so `{"name": 17}` entered the inventory as a table named `17` -- and an inventory the reconciler treats as authoritative is one it retires against, so the tables that malformed page omitted go with it. An explicit `null` is present and is not an array, so it is refused with the rest; exempting it left one malformed shape still reading as an authoritative empty inventory. Absent and empty both stay legal and mean the same thing. The fields inside an item were not held to that rule, and iterating a scalar node yields nothing, so `"auxiliaryLocations": "s3://other/part"` read as absent -- the one shape the auxiliary refusal exists to catch, which would have reconciled with a credential covering the root alone and failed at scan time on the files it does not reach. A stated `accessModes` scalar read as unstated the same way. `partitionColumns` is held to it too, and that is the one that persists: it becomes `CatalogTable.partitionKeys` and then `UpstreamRef.partition_keys`, so a scalar read as absent reconciled a partitioned table as unpartitioned -- a wrong table definition that validates clean rather than a failure. A non-text element is refused with it, since `asText` answers an object with the empty string and an empty partition key is worse than none; absent still means unpartitioned. All of them now go through the guard the page shape already used, and so do array elements: `asText` answers an object with the empty string, so `auxiliaryLocations` stated as an array of objects read as an empty list, `hasAuxiliaryLocations()` answered false, and the refusal at the load never fired, and that guard names the listing it refused. `INVALID_RESPONSE` reaches the boundary as `INTERNAL`, whose message `GrpcErrors` hides, so the log line is the only place an operator learns which schema held the malformed entry -- and it was the one refusal in this transport that said only what was wrong, not where.

- **Auxiliary locations are refused from either surface.** The protocol states them on the table listing as well as the metaData action, and says a client that cannot read one should fall back to url access or fail the request. Reading only the metadata action let a listing-only shape reconcile and then fail at scan time on a file the root credential does not reach.

- **The shared gates are tested where they live.** `core/http-endpoint-guards` shipped with no tests of its own, so every invariant in it was covered incidentally from whichever consumer happened to exercise the branch, and `mvn -pl core/http-endpoint-guards test` ran nothing. That is the argument the module was extracted on, applied to its evidence rather than its code. It now has a test class covering the zone-scoped literal, the all-numeric host, the HTTPS gate, the userinfo refusal and the redaction ordering. The ordering one matters most: that control was broken and repaired twice while this PR was in review, and both times the failing test lived in a different module.

- **`delta-common` publishes two members, not ten.** Interface members are implicitly public, so making the probe a public interface published its S3 client, its listing bound and its location helpers as module API. The contract is `validate` plus the `s3(subject)` factory; everything else is package-private in `S3DeltaLogProbe`, which the same-package test reaches without any of it being public.

- **Reader features are validated before they reach the header.** The list is interpolated into `delta-sharing-capabilities`, so a value carrying a semicolon appends a capability field of its own: `x;responseformat=parquet` makes a server answer in the flat shape, which this client then parses without complaint. Letters, digits, hyphens and underscores only.

- **Identity uses the listing's table id or none, and its components are escaped.** The protocol treats a share id and a table id as opaque strings, so joining them on a bare delimiter made `a:b` plus `c` indistinguishable from `a` plus `b:c`. The metaData action's id is not a substitute for a missing listing id: `PROTOCOL.md` defines it as the unique identifier for the table itself, so every share entry pointing at one physical table reports the same value, and a share exposing a table under two names would have produced one stable identity twice. Both shapes end at `requireUniqueStableIdentities`, which abandons the whole overlay on a duplicate -- the failure the composite exists to prevent. Without a listing id the identity is an honest unstable name.

- **Reader-feature enforcement is the server's, and that is documented rather than implemented.** `delta.sharing.reader-features` reaches the server in `delta-sharing-capabilities` on the metadata call and is not compared against the `readerFeatures` the protocol action reports back. Under directory access the data read goes straight to object storage with the vended credential, so there is no later point at which the server could refuse -- which means a server ignoring the header is not caught here. Checking it locally would mean refusing tables on a knob whose purpose is to be conservative, and is a policy this does not take.

- **A response this client cannot read fails the reconcile rather than skipping a table.** `INVALID_RESPONSE` mapped alongside `INVALID_REQUEST` onto `INVALID_CONFIGURATION`, which `CatalogTraversalFailures.describesOneBranch` treats as per-branch, so a proxy error page or a version mismatch reshaping every table would be absorbed as per-table skips and leave a broken share looking partially healthy across repeated cycles. It now maps to `INTERNAL`, which is outside that predicate, matching the Unity provider. The cost is that `GrpcErrors` hides an `INTERNAL` message, so some detail is lost at the boundary; the protocol's own per-table refusal, `INVALID_REQUEST`, stays per-branch.

- **The load takes the location a credential names as the table's root, whatever shape its path has: the protocol answers a request naming no location with the table's main location, and a Delta table may sit at a bucket root, which the probe supports on purpose. A refusal based on the shape of the path would skip tables validation reads happily -- it did, and the two paths disagreed. Whether the scope matches where the table lives is settled by reading the Delta log under it. The vend also refuses a credential scoped somewhere it cannot read: `requireServable` ran only at the load, so on the reference-server shape -- no location on the metaData action, so the coverage check is skipped -- whatever the credential endpoint returned was published unexamined, and a table reconciled from an earlier good credential could start receiving a tuple scoped to a `gs://` location. And the vend refuses a credential that does not reach the table, and leaves a broader one alone.** A scope above the table -- a share root, a bucket, an external-location prefix -- is published as the server named it. `StorageLocations` states the rule its own `covers` sits under: never be stricter than the component that will actually use the credential, because this path is reached only once no storage authority matched, so a refusal here fails a read that the catalog's own client would have attempted and that S3 would have answered on the real grant. An earlier revision of this branch did reject an ancestor; that would have failed every share whose server scopes credentials to a prefix rather than a table, which is how they are commonly scoped.

- **A malformed credential response ends the pass, and the guard that said otherwise could not fire.** The load also carried a check for a blank location coming back from the credential call, refusing it as a per-table skip. It was unreachable: the transport already refuses a credentials response naming no location, as `INVALID_RESPONSE`, before any caller sees it. Dead either way, but the shape of it was the problem -- it named a graceful per-table refusal for a case that in fact ends the whole reconcile, since `INVALID_RESPONSE` reaches the client as `INTERNAL` and `INTERNAL` is outside `describesOneBranch`. That is the intended rule and it is not being changed here: a response shape this client cannot read is not a property of one table, and absorbing it per table leaves a broken share looking partly healthy. The check is gone and the reasoning is stated where it was. Nothing tested it, which is what unreachable code looks like.

- **Auxiliary locations stated only on the listing are caught at the load, not the vend.** The vend would need a schema listing per resolve to see them, which is what the location change just removed for the same reason. The table never reconciles, so nothing materializes with a root-only credential; what remains is that validation's sampler sends table names straight from `listTables` to the vend without loading them, so an Integration can report valid while that table is later skipped at reconcile. That is a sampler shape rather than a provider one, and `objects_skipped` shows it.

- **Share identity falls back to the share name, and that is deliberate.** When a table listing omits `shareId` the identity is `shareName:tableId`, reported unstable. `listShares` decodes a share `id` that the protocol makes server-unique and immutable, so caching `/shares` could recover stability -- but only for a server that omits `shareId` on tables while populating `id` on shares, a shape there is no evidence of, at the cost of an extra listing on the load path. Left as the unstable fallback rather than built on a guess.

- **One certificate now covers both TLS endpoints in the smoke stack**, so `prepare_unity_tls` became `prepare_smoke_tls`. The rename is mechanical; the SAN gains `delta-sharing-stub` and the gate widens to either scenario being enabled.

## Additional Notes

Not in scope, deliberately:

- **`url` mode.** It needs a per-file URL path that the storage contract cannot express, and a refresh story on top (`minUrlExpirationTimestamp`, `refreshToken`).
- **Per-table access mode in `ListUpstreamObjects`.** That RPC is documented as a lightweight name listing and `CatalogClient.listTables` returns names only, so surfacing it means a new proto field and a new SPI method for one protocol's benefit. Validation reports the boundary instead, naming the table and the reason. The modes do not reach the reconciled table: `CatalogOverlayReconciler` builds a table's properties from the Integration and Overlay identities and the storage location, and does not carry the upstream properties a provider reports. That is true of every provider rather than something this work introduces, so it is a reconciler change and not this PR's business; `docs/operations.md` states it.
- **Change data feed**, and any reader feature beyond what an operator opts into.

`catalog-access/delta-common` is named for what it should accumulate rather than the one class it holds. The substance still sits in `core/connectors/common` -- `DeltaSchemaMapper` and `DeltaSchemaNormalizer`, which the Unity provider already depends on and which a shared table's `schemaString` feeds into downstream. Moving those is gated on the connector retirement, not on this work.


































