### PR TITLE
refactor(http): share the catalog endpoint gates and response handling

### DIFF
--- a/catalog-access/unity/pom.xml
+++ b/catalog-access/unity/pom.xml
@@ -26,6 +26,11 @@
     </dependency>
     <dependency>
       <groupId>ai.floedb.floecat</groupId>
+      <artifactId>floecat-http-endpoint-guards</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>ai.floedb.floecat</groupId>
       <artifactId>floecat-unity-catalog-client</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/catalog-access/unity/src/main/java/ai/floedb/floecat/catalog/unity/UnityCatalogClientProvider.java
+++ b/catalog-access/unity/src/main/java/ai/floedb/floecat/catalog/unity/UnityCatalogClientProvider.java
@@ -17,6 +17,7 @@ import ai.floedb.floecat.catalog.access.ResolvedCatalogCredentials;
 import ai.floedb.floecat.client.unity.HttpUnityCatalogClient;
 import ai.floedb.floecat.client.unity.UnityCatalogAuthentication;
 import ai.floedb.floecat.client.unity.UnityCatalogClient;
+import ai.floedb.floecat.http.guards.HttpEndpointGuards;
 import java.net.URI;
 import java.time.Duration;
 import java.util.LinkedHashMap;
@@ -198,77 +199,16 @@ public final class UnityCatalogClientProvider implements CatalogClientProvider {
   /**
    * Rejects an {@code s3.endpoint} that names somewhere the service should not be made to reach.
    *
-   * <p>Checked when the client is opened, before anything connects. The value is tenant-supplied
-   * and reaches {@code endpointOverride}, so validation would otherwise issue signed S3 requests
-   * wherever it pointed, and the same value travels on as client-safe routing to reconcile and
-   * query workers. The catalog and OAuth endpoints in this same integration are already held to
-   * this policy; this one was not.
-   *
-   * <p>HTTPS unless a deployment says otherwise. The earlier rule allowed cleartext outright, on
-   * the reasoning that an S3 request carries a SigV4 signature rather than a bearer secret -- which
-   * stopped being true here: this provider refuses to publish a vend without {@code
-   * s3.session-token}, so every signed request carries that token in {@code X-Amz-Security-Token},
-   * and a session token is replayable against the table's prefix by anyone who sees it for as long
-   * as it lives. The exposure is not confined to the validation probe either, because {@code
-   * s3.endpoint} travels on to query workers as client-safe routing.
-   *
-   * <p>The escape hatch stays, because an S3-compatible endpoint on a private network commonly is
-   * HTTP -- MinIO and LocalStack both -- but it is now a deployment saying so rather than a
-   * default: {@value #ALLOW_CLEARTEXT_S3_PROPERTY}, or the environment variable {@value
-   * #ALLOW_CLEARTEXT_S3_ENV}. The address-class rule still applies on top of either scheme: it is
-   * the one that refuses {@code 169.254.169.254}.
+   * <p>The policy and its reasoning live in {@link
+   * HttpEndpointGuards#requireUsableStorageEndpoint}, which the Delta Sharing provider holds its
+   * own storage endpoint to for the same reason: both publish a vend carrying a session token.
    */
-  static final String ALLOW_CLEARTEXT_S3_PROPERTY = "floecat.security.allow-cleartext-s3-endpoints";
-
-  static final String ALLOW_CLEARTEXT_S3_ENV = "FLOECAT_SECURITY_ALLOW_CLEARTEXT_S3_ENDPOINTS";
-
-  private static boolean allowCleartextS3Endpoints() {
-    return Boolean.parseBoolean(
-        System.getProperty(
-            ALLOW_CLEARTEXT_S3_PROPERTY,
-            System.getenv().getOrDefault(ALLOW_CLEARTEXT_S3_ENV, "false")));
-  }
-
   private static void requireUsableEndpoint(String endpoint) {
-    if (endpoint == null) {
-      return;
-    }
-    URI uri;
     try {
-      uri = URI.create(endpoint);
-    } catch (IllegalArgumentException malformed) {
-      throw new CatalogAccessException(
-          CatalogAccessException.Code.INVALID_CONFIGURATION,
-          "Unity Catalog s3.endpoint is not a valid URI",
-          malformed);
-    }
-    String scheme = uri.getScheme();
-    if (!uri.isAbsolute()
-        || uri.getHost() == null
-        || !("https".equalsIgnoreCase(scheme) || "http".equalsIgnoreCase(scheme))
-        || uri.getRawUserInfo() != null
-        || uri.getRawQuery() != null
-        || uri.getRawFragment() != null) {
-      throw new CatalogAccessException(
-          CatalogAccessException.Code.INVALID_CONFIGURATION,
-          "Unity Catalog s3.endpoint must be an absolute http or https URI with no userinfo,"
-              + " query or fragment");
-    }
-    if ("http".equalsIgnoreCase(scheme) && !allowCleartextS3Endpoints()) {
-      throw new CatalogAccessException(
-          CatalogAccessException.Code.INVALID_CONFIGURATION,
-          "Unity Catalog s3.endpoint must use HTTPS: a vended credential carries a session token,"
-              + " which travels in a header and is replayable. Set "
-              + ALLOW_CLEARTEXT_S3_ENV
-              + "=true to allow cleartext on a trusted network");
-    }
-    try {
-      HttpUnityCatalogClient.assertEndpointAddressAllowed(uri);
+      HttpEndpointGuards.requireUsableStorageEndpoint(endpoint, "Unity Catalog s3.endpoint");
     } catch (IllegalArgumentException refused) {
       throw new CatalogAccessException(
-          CatalogAccessException.Code.INVALID_CONFIGURATION,
-          "Unity Catalog s3.endpoint names an address class that is not allowed",
-          refused);
+          CatalogAccessException.Code.INVALID_CONFIGURATION, refused.getMessage(), refused);
     }
   }
 

--- a/catalog-access/unity/src/test/java/ai/floedb/floecat/catalog/unity/UnityCatalogClientProviderTest.java
+++ b/catalog-access/unity/src/test/java/ai/floedb/floecat/catalog/unity/UnityCatalogClientProviderTest.java
@@ -20,6 +20,7 @@ import ai.floedb.floecat.catalog.access.CatalogProtocol;
 import ai.floedb.floecat.catalog.access.ResolvedCatalogCredentials;
 import ai.floedb.floecat.client.unity.UnityCatalogAuthentication;
 import ai.floedb.floecat.client.unity.UnityCatalogClient;
+import ai.floedb.floecat.http.guards.HttpEndpointGuards;
 import java.net.URI;
 import java.time.Duration;
 import java.util.Map;
@@ -174,18 +175,17 @@ class UnityCatalogClientProviderTest {
     // HTTPS needs no opt-in.
     provider.open(config(Map.of("s3.endpoint", "https://storage.example")), credentials()).close();
 
-    System.setProperty(UnityCatalogClientProvider.ALLOW_CLEARTEXT_S3_PROPERTY, "true");
+    System.setProperty(HttpEndpointGuards.ALLOW_CLEARTEXT_S3_PROPERTY, "true");
     try {
       provider
           .open(config(Map.of("s3.endpoint", "http://minio.internal:9000")), credentials())
           .close();
     } finally {
-      System.clearProperty(UnityCatalogClientProvider.ALLOW_CLEARTEXT_S3_PROPERTY);
+      System.clearProperty(HttpEndpointGuards.ALLOW_CLEARTEXT_S3_PROPERTY);
     }
   }
 
-  private static final String ALLOW_CLEARTEXT_S3_ENV =
-      UnityCatalogClientProvider.ALLOW_CLEARTEXT_S3_ENV;
+  private static final String ALLOW_CLEARTEXT_S3_ENV = HttpEndpointGuards.ALLOW_CLEARTEXT_S3_ENV;
 
   /** Real credentials, because the authentication check runs ahead of the endpoint check. */
   private static ResolvedCatalogCredentials credentials() {

--- a/connectors/clients/unity-catalog/src/main/java/ai/floedb/floecat/client/unity/HttpUnityCatalogClient.java
+++ b/connectors/clients/unity-catalog/src/main/java/ai/floedb/floecat/client/unity/HttpUnityCatalogClient.java
@@ -16,12 +16,13 @@
 
 package ai.floedb.floecat.client.unity;
 
+import ai.floedb.floecat.http.guards.HttpEndpointGuards;
+import ai.floedb.floecat.http.guards.HttpResponseSnippets;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.InetAddress;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.net.http.HttpClient;
@@ -39,7 +40,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.regex.Pattern;
 
 /** JDK HTTP implementation of the small Unity Catalog client boundary. */
 public final class HttpUnityCatalogClient implements UnityCatalogClient {
@@ -89,8 +89,6 @@ public final class HttpUnityCatalogClient implements UnityCatalogClient {
 
   private static final ObjectMapper JSON = new ObjectMapper();
 
-  private static final Pattern BEARER_TOKEN = Pattern.compile("(?i)bearer\\s+[A-Za-z0-9._~+/=-]+");
-
   /**
    * Page limit for one listing. The repeated-token check in {@link #listAll} catches a server that
    * reuses a token, not one that mints a new token per page, and nothing else bounds the loop:
@@ -109,10 +107,7 @@ public final class HttpUnityCatalogClient implements UnityCatalogClient {
    * floecat.security.allow-loopback-token-endpoints}. Read from system properties and the
    * environment at construction; this module does not depend on the connector config layer.
    */
-  static final String ALLOW_LOOPBACK_PROPERTY = "floecat.security.allow-loopback-catalog-endpoints";
-
-  private static final String ALLOW_LOOPBACK_ENV =
-      "FLOECAT_SECURITY_ALLOW_LOOPBACK_CATALOG_ENDPOINTS";
+  static final String ALLOW_LOOPBACK_PROPERTY = HttpEndpointGuards.ALLOW_LOOPBACK_PROPERTY;
 
   /**
    * Cap on a single response body, in bytes. Override with {@code floecat.unity.max-response-bytes}
@@ -123,10 +118,7 @@ public final class HttpUnityCatalogClient implements UnityCatalogClient {
   private static final int DEFAULT_MAX_RESPONSE_BYTES = 32 * 1024 * 1024;
 
   /** Opt-in for a base URI naming a private (site-local) address literal. Deny by default. */
-  static final String ALLOW_PRIVATE_PROPERTY = "floecat.security.allow-private-catalog-endpoints";
-
-  private static final String ALLOW_PRIVATE_ENV =
-      "FLOECAT_SECURITY_ALLOW_PRIVATE_CATALOG_ENDPOINTS";
+  static final String ALLOW_PRIVATE_PROPERTY = HttpEndpointGuards.ALLOW_PRIVATE_PROPERTY;
 
   private final String baseUri;
   private final String credentialsPath;
@@ -165,7 +157,9 @@ public final class HttpUnityCatalogClient implements UnityCatalogClient {
     // Arguments evaluate left to right; every check runs before newHttpClient allocates a
     // transport.
     this(
-        stripTrailingSlash(validateBaseUri(baseUri).toString()),
+        stripTrailingSlash(
+            HttpEndpointGuards.requireAllowedEndpoint(baseUri, "Unity Catalog base URI")
+                .toString()),
         requirePositive(requestTimeout, "requestTimeout"),
         Objects.requireNonNull(authentication, "authentication"),
         requireAbsolutePath(credentialsPath),
@@ -194,7 +188,9 @@ public final class HttpUnityCatalogClient implements UnityCatalogClient {
       String credentialsPath,
       HttpClient httpClient) {
     this(
-        stripTrailingSlash(validateBaseUri(baseUri).toString()),
+        stripTrailingSlash(
+            HttpEndpointGuards.requireAllowedEndpoint(baseUri, "Unity Catalog base URI")
+                .toString()),
         requirePositive(requestTimeout, "requestTimeout"),
         Objects.requireNonNull(authentication, "authentication"),
         requireAbsolutePath(credentialsPath),
@@ -247,7 +243,7 @@ public final class HttpUnityCatalogClient implements UnityCatalogClient {
             + "&schema_name="
             + encode(schemaName),
         "tables",
-        HttpUnityCatalogClient::listedTable);
+        this::listedTable);
   }
 
   @Override
@@ -306,7 +302,7 @@ public final class HttpUnityCatalogClient implements UnityCatalogClient {
    * present but unusable value -- {@code {}}, half a tuple, or a non-object -- is {@code
    * INVALID_RESPONSE}. Only a missing field or an explicit JSON null means no AWS credentials.
    */
-  private static TemporaryTableCredentials.AwsCredentials awsCredentials(JsonNode awsNode) {
+  private TemporaryTableCredentials.AwsCredentials awsCredentials(JsonNode awsNode) {
     if (awsNode.isMissingNode() || awsNode.isNull()) {
       return null;
     }
@@ -504,7 +500,9 @@ public final class HttpUnityCatalogClient implements UnityCatalogClient {
     // release it.
     byte[] bytes;
     try {
-      bytes = readWithin(stream, maxResponseBytes, requestTimeout);
+      bytes =
+          HttpResponseSnippets.readWithin(
+              stream, maxResponseBytes, requestTimeout, "Unity Catalog");
     } finally {
       closeQuietly(stream);
     }
@@ -512,45 +510,6 @@ public final class HttpUnityCatalogClient implements UnityCatalogClient {
     // means nothing -- the status already answered. Throwing here would classify a permanent 403
     // whose error page happens to be large as a retryable INVALID_RESPONSE.
     return bytes.length > maxResponseBytes ? null : new String(bytes, StandardCharsets.UTF_8);
-  }
-
-  /**
-   * Reads {@code stream} up to {@code limit + 1} bytes, giving up after {@code deadline}.
-   *
-   * <p>On a virtual thread of its own, not {@code CompletableFuture.supplyAsync}'s common pool. The
-   * read blocks for the whole download, and {@code ForkJoinPool.commonPool()} has parallelism one
-   * on a small container -- so two concurrent calls queued behind each other and the waiting one
-   * failed on this deadline while the server had already answered. Every caller here is itself on a
-   * virtual thread, so there is no pool to starve.
-   *
-   * <p>Closing the stream is what releases a genuinely stalled read; abandoning the future alone
-   * would leave the reader blocked in {@code readNBytes}.
-   */
-  private static byte[] readWithin(InputStream stream, int limit, Duration deadline)
-      throws IOException {
-    var body = new java.util.concurrent.CompletableFuture<byte[]>();
-    Thread.ofVirtual()
-        .start(
-            () -> {
-              try {
-                body.complete(stream.readNBytes(limit + 1));
-              } catch (Throwable failure) {
-                body.completeExceptionally(failure);
-              }
-            });
-    try {
-      return body.get(deadline.toMillis(), java.util.concurrent.TimeUnit.MILLISECONDS);
-    } catch (java.util.concurrent.TimeoutException stalled) {
-      closeQuietly(stream);
-      throw new IOException("Unity Catalog response body stalled after " + deadline, stalled);
-    } catch (InterruptedException interrupted) {
-      Thread.currentThread().interrupt();
-      closeQuietly(stream);
-      throw new IOException("Interrupted reading the Unity Catalog response body", interrupted);
-    } catch (java.util.concurrent.ExecutionException failure) {
-      Throwable cause = failure.getCause();
-      throw cause instanceof IOException io ? io : new IOException(cause);
-    }
   }
 
   private static void closeQuietly(InputStream stream) {
@@ -634,14 +593,14 @@ public final class HttpUnityCatalogClient implements UnityCatalogClient {
     return path + " (redirected to " + effectiveUri + ")";
   }
 
-  private static UnityCatalogTable listedTable(JsonNode node) {
+  private UnityCatalogTable listedTable(JsonNode node) {
     // Null rather than a throw: listAll drops an unmapped entry, so one null or scalar element in
     // the array cannot lose the rest of the page. getTable stays strict, where the caller asked
     // for one specific table and an unreadable answer is a failure.
     return node.isObject() ? table(node, false) : null;
   }
 
-  private static UnityCatalogTable table(JsonNode node, boolean strictColumns) {
+  private UnityCatalogTable table(JsonNode node, boolean strictColumns) {
     if (!node.isObject()) {
       throw invalidResponse("Expected a table object from Unity Catalog", null);
     }
@@ -657,7 +616,7 @@ public final class HttpUnityCatalogClient implements UnityCatalogClient {
         tableProperties(node));
   }
 
-  private static List<UnityCatalogTable.Column> parseColumns(JsonNode node, boolean strict) {
+  private List<UnityCatalogTable.Column> parseColumns(JsonNode node, boolean strict) {
     // Jackson iterates an object's values as though it were an array and yields nothing for a
     // scalar, so a detail response must reject either shape. A listing can still identify its
     // other entries without that schema, so only the malformed entry gets an empty column list.
@@ -689,7 +648,7 @@ public final class HttpUnityCatalogClient implements UnityCatalogClient {
     return columns;
   }
 
-  private static List<UnityCatalogTable.Column> malformedColumns(boolean strict, String message) {
+  private List<UnityCatalogTable.Column> malformedColumns(boolean strict, String message) {
     if (strict) {
       throw invalidResponse(message, null);
     }
@@ -743,7 +702,7 @@ public final class HttpUnityCatalogClient implements UnityCatalogClient {
    * <p>An unlisted 4xx is permanent only when it carries the {@code error_code} envelope. Without
    * one it may be an error page from a proxy rather than the workspace, so it stays {@code OTHER}.
    */
-  private static UnityCatalogException httpFailure(
+  private UnityCatalogException httpFailure(
       int status, String path, String body, boolean includeResponseBody) {
     String responseBody = includeResponseBody ? truncate(body) : "";
     // Capped like the body: error_code comes from that body but is interpolated outside the
@@ -887,7 +846,7 @@ public final class HttpUnityCatalogClient implements UnityCatalogClient {
     };
   }
 
-  private static UnityCatalogException invalidResponse(String message, Throwable cause) {
+  private UnityCatalogException invalidResponse(String message, Throwable cause) {
     return new UnityCatalogException(
         UnityCatalogException.Failure.INVALID_RESPONSE, -1, message, cause);
   }
@@ -896,7 +855,7 @@ public final class HttpUnityCatalogClient implements UnityCatalogClient {
    * An {@code INVALID_RESPONSE} that keeps what the catalog actually sent. The status and a snippet
    * of the body identify which proxy is answering when a body never becomes JSON.
    */
-  private static UnityCatalogException invalidResponse(
+  private UnityCatalogException invalidResponse(
       int status, String message, String body, Throwable cause) {
     String snippet = truncate(body);
     return new UnityCatalogException(
@@ -906,26 +865,18 @@ public final class HttpUnityCatalogClient implements UnityCatalogClient {
         cause);
   }
 
-  private static String truncate(String body) {
+  private String truncate(String body) {
     return truncate(body, MAX_BODY_SNIPPET_CHARS);
   }
 
-  private static String truncate(String value, int maxChars) {
-    return value == null
-        ? ""
-        : redactBearerTokens(value.substring(0, Math.min(value.length(), maxChars)));
-  }
-
-  /**
-   * Removes bearer tokens from text on its way into a failure message.
-   *
-   * <p>The Authorization header goes out on every request, and a debug handler or a misconfigured
-   * gateway will echo request headers in an error body. That body is interpolated into the
-   * exception for every route except vending, so without this the tenant's token reaches operator
-   * logs.
-   */
-  private static String redactBearerTokens(String text) {
-    return BEARER_TOKEN.matcher(text).replaceAll("Bearer <redacted>");
+  private String truncate(String value, int maxChars) {
+    // The token this client sends, by value. The generic pattern matches the token68 alphabet a
+    // bearer token is supposed to use, and this one is operator-supplied and under no obligation to
+    // -- so a token carrying a colon was matched only that far and the remainder survived into a
+    // message that reaches validation output and operator logs. The Delta Sharing client was wired
+    // to the by-value overload when it was added here; this caller of the same control was not.
+    return HttpResponseSnippets.bounded(
+        value, maxChars, authentication.redactableSecret().orElse(null));
   }
 
   private static String text(JsonNode node, String field) {
@@ -953,154 +904,6 @@ public final class HttpUnityCatalogClient implements UnityCatalogClient {
   }
 
   /**
-   * Whether the authority embeds userinfo that {@link URI#getUserInfo()} does not report. {@code
-   * java.net.URI} populates it only for a server-based authority; a host it rejects as a hostname
-   * -- an underscore, a non-numeric port -- yields a registry-based authority with the credential
-   * still in the raw string. {@code @} delimits userinfo and has no other role there.
-   */
-  private static boolean authorityCarriesUserInfo(URI baseUri) {
-    String authority = baseUri.getRawAuthority();
-    return authority != null && authority.indexOf('@') >= 0;
-  }
-
-  /**
-   * The base URI as it may appear in a rejection message: scheme, authority and path only.
-   *
-   * <p>A query is a common place for a token, and the userinfo guard covers only credentials in the
-   * authority. Every gate here reports the value it rejected, so the display form drops the two
-   * components that carry data rather than address the endpoint.
-   */
-  private static String display(URI baseUri) {
-    if (baseUri == null) {
-      return "null";
-    }
-    StringBuilder shown = new StringBuilder();
-    if (baseUri.getScheme() != null) {
-      shown.append(baseUri.getScheme()).append("://");
-    }
-    // Parsed components only, never the raw authority. URI reports a host it cannot parse as
-    // server-based -- an underscore, a bad port, or a percent-encoded delimiter such as
-    // alice:s3cr3t%40host -- by leaving getHost() and both userinfo accessors null while the raw
-    // authority keeps the credential. Echoing that here would undo the userinfo guard for exactly
-    // the inputs it cannot recognise.
-    if (baseUri.getHost() == null) {
-      shown.append("<unparseable-authority>");
-    } else {
-      shown.append(baseUri.getHost());
-      if (baseUri.getPort() != -1) {
-        shown.append(':').append(baseUri.getPort());
-      }
-    }
-    if (baseUri.getRawPath() != null) {
-      shown.append(baseUri.getRawPath());
-    }
-    return shown.isEmpty() ? "<empty>" : shown.toString();
-  }
-
-  private static URI validateBaseUri(URI baseUri) {
-    Objects.requireNonNull(baseUri, "baseUri");
-    // Before any check whose message interpolates the URI. Credentials belong in
-    // UnityCatalogAuthentication, and the JDK client does not transmit them.
-    if (baseUri.getUserInfo() != null
-        || baseUri.getRawUserInfo() != null
-        || authorityCarriesUserInfo(baseUri)) {
-      throw new IllegalArgumentException(
-          "Unity Catalog base URI must not contain userinfo; supply credentials through "
-              + "UnityCatalogAuthentication instead");
-    }
-    if (!baseUri.isAbsolute()) {
-      throw new IllegalArgumentException(
-          "Unity Catalog base URI must be absolute: " + display(baseUri));
-    }
-    String scheme = baseUri.getScheme();
-    boolean https = "https".equalsIgnoreCase(scheme);
-    boolean loopbackHttp =
-        "http".equalsIgnoreCase(scheme)
-            && allowLoopbackCleartext()
-            && isLoopbackHost(baseUri.getHost());
-    if (!https && !loopbackHttp) {
-      throw new IllegalArgumentException(
-          "Unity Catalog base URI must use HTTPS, except HTTP is allowed for loopback hosts when "
-              + ALLOW_LOOPBACK_PROPERTY
-              + " is set: "
-              + display(baseUri));
-    }
-    if (baseUri.getHost() == null) {
-      throw new IllegalArgumentException(
-          "Unity Catalog base URI must include a host: " + display(baseUri));
-    }
-    if (baseUri.getRawQuery() != null || baseUri.getRawFragment() != null) {
-      throw new IllegalArgumentException(
-          "Unity Catalog base URI must not include a query or fragment: " + display(baseUri));
-    }
-    // -1 is absent. URI and HttpRequest.Builder both accept 65536; InetSocketAddress rejects it at
-    // send time, where it is reported as TRANSPORT.
-    int port = baseUri.getPort();
-    if (port != -1 && (port < 1 || port > 65535)) {
-      throw new IllegalArgumentException(
-          "Unity Catalog base URI port must be between 1 and 65535: " + display(baseUri));
-    }
-    assertAddressClassAllowed(baseUri);
-    return baseUri;
-  }
-
-  /**
-   * Rejects address classes a tenant-supplied connector URI must not name.
-   *
-   * <p>Link-local, wildcard, multicast, broadcast and {@code 0.0.0.0/8} literals are refused
-   * outright; no catalog is reachable at one, and {@code https://169.254.169.254} is otherwise a
-   * well-formed HTTPS URI for a cloud metadata service. Site-local literals require {@link
-   * #ALLOW_PRIVATE_PROPERTY}, since an internal catalog is an ordinary deployment. Loopback is
-   * allowed; cleartext to it is governed by {@link #ALLOW_LOOPBACK_PROPERTY}.
-   *
-   * <p>Literals only: resolving a hostname here would disagree with the resolution {@code
-   * HttpClient} performs at connect time, so a hostname is out of scope.
-   */
-  private static void assertAddressClassAllowed(URI baseUri) {
-    String host = unbracket(baseUri.getHost());
-    // A zone id names a local interface, and ofLiteral cannot parse one. Left to the catch below a
-    // scoped literal reads as a hostname and skips this gate entirely, so fe80::1%eth0 admits a
-    // link-local address. The transport cannot carry one either.
-    if (host.indexOf('%') >= 0) {
-      throw new IllegalArgumentException(
-          "Unity Catalog base URI must not name a zone-scoped address: " + display(baseUri));
-    }
-    InetAddress address;
-    try {
-      address = InetAddress.ofLiteral(host);
-    } catch (IllegalArgumentException notALiteral) {
-      // A host of only digits and dots is not a hostname -- a DNS name cannot be entirely numeric
-      // -- and the resolver the transport uses accepts these modulo 2^32 even though ofLiteral
-      // refuses them: 7147006462 resolves to 169.254.169.254 and 4294967296 to 0.0.0.0. Returning
-      // here would hand the transport a link-local or wildcard target this gate refuses by name.
-      if (isNumericHost(host)) {
-        throw new IllegalArgumentException(
-            "Unity Catalog base URI must not name a numeric host that is not an address literal: "
-                + display(baseUri));
-      }
-      return;
-    }
-    if (address.isLoopbackAddress()) {
-      return;
-    }
-    if (address.isLinkLocalAddress()
-        || address.isAnyLocalAddress()
-        || address.isMulticastAddress()
-        || isBroadcastOrThisNetwork(address)) {
-      throw new IllegalArgumentException(
-          "Unity Catalog base URI must not name a link-local, wildcard or multicast address: "
-              + display(baseUri));
-    }
-    if (isSiteLocal(address) && !allowPrivateAddresses()) {
-      throw new IllegalArgumentException(
-          "Unity Catalog base URI names a private address, which requires "
-              + ALLOW_PRIVATE_PROPERTY
-              + ": "
-              + display(baseUri));
-    }
-  }
-
-  /**
    * The same address-class policy, for another tenant-supplied endpoint in this module's care.
    *
    * <p>Exposed rather than copied: {@code UnityOAuthTokenProvider} POSTs the integration's OAuth
@@ -1109,46 +912,7 @@ public final class HttpUnityCatalogClient implements UnityCatalogClient {
    * implementation of this rule is how the two drift apart.
    */
   public static void assertEndpointAddressAllowed(URI endpoint) {
-    assertAddressClassAllowed(Objects.requireNonNull(endpoint, "endpoint"));
-  }
-
-  /** Whether every character is an ASCII digit or a dot. Deliberately not {@code isDigit}. */
-  private static boolean isNumericHost(String host) {
-    if (host.isEmpty()) {
-      return false;
-    }
-    for (int i = 0; i < host.length(); i++) {
-      char c = host.charAt(i);
-      if ((c < '0' || c > '9') && c != '.') {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  /**
-   * IPv4 limited broadcast and {@code 0.0.0.0/8}. {@code isMulticastAddress} covers 224/4 and
-   * {@code isAnyLocalAddress} only the exact wildcard, so neither address is caught by them.
-   */
-  private static boolean isBroadcastOrThisNetwork(InetAddress address) {
-    byte[] bytes = address.getAddress();
-    if (bytes.length != 4) {
-      return false;
-    }
-    boolean broadcast = true;
-    for (byte octet : bytes) {
-      broadcast &= octet == (byte) 0xFF;
-    }
-    return broadcast || bytes[0] == 0;
-  }
-
-  /** IPv4 RFC 1918 and IPv6 unique-local, which {@code isSiteLocalAddress} misses for fc00::/7. */
-  private static boolean isSiteLocal(InetAddress address) {
-    if (address.isSiteLocalAddress()) {
-      return true;
-    }
-    byte[] bytes = address.getAddress();
-    return bytes.length == 16 && (bytes[0] & 0xFE) == 0xFC;
+    HttpEndpointGuards.assertEndpointAddressAllowed(endpoint);
   }
 
   private static int configuredMaxPages() {
@@ -1181,20 +945,6 @@ public final class HttpUnityCatalogClient implements UnityCatalogClient {
       throw new IllegalArgumentException(name + " must be a positive integer: " + configured);
     }
     return value;
-  }
-
-  private static boolean allowPrivateAddresses() {
-    return Boolean.parseBoolean(
-        System.getProperty(
-            ALLOW_PRIVATE_PROPERTY, System.getenv().getOrDefault(ALLOW_PRIVATE_ENV, "false")));
-  }
-
-  private static String unbracket(String host) {
-    String value = host == null ? "" : host.trim();
-    if (value.startsWith("[") && value.endsWith("]")) {
-      value = value.substring(1, value.length() - 1);
-    }
-    return value.endsWith(".") ? value.substring(0, value.length() - 1) : value;
   }
 
   private static HttpClient newHttpClient(Duration connectTimeout) {
@@ -1258,42 +1008,6 @@ public final class HttpUnityCatalogClient implements UnityCatalogClient {
    * catalog request beside it was allowed.
    */
   public static boolean isCleartextLoopbackAllowed(URI endpoint) {
-    Objects.requireNonNull(endpoint, "endpoint");
-    return allowLoopbackCleartext() && isLoopbackHost(endpoint.getHost());
-  }
-
-  private static boolean allowLoopbackCleartext() {
-    return Boolean.parseBoolean(
-        System.getProperty(
-            ALLOW_LOOPBACK_PROPERTY, System.getenv().getOrDefault(ALLOW_LOOPBACK_ENV, "false")));
-  }
-
-  private static boolean isLoopbackHost(String host) {
-    if (host == null) {
-      return false;
-    }
-    String normalized = host.toLowerCase(Locale.ROOT);
-    if (normalized.startsWith("[") && normalized.endsWith("]")) {
-      normalized = normalized.substring(1, normalized.length() - 1);
-    }
-    if (normalized.endsWith(".")) {
-      normalized = normalized.substring(0, normalized.length() - 1);
-    }
-    // Exactly "localhost", not any *.localhost name. RFC 6761 says such names should resolve to
-    // loopback, but nothing here enforces that and this gate does not resolve: a zone the tenant
-    // controls can point catalog.localhost at a public address, and the Authorization header would
-    // then go out in cleartext to it. CredentialResolverSupport, which this mirrors, has no suffix
-    // rule either -- it resolves and requires every answer to be loopback.
-    if (normalized.equals("localhost")) {
-      return true;
-    }
-    // ofLiteral, never getByName: a host this cannot decide is denied, not resolved. A resolver
-    // here disagrees with the one HttpClient uses at connect time. Character-shape pre-filters are
-    // no substitute: "4294967296" and "1." are all digits and dots yet parse as no address.
-    try {
-      return InetAddress.ofLiteral(normalized).isLoopbackAddress();
-    } catch (IllegalArgumentException notAnAddressLiteral) {
-      return false;
-    }
+    return HttpEndpointGuards.isCleartextLoopbackAllowed(endpoint);
   }
 }

--- a/connectors/clients/unity-catalog/src/main/java/ai/floedb/floecat/client/unity/UnityCatalogAuthentication.java
+++ b/connectors/clients/unity-catalog/src/main/java/ai/floedb/floecat/client/unity/UnityCatalogAuthentication.java
@@ -17,9 +17,28 @@
 package ai.floedb.floecat.client.unity;
 
 import java.util.Map;
+import java.util.Optional;
 
 /** Supplies fresh authentication headers for each Unity Catalog request. */
 @FunctionalInterface
 public interface UnityCatalogAuthentication {
   Map<String, String> headers();
+
+  /**
+   * The secret this puts on the wire, where it is a fixed value worth redacting by name.
+   *
+   * <p>The generic bearer pattern matches the RFC token68 alphabet, and a header value permits more
+   * -- so an operator-supplied token carrying a colon is matched only as far as the colon and the
+   * remainder survives into an error message that reaches validation output and operator logs. A
+   * client that knows its own secret can redact it exactly, which is what the shared snippet
+   * helper's by-value overload is for.
+   *
+   * <p>Empty by default, and empty for a rotating token: reading one here would mean asking the
+   * token provider for a value on a failure path, where a refresh is the last thing wanted. A
+   * rotating access token is issued in the token68 shape anyway, so the pattern covers it; the gap
+   * is the operator-supplied one.
+   */
+  default Optional<String> redactableSecret() {
+    return Optional.empty();
+  }
 }

--- a/connectors/clients/unity-catalog/src/test/java/ai/floedb/floecat/client/unity/HttpUnityCatalogClientTest.java
+++ b/connectors/clients/unity-catalog/src/test/java/ai/floedb/floecat/client/unity/HttpUnityCatalogClientTest.java
@@ -55,6 +55,48 @@ class HttpUnityCatalogClientTest {
             () -> Map.of("Authorization", "Bearer catalog-token"));
   }
 
+  /**
+   * A token carrying a character outside the token68 alphabet is redacted by value, not by pattern.
+   * The generic pattern matches what a bearer token is supposed to be; this one is
+   * operator-supplied and need not be, so a colon-bearing token was matched only that far and the
+   * remainder survived into a message that reaches validation output and operator logs. The Delta
+   * Sharing client was wired to the by-value overload when it was added; this caller of the same
+   * control was not.
+   */
+  @Test
+  void anEchoedTokenOutsideTheGrammarIsRedactedInFull() throws Exception {
+    String token = "abc:SECRET-TAIL";
+    server.createContext(
+        "/api/2.1/unity-catalog/catalogs",
+        exchange -> {
+          byte[] body =
+              ("upstream echoed: Authorization: Bearer " + token)
+                  .getBytes(java.nio.charset.StandardCharsets.UTF_8);
+          exchange.sendResponseHeaders(500, body.length);
+          exchange.getResponseBody().write(body);
+          exchange.close();
+        });
+    try (HttpUnityCatalogClient tokenClient =
+        new HttpUnityCatalogClient(
+            URI.create("http://127.0.0.1:" + server.getAddress().getPort()),
+            Duration.ofSeconds(1),
+            Duration.ofSeconds(5),
+            new UnityCatalogAuthentication() {
+              @Override
+              public Map<String, String> headers() {
+                return Map.of("Authorization", "Bearer " + token);
+              }
+
+              @Override
+              public java.util.Optional<String> redactableSecret() {
+                return java.util.Optional.of(token);
+              }
+            })) {
+      assertThatThrownBy(tokenClient::listCatalogs)
+          .satisfies(e -> assertThat(e.getMessage()).doesNotContain("SECRET-TAIL"));
+    }
+  }
+
   @AfterEach
   void tearDown() {
     if (previousAllowLoopback == null) {
@@ -1116,7 +1158,11 @@ class HttpUnityCatalogClientTest {
             UnityCatalogException.class,
             failure -> {
               assertThat(failure.getMessage()).doesNotContain("catalog-token");
-              assertThat(failure.getMessage()).contains("Bearer <redacted>");
+              // The whole header value goes, scheme included: the pass recognises the header name
+              // rather than the token's shape, so how the value was encoded stops mattering. The
+              // name survives, so the message still says which header was echoed.
+              assertThat(failure.getMessage()).contains("Authorization");
+              assertThat(failure.getMessage()).contains("<redacted>");
               // The rest of the body still reaches the message.
               assertThat(failure.getMessage()).contains("bad request");
             });
@@ -1943,7 +1989,7 @@ class HttpUnityCatalogClientTest {
   @Test
   void anEmptyTwoHundredBodyKeepsItsStatusSoItStaysRetryable() {
     // Headers then a close -- a sidecar restarting, a proxy that dropped the payload. Jackson
-    // parses "" to a missing node instead of throwing, so this used to reach the caller's shape
+    // parses "" to a missing node instead of throwing, so this reaches the caller's shape
     // check and be reported with no status, which a consumer reads as a permanent shape rejection.
     // The same connection truncated one byte later throws from readNBytes and is retryable; these
     // two must not disagree.

--- a/core/http-endpoint-guards/pom.xml
+++ b/core/http-endpoint-guards/pom.xml
@@ -23,23 +23,12 @@
     <groupId>ai.floedb.floecat</groupId>
     <artifactId>floecat</artifactId>
     <version>0.1.0-SNAPSHOT</version>
-    <relativePath>../../..</relativePath>
+    <relativePath>../..</relativePath>
   </parent>
 
-  <artifactId>floecat-unity-catalog-client</artifactId>
+  <artifactId>floecat-http-endpoint-guards</artifactId>
 
   <dependencies>
-    <dependency>
-      <groupId>ai.floedb.floecat</groupId>
-      <artifactId>floecat-http-endpoint-guards</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <version>${version.jackson}</version>
-    </dependency>
-
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>

--- a/core/http-endpoint-guards/src/main/java/ai/floedb/floecat/http/guards/HttpEndpointGuards.java
+++ b/core/http-endpoint-guards/src/main/java/ai/floedb/floecat/http/guards/HttpEndpointGuards.java
@@ -1,0 +1,417 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.http.guards;
+
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * Transport gates for an operator-supplied catalog endpoint, shared by every client that accepts
+ * one.
+ *
+ * <p>Deny by default. HTTPS is required; cleartext to a loopback host and a base URI naming a
+ * private address literal each need an explicit opt-in; link-local, wildcard and multicast literals
+ * are always refused, the cloud metadata address among them.
+ *
+ * <p>The checks are deliberately literal-only. Deciding them for a hostname means resolving it, and
+ * a resolver here disagrees with the resolution {@code HttpClient} performs at connect time. A
+ * hostname pointing at a private address is therefore network policy rather than something this
+ * class claims to prevent.
+ *
+ * <p>Extracted from {@code HttpUnityCatalogClient}, which held the only copy. The subtleties are
+ * why this is shared rather than reimplemented per client: a zone-scoped literal parses as a
+ * hostname and would skip the address-class gate, an all-numeric host is resolved modulo 2^32 by
+ * the transport so {@code 7147006462} reaches the metadata address, and {@code localhost} matches
+ * exactly rather than as a suffix because a tenant-controlled zone can point {@code x.localhost} at
+ * a public address that would then receive an Authorization header in cleartext.
+ */
+public final class HttpEndpointGuards {
+
+  /** Property permitting cleartext HTTP to a loopback host. */
+  public static final String ALLOW_LOOPBACK_PROPERTY =
+      "floecat.security.allow-loopback-catalog-endpoints";
+
+  private static final String ALLOW_LOOPBACK_ENV =
+      "FLOECAT_SECURITY_ALLOW_LOOPBACK_CATALOG_ENDPOINTS";
+
+  /** Property permitting a base URI that names a private address literal. */
+  public static final String ALLOW_PRIVATE_PROPERTY =
+      "floecat.security.allow-private-catalog-endpoints";
+
+  private static final String ALLOW_PRIVATE_ENV =
+      "FLOECAT_SECURITY_ALLOW_PRIVATE_CATALOG_ENDPOINTS";
+
+  private HttpEndpointGuards() {}
+
+  public static URI requireAllowedEndpoint(URI baseUri, String subject) {
+    Objects.requireNonNull(baseUri, "baseUri");
+    // Before any check whose message interpolates the URI. Credentials belong in
+    // UnityCatalogAuthentication, and the JDK client does not transmit them.
+    if (baseUri.getUserInfo() != null
+        || baseUri.getRawUserInfo() != null
+        || authorityCarriesUserInfo(baseUri)) {
+      throw new IllegalArgumentException(
+          subject + " must not contain userinfo; supply credentials out of band");
+    }
+    if (!baseUri.isAbsolute()) {
+      throw new IllegalArgumentException(subject + " must be absolute: " + display(baseUri));
+    }
+    String scheme = baseUri.getScheme();
+    boolean https = "https".equalsIgnoreCase(scheme);
+    boolean loopbackHttp =
+        "http".equalsIgnoreCase(scheme)
+            && allowLoopbackCleartext()
+            && isLoopbackHost(baseUri.getHost());
+    if (!https && !loopbackHttp) {
+      throw new IllegalArgumentException(
+          subject
+              + " must use HTTPS, except HTTP is allowed for loopback hosts when "
+              + ALLOW_LOOPBACK_PROPERTY
+              + " is set: "
+              + display(baseUri));
+    }
+    if (baseUri.getHost() == null) {
+      throw new IllegalArgumentException(subject + " must include a host: " + display(baseUri));
+    }
+    if (baseUri.getRawQuery() != null || baseUri.getRawFragment() != null) {
+      throw new IllegalArgumentException(
+          subject + " must not include a query or fragment: " + display(baseUri));
+    }
+    // -1 is absent. URI and HttpRequest.Builder both accept 65536; InetSocketAddress rejects it at
+    // send time, where it is reported as TRANSPORT.
+    int port = baseUri.getPort();
+    if (port != -1 && (port < 1 || port > 65535)) {
+      throw new IllegalArgumentException(
+          subject + " port must be between 1 and 65535: " + display(baseUri));
+    }
+    assertAddressClassAllowed(baseUri, subject);
+    return baseUri;
+  }
+
+  /**
+   * Rejects address classes a tenant-supplied connector URI must not name.
+   *
+   * <p>Link-local, wildcard, multicast, broadcast and {@code 0.0.0.0/8} literals are refused
+   * outright; no catalog is reachable at one, and {@code https://169.254.169.254} is otherwise a
+   * well-formed HTTPS URI for a cloud metadata service. Site-local literals require {@link
+   * #ALLOW_PRIVATE_PROPERTY}, since an internal catalog is an ordinary deployment. Loopback is
+   * allowed; cleartext to it is governed by {@link #ALLOW_LOOPBACK_PROPERTY}.
+   *
+   * <p>Literals only: resolving a hostname here would disagree with the resolution {@code
+   * HttpClient} performs at connect time, so a hostname is out of scope.
+   */
+  private static void assertAddressClassAllowed(URI baseUri, String subject) {
+    String host = unbracket(baseUri.getHost());
+    // A zone id names a local interface, and ofLiteral cannot parse one. Left to the catch below a
+    // scoped literal reads as a hostname and skips this gate entirely, so fe80::1%eth0 admits a
+    // link-local address. The transport cannot carry one either.
+    if (host.indexOf('%') >= 0) {
+      throw new IllegalArgumentException(
+          subject + " must not name a zone-scoped address: " + display(baseUri));
+    }
+    InetAddress address;
+    try {
+      address = InetAddress.ofLiteral(host);
+    } catch (IllegalArgumentException notALiteral) {
+      // A host of only digits and dots is not a hostname -- a DNS name cannot be entirely numeric
+      // -- and the resolver the transport uses accepts these modulo 2^32 even though ofLiteral
+      // refuses them: 7147006462 resolves to 169.254.169.254 and 4294967296 to 0.0.0.0. Returning
+      // here would hand the transport a link-local or wildcard target this gate refuses by name.
+      if (isNumericHost(host)) {
+        throw new IllegalArgumentException(
+            subject
+                + " must not name a numeric host that is not an address literal: "
+                + display(baseUri));
+      }
+      return;
+    }
+    if (address.isLoopbackAddress()) {
+      return;
+    }
+    if (address.isLinkLocalAddress()
+        || address.isAnyLocalAddress()
+        || address.isMulticastAddress()
+        || isBroadcastOrThisNetwork(address)) {
+      throw new IllegalArgumentException(
+          subject
+              + " must not name a link-local, wildcard or multicast address: "
+              + display(baseUri));
+    }
+    if (isSiteLocal(address) && !allowPrivateAddresses()) {
+      throw new IllegalArgumentException(
+          subject
+              + " names a private address, which requires "
+              + ALLOW_PRIVATE_PROPERTY
+              + ": "
+              + display(baseUri));
+    }
+  }
+
+  private static boolean isLoopbackHost(String host) {
+    if (host == null) {
+      return false;
+    }
+    String normalized = host.toLowerCase(Locale.ROOT);
+    if (normalized.startsWith("[") && normalized.endsWith("]")) {
+      normalized = normalized.substring(1, normalized.length() - 1);
+    }
+    if (normalized.endsWith(".")) {
+      normalized = normalized.substring(0, normalized.length() - 1);
+    }
+    // Exactly "localhost", not any *.localhost name. RFC 6761 says such names should resolve to
+    // loopback, but nothing here enforces that and this gate does not resolve: a zone the tenant
+    // controls can point catalog.localhost at a public address, and the Authorization header would
+    // then go out in cleartext to it. CredentialResolverSupport, which this mirrors, has no suffix
+    // rule either -- it resolves and requires every answer to be loopback.
+    if (normalized.equals("localhost")) {
+      return true;
+    }
+    // ofLiteral, never getByName: a host this cannot decide is denied, not resolved. A resolver
+    // here disagrees with the one HttpClient uses at connect time. Character-shape pre-filters are
+    // no substitute: "4294967296" and "1." are all digits and dots yet parse as no address.
+    try {
+      return InetAddress.ofLiteral(normalized).isLoopbackAddress();
+    } catch (IllegalArgumentException notAnAddressLiteral) {
+      return false;
+    }
+  }
+
+  /**
+   * Whether the authority embeds userinfo that {@link URI#getUserInfo()} does not report. {@code
+   * java.net.URI} populates it only for a server-based authority; a host it rejects as a hostname
+   * -- an underscore, a non-numeric port -- yields a registry-based authority with the credential
+   * still in the raw string. {@code @} delimits userinfo and has no other role there.
+   */
+  private static boolean authorityCarriesUserInfo(URI baseUri) {
+    String authority = baseUri.getRawAuthority();
+    return authority != null && authority.indexOf('@') >= 0;
+  }
+
+  /**
+   * The base URI as it may appear in a rejection message: scheme, authority and path only.
+   *
+   * <p>A query is a common place for a token, and the userinfo guard covers only credentials in the
+   * authority. Every gate here reports the value it rejected, so the display form drops the two
+   * components that carry data rather than address the endpoint.
+   */
+  private static String display(URI baseUri) {
+    if (baseUri == null) {
+      return "null";
+    }
+    StringBuilder shown = new StringBuilder();
+    if (baseUri.getScheme() != null) {
+      shown.append(baseUri.getScheme()).append("://");
+    }
+    // Parsed components only, never the raw authority. URI reports a host it cannot parse as
+    // server-based -- an underscore, a bad port, or a percent-encoded delimiter such as
+    // alice:s3cr3t%40host -- by leaving getHost() and both userinfo accessors null while the raw
+    // authority keeps the credential. Echoing that here would undo the userinfo guard for exactly
+    // the inputs it cannot recognise.
+    if (baseUri.getHost() == null) {
+      shown.append("<unparseable-authority>");
+    } else {
+      shown.append(baseUri.getHost());
+      if (baseUri.getPort() != -1) {
+        shown.append(':').append(baseUri.getPort());
+      }
+    }
+    if (baseUri.getRawPath() != null) {
+      shown.append(baseUri.getRawPath());
+    }
+    return shown.isEmpty() ? "<empty>" : shown.toString();
+  }
+
+  private static String unbracket(String host) {
+    String value = host == null ? "" : host.trim();
+    if (value.startsWith("[") && value.endsWith("]")) {
+      value = value.substring(1, value.length() - 1);
+    }
+    return value.endsWith(".") ? value.substring(0, value.length() - 1) : value;
+  }
+
+  /** Whether every character is an ASCII digit or a dot. Deliberately not {@code isDigit}. */
+  private static boolean isNumericHost(String host) {
+    if (host.isEmpty()) {
+      return false;
+    }
+    for (int i = 0; i < host.length(); i++) {
+      char c = host.charAt(i);
+      if ((c < '0' || c > '9') && c != '.') {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /** IPv4 RFC 1918 and IPv6 unique-local, which {@code isSiteLocalAddress} misses for fc00::/7. */
+  private static boolean isSiteLocal(InetAddress address) {
+    if (address.isSiteLocalAddress()) {
+      return true;
+    }
+    byte[] bytes = address.getAddress();
+    return bytes.length == 16 && (bytes[0] & 0xFE) == 0xFC;
+  }
+
+  /**
+   * IPv4 limited broadcast and {@code 0.0.0.0/8}. {@code isMulticastAddress} covers 224/4 and
+   * {@code isAnyLocalAddress} only the exact wildcard, so neither address is caught by them.
+   */
+  private static boolean isBroadcastOrThisNetwork(InetAddress address) {
+    byte[] bytes = address.getAddress();
+    if (bytes.length != 4) {
+      return false;
+    }
+    boolean broadcast = true;
+    for (byte octet : bytes) {
+      broadcast &= octet == (byte) 0xFF;
+    }
+    return broadcast || bytes[0] == 0;
+  }
+
+  private static boolean allowPrivateAddresses() {
+    return Boolean.parseBoolean(
+        System.getProperty(
+            ALLOW_PRIVATE_PROPERTY, System.getenv().getOrDefault(ALLOW_PRIVATE_ENV, "false")));
+  }
+
+  private static boolean allowLoopbackCleartext() {
+    return Boolean.parseBoolean(
+        System.getProperty(
+            ALLOW_LOOPBACK_PROPERTY, System.getenv().getOrDefault(ALLOW_LOOPBACK_ENV, "false")));
+  }
+
+  /**
+   * The address-class policy alone, for a second tenant-supplied endpoint in a client's care.
+   *
+   * <p>A client that derives a token endpoint from a catalog URI POSTs credentials to a URI the
+   * tenant chose, which is the one request in such a path carrying a secret. It has to answer this
+   * question the same way the catalog endpoint does.
+   */
+  public static void assertEndpointAddressAllowed(URI endpoint) {
+    assertAddressClassAllowed(Objects.requireNonNull(endpoint, "endpoint"), "Catalog endpoint");
+  }
+
+  /**
+   * HTTPS unless a deployment says otherwise: {@value #ALLOW_CLEARTEXT_S3_PROPERTY}, or the
+   * environment variable {@value #ALLOW_CLEARTEXT_S3_ENV}.
+   */
+  public static final String ALLOW_CLEARTEXT_S3_PROPERTY =
+      "floecat.security.allow-cleartext-s3-endpoints";
+
+  public static final String ALLOW_CLEARTEXT_S3_ENV =
+      "FLOECAT_SECURITY_ALLOW_CLEARTEXT_S3_ENDPOINTS";
+
+  /**
+   * Rejects a storage endpoint that names somewhere the service should not be made to reach.
+   *
+   * <p>Checked when a client is opened, before anything connects. The value is tenant-supplied and
+   * reaches {@code endpointOverride}, so validation would otherwise issue signed S3 requests
+   * wherever it pointed, and the same value travels on as client-safe routing to reconcile and
+   * query workers.
+   *
+   * <p>HTTPS unless a deployment says otherwise. An S3 request carries a SigV4 signature rather
+   * than a bearer secret, which would make cleartext defensible -- except that a provider vending
+   * storage credentials publishes a session token, every signed request then carries it in {@code
+   * X-Amz-Security-Token}, and a session token is replayable against the table's prefix by anyone
+   * who sees it for as long as it lives.
+   *
+   * <p>The escape hatch stays, because an S3-compatible endpoint on a private network commonly is
+   * HTTP -- MinIO and LocalStack both -- but it is a deployment saying so rather than a default.
+   * The address-class rule still applies on top of either scheme: it is the one that refuses {@code
+   * 169.254.169.254}.
+   *
+   * @param subject how the endpoint is named in a refusal, such as {@code "Unity Catalog
+   *     s3.endpoint"}
+   * @throws IllegalArgumentException naming what was refused, for a caller to wrap in whatever its
+   *     own contract raises
+   */
+  public static void requireUsableStorageEndpoint(String endpoint, String subject) {
+    Objects.requireNonNull(subject, "subject");
+    if (endpoint == null || endpoint.isBlank()) {
+      return;
+    }
+    URI uri;
+    try {
+      uri = URI.create(endpoint);
+    } catch (IllegalArgumentException malformed) {
+      // The cause is never attached, and neither is the value. URI.create quotes the whole input in
+      // its message and again in the nested URISyntaxException, so an endpoint carrying userinfo or
+      // a signed query -- which is what the checks below exist to refuse -- put that secret into
+      // the chain a validation failure logs, on the one path where the value was never parseable
+      // enough to be redacted. A parse position says where without saying what.
+      throw new IllegalArgumentException(
+          subject + " is not a valid URI: " + parsePosition(malformed));
+    }
+    String scheme = uri.getScheme();
+    if (!uri.isAbsolute()
+        || uri.getHost() == null
+        || !("https".equalsIgnoreCase(scheme) || "http".equalsIgnoreCase(scheme))
+        || uri.getRawUserInfo() != null
+        || uri.getRawQuery() != null
+        || uri.getRawFragment() != null) {
+      throw new IllegalArgumentException(
+          subject + " must be an absolute http or https URI with no userinfo, query or fragment");
+    }
+    if ("http".equalsIgnoreCase(scheme) && !allowCleartextS3Endpoints()) {
+      throw new IllegalArgumentException(
+          subject
+              + " must use HTTPS: a vended credential carries a session token, which travels in a"
+              + " header and is replayable. Set "
+              + ALLOW_CLEARTEXT_S3_ENV
+              + "=true to allow cleartext on a trusted network");
+    }
+    assertAddressClassAllowed(uri, subject);
+  }
+
+  /**
+   * Where a parse failed, never what failed to parse.
+   *
+   * <p>{@code URI.create} reports "Malformed escape pair at index 34: <the whole input>". The index
+   * is the diagnostic; the input is the secret.
+   */
+  private static String parsePosition(IllegalArgumentException malformed) {
+    Throwable cause = malformed.getCause();
+    String message =
+        cause instanceof URISyntaxException syntax
+            ? syntax.getReason() + " at index " + syntax.getIndex()
+            : "could not be parsed";
+    return message;
+  }
+
+  private static boolean allowCleartextS3Endpoints() {
+    return Boolean.parseBoolean(
+        System.getProperty(
+            ALLOW_CLEARTEXT_S3_PROPERTY,
+            System.getenv().getOrDefault(ALLOW_CLEARTEXT_S3_ENV, "false")));
+  }
+
+  /**
+   * Whether cleartext is permitted to this endpoint because it is loopback and the opt-in is set.
+   *
+   * <p>Exposed so a derived token endpoint can answer it the same way. An integration against an
+   * HTTP loopback catalog, the ordinary local-dev shape, derives its token endpoint from the
+   * catalog URI and inherits the {@code http} scheme; holding that endpoint to HTTPS with no escape
+   * hatch makes client-credentials authentication impossible to run locally while the catalog
+   * request beside it is allowed.
+   */
+  public static boolean isCleartextLoopbackAllowed(URI endpoint) {
+    Objects.requireNonNull(endpoint, "endpoint");
+    return allowLoopbackCleartext() && isLoopbackHost(endpoint.getHost());
+  }
+}

--- a/core/http-endpoint-guards/src/main/java/ai/floedb/floecat/http/guards/HttpResponseSnippets.java
+++ b/core/http-endpoint-guards/src/main/java/ai/floedb/floecat/http/guards/HttpResponseSnippets.java
@@ -1,0 +1,317 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.http.guards;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Duration;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.regex.Pattern;
+
+/**
+ * Turns an upstream response body into something safe to put in a failure message.
+ *
+ * <p>A catalog client sends {@code Authorization} on every request, and a debug handler or a
+ * misconfigured gateway will echo request headers back in an error body. That body is interpolated
+ * into an exception, which reaches validation responses and operator logs, so without this the
+ * tenant's own token travels with the diagnosis.
+ *
+ * <p>Shared rather than copied because it is a security control with two callers. A second copy
+ * drifts, and the copy that drifts is the one nobody reads.
+ */
+public final class HttpResponseSnippets {
+
+  /**
+   * How many encoding layers {@link #couldStillHold} will peel before withholding outright.
+   *
+   * <p>Bounds the work on a body that decodes to something new indefinitely. Ordinary bodies cost
+   * one pass: a text holding no {@code %} and no backslash is returned unchanged by both decoders,
+   * so the loop stops on its first comparison.
+   */
+  private static final int MAX_DECODE_LAYERS = 4;
+
+  private static final Pattern BEARER_TOKEN = Pattern.compile("(?i)bearer\\s+[A-Za-z0-9._~+/=-]+");
+
+  /**
+   * The value following an {@code Authorization} header name, whatever shape it is in.
+   *
+   * <p>Every other pass here has to recognise the credential: the caller's literal, its JSON
+   * escapes, the token68 grammar. Each one has been defeated in turn by a rendering nobody
+   * enumerated -- a colon, an escaped solidus, a backslash-u escape, and percent-encoding, which is
+   * how {@code abc/SECRET} reflected as {@code abc%2FSECRET} kept its tail. This pass recognises
+   * the header *name* instead and discards everything after it up to the first delimiter, so the
+   * encoding of the value stops mattering. An echoed Authorization header is the case all of this
+   * exists for, and its value is never worth reading.
+   */
+  private static final Pattern AUTHORIZATION_VALUE =
+      Pattern.compile("(?i)(authorization[\"']?\\s*[:=]\\s*[\"']?)([^\"',}\\]\\n]*)");
+
+  private HttpResponseSnippets() {}
+
+  /**
+   * Reads a response body under a deadline, closing the stream if it stalls.
+   *
+   * <p>{@code HttpRequest.timeout} only gates receipt of the headers, because {@code ofInputStream}
+   * returns as soon as they arrive. A server that sends headers and then stops leaves the read
+   * blocked with nothing to interrupt it, which occupies a reconcile worker indefinitely.
+   *
+   * <p>On a virtual thread of its own rather than the common pool: the read blocks for the whole
+   * download, and {@code ForkJoinPool.commonPool()} has parallelism one on a small container, so
+   * two concurrent calls queue behind each other and the waiting one fails on this deadline while
+   * the server has already answered.
+   *
+   * <p>Closing the stream is what releases a genuinely stalled read; abandoning the future alone
+   * would leave the reader blocked in {@code readNBytes}.
+   *
+   * @param subject how the upstream is named in the failure, such as {@code "Unity Catalog"}
+   */
+  public static byte[] readWithin(InputStream stream, int limit, Duration deadline, String subject)
+      throws IOException {
+    var body = new CompletableFuture<byte[]>();
+    Thread.ofVirtual()
+        .start(
+            () -> {
+              try {
+                body.complete(stream.readNBytes(limit + 1));
+              } catch (Throwable failure) {
+                body.completeExceptionally(failure);
+              }
+            });
+    try {
+      return body.get(deadline.toMillis(), TimeUnit.MILLISECONDS);
+    } catch (TimeoutException stalled) {
+      closeQuietly(stream);
+      throw new IOException(subject + " response body stalled after " + deadline, stalled);
+    } catch (InterruptedException interrupted) {
+      Thread.currentThread().interrupt();
+      closeQuietly(stream);
+      throw new IOException("Interrupted reading the " + subject + " response body", interrupted);
+    } catch (ExecutionException failure) {
+      Throwable cause = failure.getCause();
+      throw cause instanceof IOException io ? io : new IOException(cause);
+    }
+  }
+
+  private static void closeQuietly(InputStream stream) {
+    try {
+      stream.close();
+    } catch (IOException ignored) {
+      // Closing is how a stalled read is released; a failure to close adds nothing to report.
+    }
+  }
+
+  /** Removes bearer tokens from text on its way into a failure message. */
+  public static String redactBearerTokens(String text) {
+    if (text == null) {
+      return "";
+    }
+    // The header's whole value first, then the grammar. The first does not care how the value was
+    // encoded; the second still covers a token quoted without its header name beside it.
+    String withoutHeader = AUTHORIZATION_VALUE.matcher(text).replaceAll("$1<redacted>");
+    return BEARER_TOKEN.matcher(withoutHeader).replaceAll("Bearer <redacted>");
+  }
+
+  /**
+   * {@link #redactBearerTokens} plus the caller's own token, wherever it appears.
+   *
+   * <p>The pattern above matches the RFC token68 alphabet, which is what a bearer token is supposed
+   * to be. A caller may hold one that is not: any character that a header value permits is accepted
+   * and sent, so a token carrying a colon matched only up to it and the remainder reached the
+   * message unredacted -- defeating the control in exactly the echoed-header case it exists for. A
+   * caller that knows its own secret can say so, and then nothing depends on guessing the shape.
+   */
+  public static String redactSecrets(String text, String secret) {
+    if (text == null) {
+      return "";
+    }
+    // The caller's own value first. The pattern below rewrites the part of a token that does match
+    // the grammar, which destroys the literal it would then be searched for: redacting the pattern
+    // first turned "Bearer part1:part2" into "Bearer <redacted>:part2" and left the suffix behind.
+    String withoutSecret = text;
+    if (secret != null && !secret.isBlank()) {
+      // The escaped form first, then the raw one. A server echoing the Authorization header into a
+      // JSON body escapes the quotes and backslashes in it, so a token holding either -- both are
+      // legal in a header value, and this client accepts what the header permits -- appears as
+      // \" or \\ and the literal search misses it. The pattern misses it too, since a quote is
+      // outside the token68 alphabet, so the tail of such a token survived both passes.
+      // The escaped renderings first, longest-transformed first, then the raw one. A serializer
+      // may escape any subset of these three, so each is tried on its own as well as together:
+      // the solidus matters most, because it is inside the token68 alphabet and common in real
+      // tokens, so "abc/SECRET" echoed as "abc\\/SECRET" was missed by the literal search and cut
+      // at the backslash by the pattern -- leaving most of the token in the message.
+      for (String escaped : escapedForms(secret)) {
+        withoutSecret = withoutSecret.replace(escaped, "<redacted>");
+      }
+      withoutSecret = withoutSecret.replace(secret, "<redacted>");
+    }
+    // Then fail closed. The forms above are the ones worth enumerating; a serializer is free to
+    // escape in a way none of them match, so rather than grow that list until one entry is wrong,
+    // ask whether anything the body could de-escape to still holds the secret and withhold it if
+    // so. A false positive costs a diagnostic; a false negative costs the credential.
+    //
+    // Asked before the pattern runs, not after: the pattern rewrites the part of a token that does
+    // match the grammar, so once "Bearer abc/SECRET" has become "Bearer <redacted>" plus a tail,
+    // the literal this looks for no longer exists. The same ordering mistake as bounding before
+    // redacting, one layer further in.
+    if (secret != null && !secret.isBlank() && couldStillHold(withoutSecret, secret)) {
+      return "<withheld: the response echoed the credential>";
+    }
+    return redactBearerTokens(withoutSecret);
+  }
+
+  /** The ways a JSON serializer may render the secret, each escape applied and combined. */
+  private static List<String> escapedForms(String secret) {
+    LinkedHashSet<String> forms = new LinkedHashSet<>();
+    forms.add(secret.replace("\\", "\\\\").replace("\"", "\\\"").replace("/", "\\/"));
+    forms.add(secret.replace("\\", "\\\\").replace("\"", "\\\""));
+    forms.add(secret.replace("/", "\\/"));
+    forms.add(secret.replace("\"", "\\\""));
+    forms.add(secret.replace("\\", "\\\\"));
+    forms.remove(secret);
+    return List.copyOf(forms);
+  }
+
+  /**
+   * Whether any de-escaping of this text would reveal the secret.
+   *
+   * <p>Deliberately a superset of a real JSON unescape: every backslash is dropped and every {@code
+   * a backslash-u escape} decoded, which can join characters an unescape would not. That direction
+   * is the safe one -- it can only withhold a body that was in fact clean, never publish one that
+   * was not.
+   */
+  private static boolean couldStillHold(String text, String secret) {
+    // Layer by layer, until the text stops changing. One pass leaves a value encoded twice intact:
+    // "abc%252FSECRET" decodes once to "abc%2FSECRET", which holds no secret to find, and the log
+    // then carries something a reader decodes again to recover the credential.
+    //
+    // Both sides are de-escaped the same way. Stripping backslashes from the body alone destroys
+    // the evidence for a secret that contains one: "\\SECRET" strips to "SECRET" and would be
+    // compared against the raw "\\SECRET". Comparing like with like errs towards withholding.
+    String bare = decodeUnicodeEscapes(secret).replace("\\", "");
+    String current = text;
+    for (int layer = 0; layer < MAX_DECODE_LAYERS; layer++) {
+      String stripped = current.replace("\\", "");
+      if (stripped.contains(secret) || stripped.contains(bare)) {
+        return true;
+      }
+      String next = decodePercentEscapes(decodeUnicodeEscapes(current));
+      if (next.equals(current)) {
+        return false;
+      }
+      current = next;
+    }
+    // Still decoding to something new after the bound. Whatever that is, it is not a body worth
+    // publishing to find out.
+    return true;
+  }
+
+  /** Percent escapes decoded, so the net sees a value a proxy reflected in encoded form. */
+  private static String decodePercentEscapes(String text) {
+    if (text.indexOf('%') < 0) {
+      return text;
+    }
+    StringBuilder out = new StringBuilder(text.length());
+    for (int i = 0; i < text.length(); i++) {
+      if (text.charAt(i) == '%' && i + 2 < text.length()) {
+        try {
+          out.append((char) Integer.parseInt(text.substring(i + 1, i + 3), 16));
+          i += 2;
+          continue;
+        } catch (NumberFormatException notAnEscape) {
+          // Not an escape after all; copy the percent verbatim.
+        }
+      }
+      out.append(text.charAt(i));
+    }
+    return out.toString();
+  }
+
+  private static String decodeUnicodeEscapes(String text) {
+    if (text.indexOf('\\') < 0) {
+      return text;
+    }
+    StringBuilder out = new StringBuilder(text.length());
+    for (int i = 0; i < text.length(); i++) {
+      if (text.charAt(i) == '\\'
+          && i + 5 < text.length()
+          && (text.charAt(i + 1) == 'u' || text.charAt(i + 1) == 'U')) {
+        try {
+          out.append((char) Integer.parseInt(text.substring(i + 2, i + 6), 16));
+          i += 5;
+          continue;
+        } catch (NumberFormatException notAnEscape) {
+          // Not an escape after all; fall through and copy the backslash verbatim.
+        }
+      }
+      out.append(text.charAt(i));
+    }
+    return out.toString();
+  }
+
+  /**
+   * A bounded, redacted snippet of a response body.
+   *
+   * <p>Redacted first and bounded after. The reverse cut a secret in half before anything looked
+   * for it: the remaining fragment no longer matched a caller's literal token, and for a token
+   * outside the {@code token68} grammar the pattern stopped at the first character it does not
+   * accept, so the suffix between there and the bound survived into the snippet.
+   *
+   * <p>Redacting only a window around the bound is not enough either, which is why the whole body
+   * is scanned. A replacement is shorter than what it replaces, so redacting pulls later text
+   * forward into the bounded range -- text that a window would not have reached, and that can hold
+   * another occurrence of the same secret.
+   *
+   * <p>The cost is a scan of the whole body on a failure path. It is bounded by the caller's own
+   * response cap, and a failure that is about to be logged is not where a copy matters.
+   */
+  public static String bounded(String value, int maxChars) {
+    return bounded(value, maxChars, null);
+  }
+
+  /** {@link #bounded} that also removes the caller's own token, by value. */
+  public static String bounded(String value, int maxChars, String secret) {
+    if (value == null) {
+      return "";
+    }
+    String redacted = redactSecrets(value, secret);
+    return redacted.substring(0, Math.min(redacted.length(), maxChars));
+  }
+
+  /**
+   * {@link #bounded} for a body that reaches a single-line message, with an ellipsis where the
+   * bound cut it.
+   */
+  public static String boundedSingleLine(String body, int maxChars) {
+    return boundedSingleLine(body, maxChars, null);
+  }
+
+  /** {@link #boundedSingleLine} that also removes the caller's own token. */
+  public static String boundedSingleLine(String body, int maxChars, String secret) {
+    if (body == null) {
+      return "";
+    }
+    String flattened = body.replace('\n', ' ').replace('\r', ' ').trim();
+    // Redact, then bound. See bounded() for why the order is this way round and why the whole body
+    // is scanned rather than a window at the cut.
+    String redacted = redactSecrets(flattened, secret);
+    return redacted.length() <= maxChars ? redacted : redacted.substring(0, maxChars) + "...";
+  }
+}

--- a/core/http-endpoint-guards/src/test/java/ai/floedb/floecat/http/guards/HttpEndpointGuardsTest.java
+++ b/core/http-endpoint-guards/src/test/java/ai/floedb/floecat/http/guards/HttpEndpointGuardsTest.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.http.guards;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.net.URI;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The gates, tested where they live.
+ *
+ * <p>This module exists because a security control with two callers drifts when it is copied. The
+ * same argument reaches its tests: with coverage only in the consumers, a change here is checked by
+ * whichever consumer happens to exercise the branch, and {@code mvn -pl} on this module proves
+ * nothing. Both of these have since been broken and repaired with the failing test living in
+ * another module.
+ */
+class HttpEndpointGuardsTest {
+
+  private static final String SUBJECT = "Catalog endpoint";
+
+  /**
+   * A zone id makes a literal parse as a hostname, which skips the address-class gate entirely.
+   * {@code fe80::1%eth0} would otherwise reach a link-local interface with the Authorization header
+   * attached.
+   */
+  @Test
+  void refusesAZoneScopedLiteral() {
+    assertThatThrownBy(
+            () ->
+                HttpEndpointGuards.requireAllowedEndpoint(
+                    URI.create("https://[fe80::1%25eth0]/api"), SUBJECT))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("zone-scoped");
+  }
+
+  /**
+   * An all-numeric host is not a hostname, and the transport resolves one modulo 2^32 -- so {@code
+   * 7147006462} reaches 169.254.169.254, the cloud metadata address.
+   */
+  @Test
+  void refusesAnAllNumericHostThatIsNotAnAddressLiteral() {
+    assertThatThrownBy(
+            () ->
+                HttpEndpointGuards.requireAllowedEndpoint(
+                    URI.create("https://7147006462/api"), SUBJECT))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("numeric host");
+  }
+
+  /** Cleartext is refused, since the Authorization header goes out on every request. */
+  @Test
+  void refusesCleartextForANonLoopbackHost() {
+    assertThatThrownBy(
+            () ->
+                HttpEndpointGuards.requireAllowedEndpoint(
+                    URI.create("http://sharing.example.com/api"), SUBJECT))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatCode(
+            () ->
+                HttpEndpointGuards.requireAllowedEndpoint(
+                    URI.create("https://sharing.example.com/api"), SUBJECT))
+        .doesNotThrowAnyException();
+  }
+
+  /** Credentials belong in the header, not in a URI that reaches logs and error messages. */
+  @Test
+  void refusesUserInfo() {
+    assertThatThrownBy(
+            () ->
+                HttpEndpointGuards.requireAllowedEndpoint(
+                    URI.create("https://user:pass@sharing.example.com/api"), SUBJECT))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("userinfo");
+  }
+
+  /**
+   * The caller's own token is removed before the character bound, not after.
+   *
+   * <p>Bounding first cut a token in half before either pass looked for it: the literal no longer
+   * matched, and the pattern stops at the first character outside the token68 grammar, so
+   * everything between a colon and the cut survived into a message that reaches operator logs.
+   */
+  @Test
+  void redactsACallerTokenThatStraddlesTheBound() {
+    String secret = "part1:part2-SECRETSUFFIX";
+    String body = "x".repeat(1980) + "Bearer " + secret + " trailing";
+
+    String snippet = HttpResponseSnippets.boundedSingleLine(body, 2_000, secret);
+
+    assertThat(snippet).doesNotContain("part2").doesNotContain("SECRETSUFFIX");
+  }
+
+  /**
+   * Every occurrence, not only the one inside the bound. A replacement is shorter than what it
+   * replaces, so redacting pulls later text forward into the bounded range -- which is why the
+   * whole body is scanned rather than a window around the cut.
+   */
+  @Test
+  void redactsAnOccurrenceThatRedactionPullsIntoRange() {
+    String secret = "part1:part2-SECRETSUFFIX";
+    String body =
+        "y".repeat(1900) + "Bearer " + secret + "z".repeat(60) + secret + "z".repeat(60) + secret;
+
+    assertThat(HttpResponseSnippets.boundedSingleLine(body, 2_000, secret))
+        .doesNotContain("part1:");
+  }
+
+  /** A token shaped the way the grammar says is still covered when the caller names none. */
+  @Test
+  void redactsABearerTokenWithNoCallerSecretGiven() {
+    assertThat(HttpResponseSnippets.boundedSingleLine("echo Bearer abc123.def", 2_000, null))
+        .contains("Bearer <redacted>")
+        .doesNotContain("abc123");
+  }
+
+  /**
+   * The parser's own exception is the leak. {@code URI.create} quotes the whole input in its
+   * message and again in the nested {@code URISyntaxException}, so an endpoint carrying userinfo --
+   * which is what this method exists to refuse -- put that secret into the chain a validation
+   * failure logs, on the one path where the value was never parseable enough to be redacted.
+   */
+  @Test
+  void aMalformedEndpointDoesNotCarryItsValueIntoTheCauseChain() {
+    String endpoint = "https://user:s3cr3t-PASSWORD@host/%ZZ";
+
+    assertThatThrownBy(() -> HttpEndpointGuards.requireUsableStorageEndpoint(endpoint, SUBJECT))
+        .isInstanceOf(IllegalArgumentException.class)
+        .satisfies(
+            e -> {
+              for (Throwable t = e; t != null; t = t.getCause()) {
+                assertThat(String.valueOf(t.getMessage()))
+                    .doesNotContain("s3cr3t-PASSWORD")
+                    .doesNotContain(endpoint);
+              }
+            });
+  }
+
+  /** The position still reaches the message, since it is the half that diagnoses anything. */
+  @Test
+  void aMalformedEndpointStillSaysWhereItFailed() {
+    assertThatThrownBy(
+            () -> HttpEndpointGuards.requireUsableStorageEndpoint("https://host/%ZZ", SUBJECT))
+        .hasMessageContaining("index");
+  }
+
+  /**
+   * A token holding a quote or a backslash appears escaped inside a JSON body, so the literal
+   * search missed it -- and the pattern missed it too, because a quote is outside the token68
+   * alphabet. Both characters are legal in a header value and this control accepts what a header
+   * permits.
+   */
+  @Test
+  void redactsATokenThatAJsonBodyEscaped() {
+    String secret = "abc\"def";
+    String body = "{\"error\":\"upstream sent Authorization: Bearer abc\\\"def\"}";
+
+    assertThat(HttpResponseSnippets.boundedSingleLine(body, 2_000, secret))
+        .doesNotContain("abc")
+        .doesNotContain("def");
+  }
+
+  /**
+   * The solidus is the one that matters most: it is inside the token68 alphabet and common in real
+   * tokens, so {@code abc/SECRET} echoed as {@code abc\\/SECRET} was missed by the literal search
+   * and cut at the backslash by the pattern -- leaving most of the token in the message.
+   */
+  @Test
+  void redactsATokenWhoseSolidusAJsonBodyEscaped() {
+    String secret = "abc/SECRET";
+    String body = "{\"echo\":\"Authorization: Bearer abc\\/SECRET\"}";
+
+    assertThat(HttpResponseSnippets.boundedSingleLine(body, 2_000, secret))
+        .doesNotContain("SECRET");
+  }
+
+  /**
+   * And an escaping none of the named forms match is withheld rather than partly redacted. A false
+   * positive costs a diagnostic; a false negative costs the credential.
+   */
+  @Test
+  void aBodyEscapedInAnUnrecognisedWayIsWithheldRatherThanPartlyRedacted() {
+    String secret = "abc/SECRET";
+    // Every character escaped individually, which no form in the list constructs.
+    String body = "{\"echo\":\"Bearer a\\bc\\/SE\\CRET\"}";
+
+    assertThat(HttpResponseSnippets.boundedSingleLine(body, 2_000, secret))
+        .doesNotContain("SECRET")
+        .contains("withheld");
+  }
+
+  /** The same for a backslash, which a JSON body doubles. */
+  @Test
+  void redactsATokenWhoseBackslashAJsonBodyDoubled() {
+    String secret = "abc\\def";
+    String body = "{\"echo\":\"Bearer abc\\\\def\"}";
+
+    assertThat(HttpResponseSnippets.boundedSingleLine(body, 2_000, secret)).doesNotContain("def");
+  }
+
+  /**
+   * A secret that itself contains a backslash. Stripping backslashes from the body alone destroyed
+   * the evidence: the decoded body strips to {@code SECRET} and was compared against the raw {@code
+   * \\SECRET}, so nothing matched and nothing was withheld -- while the pattern missed it too, the
+   * token beginning with a backslash. The whole credential stayed reconstructable.
+   */
+  @Test
+  void aBackslashBearingSecretRenderedAsAUnicodeEscapeIsWithheld() {
+    String secret = "\\SECRET-TAIL";
+    String body = "{\"echo\":\"Bearer \\u005cSECRET-TAIL\"}";
+
+    assertThat(HttpResponseSnippets.boundedSingleLine(body, 2_000, secret))
+        .doesNotContain("SECRET-TAIL")
+        .contains("withheld");
+  }
+
+  /**
+   * A percent-encoded reflection. Every pass that has to recognise the credential has been defeated
+   * in turn by a rendering nobody enumerated -- a colon, an escaped solidus, a backslash-u escape,
+   * and this. Recognising the header name instead makes the encoding of the value stop mattering.
+   */
+  @Test
+  void anAuthorizationValueIsRedactedWhateverEncodingItArrivesIn() {
+    for (String body :
+        new String[] {
+          "upstream echoed Authorization: Bearer abc%2FSECRET-TAIL",
+          "{\"Authorization\":\"Bearer abc%2FSECRET-TAIL\"}",
+          "headers={Authorization=Bearer abc%2FSECRET-TAIL, Accept=*/*}",
+          // Deliberately not base64. The scheme is what this case is about -- the pass matches the
+          // header name, so the value's encoding is beside the point -- and a fixture that decodes
+          // to a credential pair is one a secret scanner reports, correctly, as a credential.
+          "Authorization: Basic NOT-A-REAL-CREDENTIAL-FIXTURE"
+        }) {
+      assertThat(HttpResponseSnippets.bounded(body, 500))
+          .as(body)
+          .doesNotContain("SECRET-TAIL")
+          .doesNotContain("NOT-A-REAL-CREDENTIAL-FIXTURE");
+    }
+  }
+
+  /** The header name survives, so the message still says what was echoed. */
+  @Test
+  void redactingTheValueLeavesTheHeaderNameReadable() {
+    assertThat(HttpResponseSnippets.bounded("Authorization: Bearer abc%2FSECRET", 500))
+        .contains("Authorization")
+        .contains("<redacted>");
+  }
+
+  /** A token quoted without its header name beside it is still covered by the grammar pass. */
+  @Test
+  void aBareBearerTokenIsStillRedacted() {
+    assertThat(HttpResponseSnippets.bounded("the token was Bearer abc123.def", 500))
+        .contains("Bearer <redacted>")
+        .doesNotContain("abc123");
+  }
+
+  /** A null secret is a caller with nothing to name, not a failure. */
+  @Test
+  void toleratesANullOrBlankSecret() {
+    assertThatCode(
+            () -> {
+              HttpResponseSnippets.redactSecrets("body", null);
+              HttpResponseSnippets.redactSecrets("body", "");
+              HttpResponseSnippets.redactSecrets(null, "secret");
+            })
+        .doesNotThrowAnyException();
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,7 @@
       <module>core/metadata-admission-runtime</module>
       <module>core/stats</module>
       <module>core/catalog</module>
+      <module>core/http-endpoint-guards</module>
       <module>core/catalog-access-spi</module>
       <module>core/scanner</module>
       <module>core/metagraph</module>


### PR DESCRIPTION
# refactor(http): share the catalog endpoint gates and response handling

Stack 1 of 6. Base branch: `main`.

## What

Moves four things that were private to the Unity client into a shared module, because a second
Delta-backed provider needs each of them.

- `core/http-endpoint-guards` holds what a tenant-supplied endpoint is held to:
  `requireAllowedEndpoint` for a catalog URI, `requireUsableStorageEndpoint` for an `s3.endpoint`.
- `HttpResponseSnippets` holds the two things a response body needs on the way into a failure:
  bearer tokens redacted out of it, and a read bounded by its own deadline. `HttpRequest.timeout`
  gates receipt of the headers only, so a server that sends headers and then stalls holds a
  reconcile worker with nothing to interrupt it.
- The constants the move left behind are gone, and the loopback property delegates like its sibling.

## Review focus

A move plus the new module's own tests. No behaviour change is intended for Unity -- the Unity
client and provider are edited only to call the shared members.

## Scope

12 files changed, 1182 insertions(+), 391 deletions(-)

- `catalog-access/unity`
- `connectors/clients`
- `core/http-endpoint-guards`
- `pom.xml`

Full rationale and the review history behind these changes are in #519, which this
stack replaces.
