### PR TITLE
refactor(catalog-access): add delta-common and move the Delta log probe into it

### DIFF
--- a/catalog-access/delta-common/pom.xml
+++ b/catalog-access/delta-common/pom.xml
@@ -16,7 +16,7 @@
     <relativePath>../..</relativePath>
   </parent>
 
-  <artifactId>floecat-catalog-access-unity</artifactId>
+  <artifactId>floecat-catalog-access-delta-common</artifactId>
 
   <dependencies>
     <dependency>
@@ -25,19 +25,8 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>ai.floedb.floecat</groupId>
-      <artifactId>floecat-http-endpoint-guards</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>ai.floedb.floecat</groupId>
-      <artifactId>floecat-unity-catalog-client</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>ai.floedb.floecat</groupId>
-      <artifactId>floecat-catalog-access-delta-common</artifactId>
-      <version>${project.version}</version>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>s3</artifactId>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/catalog-access/delta-common/src/main/java/ai/floedb/floecat/catalog/delta/DeltaLogStorageProbe.java
+++ b/catalog-access/delta-common/src/main/java/ai/floedb/floecat/catalog/delta/DeltaLogStorageProbe.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+package ai.floedb.floecat.catalog.delta;
+
+import ai.floedb.floecat.catalog.access.VendedStorageCredentials;
+import java.util.Locale;
+import java.util.Objects;
+
+@FunctionalInterface
+public interface DeltaLogStorageProbe {
+
+  void validate(String tableLocation, VendedStorageCredentials credentials);
+
+  /**
+   * Whether the S3 probe can address this location at all.
+   *
+   * <p>Part of the contract rather than an internal: a provider that vends AWS credentials needs to
+   * know before it reconciles a table whether the location it was given is one this can read. An
+   * {@code abfss://} or {@code gs://} table would otherwise load, reconcile, and fail at every
+   * scan.
+   */
+  static boolean s3Serves(String tableLocation) {
+    return S3DeltaLogProbe.s3Location(tableLocation) != null;
+  }
+
+  /**
+   * The form of a location a provider should publish, vend and compare.
+   *
+   * <p>An S3 object key may hold a space and {@code java.net.URI} may not. This probe encodes one
+   * before parsing, so it answers for {@code s3://bucket/db/my table} -- and a provider that then
+   * publishes the raw string reconciles a table the read path cannot open, because that path calls
+   * {@code URI.create} on the location at every site. Before the probe accepted such a location it
+   * was refused outright, which was at least a recorded failure; accepting it on one side without
+   * canonicalising on the other turns that into a table that validates clean and fails every scan.
+   *
+   * <p>Here rather than in either provider because both need the same answer, which is the reason
+   * this module exists. Encoded rather than refused because the read path derives its key with
+   * {@code URI.getPath}, which decodes, so S3 is asked for the key that was written. Idempotent,
+   * since only a literal space is replaced: a location that already carries {@code %20} is
+   * unchanged and nothing is double-encoded.
+   *
+   * <p>Other characters {@code URI} rejects and S3 permits are still refused by {@link #s3Serves}.
+   * A space is the one that occurs.
+   */
+  static String canonicalLocation(String tableLocation) {
+    if (tableLocation == null) {
+      return null;
+    }
+    // The scheme too, not only the space. s3Serves accepts s3, s3a and s3n in any case, while the
+    // reader's resolvePath matches a literal lowercase s3:// or s3a:// and throws on anything
+    // else -- so publishing the spelling the server used meant s3n://bucket/table and
+    // S3://bucket/table validated, reconciled, and failed every scan on an unsupported path.
+    // Servability and publication have to agree about what a location is, and the reader decides.
+    // No trim. An S3 object key may end in a space, and the probe does not trim either -- so
+    // trimming here published a different prefix from the one validation had just read, which is
+    // the divergence this method exists to prevent. Whatever the server sent is the key; the only
+    // changes made to it are the ones the reader requires.
+    return publishableScheme(tableLocation).replace(" ", "%20");
+  }
+
+  /**
+   * The scheme folded only where the reader cannot parse it.
+   *
+   * <p>{@code StorageLocations.normalizeScheme} folds s3, s3a and s3n alike, and folding everything
+   * to s3 put the stored location in a different scheme namespace from the prefix an operator
+   * registers: {@code StorageAuthorityResolver.matchesLocationPrefix} is a scheme-sensitive {@code
+   * startsWith}, and {@code S3Location.parse} explicitly accepts an {@code s3a://} authority prefix
+   * -- so a catalog reporting s3a, an authority registered as s3a, and a location stored as s3
+   * never match.
+   *
+   * <p>So only the spellings the reader genuinely cannot read are changed: {@code s3n} and any
+   * uppercase form, since {@code S3V2FileSystemClient.resolvePath} matches a literal lowercase
+   * {@code s3://} or {@code s3a://}. What the source reported is otherwise what gets stored.
+   */
+  private static String publishableScheme(String location) {
+    int schemeEnd = location.indexOf("://");
+    if (schemeEnd < 0) {
+      return location;
+    }
+    String scheme = location.substring(0, schemeEnd).toLowerCase(Locale.ROOT);
+    if ("s3a".equals(scheme)) {
+      return scheme + location.substring(schemeEnd);
+    }
+    return "s3".equals(scheme) || "s3n".equals(scheme)
+        ? "s3" + location.substring(schemeEnd)
+        : location;
+  }
+
+  /**
+   * A probe that lists and reads one object under the table's Delta log with the vended
+   * credentials.
+   *
+   * <p>Listing alone would pass on a grant that cannot read, so the probe reads a byte. What it
+   * proves is that the credential the provider vended actually reaches the storage it named, which
+   * is the question a validation run is asking on the operator's behalf.
+   *
+   * @param subject how the catalog is named in a refusal, such as {@code "Unity Catalog"}
+   */
+  static DeltaLogStorageProbe s3(String subject) {
+    Objects.requireNonNull(subject, "subject");
+    return (tableLocation, credentials) ->
+        S3DeltaLogProbe.validate(subject, tableLocation, credentials);
+  }
+}

--- a/catalog-access/delta-common/src/main/java/ai/floedb/floecat/catalog/delta/S3DeltaLogProbe.java
+++ b/catalog-access/delta-common/src/main/java/ai/floedb/floecat/catalog/delta/S3DeltaLogProbe.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  */
 
-package ai.floedb.floecat.catalog.unity;
+package ai.floedb.floecat.catalog.delta;
 
 import ai.floedb.floecat.catalog.access.CatalogAccessException;
 import ai.floedb.floecat.catalog.access.StorageLocations;
@@ -33,35 +33,30 @@ import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 
-@FunctionalInterface
-interface UnityStorageAccessValidator {
+final class S3DeltaLogProbe {
 
-  /** Implicitly public static final: this interface is package-private, so the constant is too. */
-  String DELTA_LOG_DIR = "_delta_log/";
+  private S3DeltaLogProbe() {}
 
-  void validate(String tableLocation, VendedStorageCredentials credentials);
+  private static final String DELTA_LOG_DIR = "_delta_log/";
 
-  static UnityStorageAccessValidator s3() {
-    return UnityStorageAccessValidator::validateS3;
-  }
-
-  private static void validateS3(String tableLocation, VendedStorageCredentials credentials) {
+  static void validate(String subject, String tableLocation, VendedStorageCredentials credentials) {
     // Parsed once, and inside the guard. Doing it here unguarded put an IllegalArgumentException
     // ahead of the check meant to catch it: an object key holding a character URI rejects -- a
-    // space is the common one -- threw before s3Location could answer, and UnityCatalogErrors
-    // mapped it to "storage access validation configuration is invalid", which describes neither
-    // the location nor anything an operator configured.
+    // space is the common one -- threw before s3Location could answer, and the caller mapped it
+    // to "storage access validation configuration is invalid", which describes neither the
+    // location nor anything an operator configured.
     URI location = s3Location(tableLocation);
     if (location == null) {
       throw new CatalogAccessException(
           CatalogAccessException.Code.UNSUPPORTED,
-          "Unity Catalog storage validation needs an addressable S3 location, and could not read"
-              + " a bucket from this one");
+          subject
+              + " storage validation needs an addressable S3 location, and could not read a"
+              + " bucket from this one");
     }
     String bucketName = bucketOf(location);
     Map<String, String> properties = credentials.properties();
-    String accessKey = required(properties, "s3.access-key-id");
-    String secretKey = required(properties, "s3.secret-access-key");
+    String accessKey = required(subject, properties, "s3.access-key-id");
+    String secretKey = required(subject, properties, "s3.secret-access-key");
     String sessionToken = nonBlank(properties.get("s3.session-token"));
     AwsCredentials awsCredentials =
         sessionToken == null
@@ -83,10 +78,10 @@ interface UnityStorageAccessValidator {
       builder.endpointOverride(URI.create(endpoint));
     }
 
-    // The bucket named in the object URI, never s3.access-point. SourceCatalogCredentialVendor
-    // strips that key before any reader sees it -- noteIgnoredAccessPoint records why -- so probing
-    // the access point would validate an endpoint no scan ever addresses, and a grant scoped to it
-    // alone would report success against reads that all get 403.
+    // The bucket named in the object URI, never s3.access-point. The vend strips that key before
+    // any reader sees it, so probing the access point would validate an endpoint no scan ever
+    // addresses, and a grant scoped to it alone would report success against reads that all get
+    // 403.
     String bucket = bucketName;
     String logPrefix = deltaLogPrefix(location.getPath());
     try (S3Client s3 = builder.build()) {
@@ -95,8 +90,8 @@ interface UnityStorageAccessValidator {
               ListObjectsV2Request.builder().bucket(bucket).prefix(logPrefix).maxKeys(1).build());
       if (listing.contents().isEmpty()) {
         throw new CatalogAccessException(
-            CatalogAccessException.Code.UNSUPPORTED,
-            "Unity Catalog table storage contains no Delta log object to validate");
+            CatalogAccessException.Code.INVALID_CONFIGURATION,
+            subject + " table storage contains no Delta log object to validate");
       }
       try {
         // Streamed and aborted, not buffered. Range is a request hint: an S3-compatible endpoint
@@ -136,29 +131,27 @@ interface UnityStorageAccessValidator {
           failure.awsErrorDetails() == null ? null : failure.awsErrorDetails().errorCode();
       throw new CatalogAccessException(
           storageFailureCode(errorCode, failure.statusCode()),
-          "Unity Catalog storage validation failed",
+          subject + " storage validation failed",
           failure);
     } catch (java.io.IOException failure) {
       // Reading or releasing the probe body: a fact about reaching the store, like the transport
       // failures below it, not about the credential.
       throw new CatalogAccessException(
           CatalogAccessException.Code.UNAVAILABLE,
-          "Unity Catalog storage validation could not read the probe object",
+          subject + " storage validation could not read the probe object",
           failure);
     } catch (RuntimeException failure) {
       throw new CatalogAccessException(
-          CatalogAccessException.Code.UNAVAILABLE,
-          "Unity Catalog storage validation failed",
-          failure);
+          CatalogAccessException.Code.UNAVAILABLE, subject + " storage validation failed", failure);
     }
   }
 
-  private static String required(Map<String, String> properties, String key) {
+  private static String required(String subject, Map<String, String> properties, String key) {
     String value = nonBlank(properties.get(key));
     if (value == null) {
       throw new CatalogAccessException(
           CatalogAccessException.Code.INVALID_CONFIGURATION,
-          "Unity Catalog storage credentials omitted " + key);
+          subject + " storage credentials omitted " + key);
     }
     return value;
   }
@@ -182,7 +175,7 @@ interface UnityStorageAccessValidator {
    * <p>Scoped to the listing on purpose. The ranged read streams a body of unknown size and aborts
    * after one byte, so capping that stream would constrain a path whose bound already holds.
    */
-  final class BoundedListingBody implements ExecutionInterceptor {
+  private static final class BoundedListingBody implements ExecutionInterceptor {
 
     @Override
     public Optional<InputStream> modifyHttpResponseContent(
@@ -299,11 +292,28 @@ interface UnityStorageAccessValidator {
     }
     URI normalized;
     try {
-      normalized = URI.create(StorageLocations.normalizeScheme(tableLocation));
+      // A space is percent-encoded before parsing. It is legal in an S3 object key and illegal in
+      // java.net.URI, so a valid table location answered null here and the caller refused it for
+      // having no addressable bucket -- a diagnosis pointing at the bucket when the key was the
+      // problem. getPath decodes it again, so the key the probe asks for is unchanged. Other
+      // characters URI rejects and S3 permits still answer null; a space is the one that occurs.
+      normalized = URI.create(StorageLocations.normalizeScheme(tableLocation).replace(" ", "%20"));
     } catch (IllegalArgumentException notAUri) {
       return null;
     }
     if (!"s3".equalsIgnoreCase(normalized.getScheme()) || bucketOf(normalized) == null) {
+      return null;
+    }
+    // Nothing that carries a secret. bucketOf refuses an authority holding userinfo, but only on
+    // its fallback branch: getHost() answers "bucket" for s3://user:password@bucket/table, so that
+    // check never ran and the location was servable. A provider then stores it as the reconciled
+    // table's storage_location, which puts a password or a signed query into catalog metadata --
+    // readable by every client that can read the table. None of these belong in an S3 object
+    // location anyway, and the endpoint gates already refuse the same four on a catalog URI.
+    if (normalized.getRawUserInfo() != null
+        || normalized.getRawQuery() != null
+        || normalized.getRawFragment() != null
+        || normalized.getPort() != -1) {
       return null;
     }
     return normalized;
@@ -338,8 +348,20 @@ interface UnityStorageAccessValidator {
     return authority;
   }
 
+  /**
+   * Exactly the URI separator, and no more.
+   *
+   * <p>An S3 object key may begin with a slash, so {@code s3://bucket//table} names the key {@code
+   * /table}. The read path removes one leading slash and addresses that key; this removed every one
+   * and probed {@code table/_delta_log/} instead -- a different prefix, so validation either
+   * rejected a readable table or, where something else sat at the stripped prefix, read that Delta
+   * log and reported success for a location no scan would reach.
+   */
   private static String stripLeadingSlash(String value) {
-    return value == null ? "" : value.replaceFirst("^/+", "");
+    if (value == null) {
+      return "";
+    }
+    return value.startsWith("/") ? value.substring(1) : value;
   }
 
   private static String nonBlank(String value) {

--- a/catalog-access/delta-common/src/test/java/ai/floedb/floecat/catalog/delta/DeltaLogStorageProbeTest.java
+++ b/catalog-access/delta-common/src/test/java/ai/floedb/floecat/catalog/delta/DeltaLogStorageProbeTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package ai.floedb.floecat.catalog.unity;
+package ai.floedb.floecat.catalog.delta;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -34,7 +34,10 @@ import org.junit.jupiter.api.Test;
  * smoke failure -- which key prefix the Delta log is looked for under, and what an S3 error means
  * about the credential -- are pure, and asserted here.
  */
-class UnityStorageAccessValidatorTest {
+class DeltaLogStorageProbeTest {
+
+  /** Every refusal names its caller, so the tests assert against one name. */
+  private static final String SUBJECT = "Test Catalog";
 
   /**
    * A table at the bucket root has an empty path, and a leading slash would make the prefix
@@ -52,9 +55,7 @@ class UnityStorageAccessValidatorTest {
             new Case("trailing slash", "/tpch/orders/", "tpch/orders/_delta_log/"),
             new Case("no leading slash", "tpch/orders", "tpch/orders/_delta_log/"),
             new Case("null path", null, "_delta_log/"))) {
-      assertThat(UnityStorageAccessValidator.deltaLogPrefix(c.path()))
-          .as(c.name())
-          .isEqualTo(c.expected());
+      assertThat(S3DeltaLogProbe.deltaLogPrefix(c.path())).as(c.name()).isEqualTo(c.expected());
     }
   }
 
@@ -85,7 +86,7 @@ class UnityStorageAccessValidatorTest {
                 "ExpiredToken",
                 400,
                 CatalogAccessException.Code.CREDENTIAL_EXPIRED))) {
-      assertThat(UnityStorageAccessValidator.storageFailureCode(c.errorCode(), c.status()))
+      assertThat(S3DeltaLogProbe.storageFailureCode(c.errorCode(), c.status()))
           .as(c.name())
           .isEqualTo(c.expected());
     }
@@ -109,7 +110,7 @@ class UnityStorageAccessValidatorTest {
             // Neither belongs in an S3 location, so an authority carrying one is not a bucket name.
             new Case("userinfo", "s3://user@my_bucket/x", null),
             new Case("port", "s3://my_bucket:9000/x", null))) {
-      assertThat(UnityStorageAccessValidator.bucketOf(java.net.URI.create(c.location())))
+      assertThat(S3DeltaLogProbe.bucketOf(java.net.URI.create(c.location())))
           .as(c.name())
           .isEqualTo(c.expected());
     }
@@ -136,25 +137,115 @@ class UnityStorageAccessValidatorTest {
             new Case("abfss", "abfss://c@a.dfs.core.windows.net/o", null),
             new Case("no scheme", "/warehouse/orders", null),
             new Case("blank", "  ", null))) {
-      assertThat(UnityStorageAccessValidator.s3Bucket(c.location()))
-          .as(c.name())
-          .isEqualTo(c.expected());
+      assertThat(S3DeltaLogProbe.s3Bucket(c.location())).as(c.name()).isEqualTo(c.expected());
     }
   }
 
   /**
    * A key holding a character URI rejects reads as "not addressable", not as a thrown parse error.
-   * The parse used to run ahead of the guard meant to report it, so an object key with a space --
-   * legal in S3 -- surfaced as "storage access validation configuration is invalid", describing
-   * neither the location nor anything an operator had configured.
+   * The parse runs inside the guard that reports it, so such a key is refused for what it is --
+   * rather than surfacing as "storage access validation configuration is invalid", which describes
+   * neither the location nor anything an operator set.
    */
   @Test
   void anUnparseableKeyIsRefusedRatherThanThrowingPastTheGuard() {
-    for (String location :
-        List.of("s3://warehouse/db/my table", "s3://warehouse/db/a|b", "s3://warehouse/db/x y/z")) {
-      assertThat(UnityStorageAccessValidator.s3Location(location)).as(location).isNull();
-      assertThat(UnityStorageAccessValidator.s3Bucket(location)).as(location).isNull();
+    for (String location : List.of("s3://warehouse/db/a|b", "s3://warehouse/db/a\"b")) {
+      assertThat(S3DeltaLogProbe.s3Location(location)).as(location).isNull();
+      assertThat(S3DeltaLogProbe.s3Bucket(location)).as(location).isNull();
     }
+  }
+
+  /**
+   * An S3 object key may end in a space, and the probe does not trim -- so trimming in the
+   * canonical form published a different prefix from the one validation had just probed. Both
+   * providers use this value for publication, scope comparison and validation, so such a table
+   * either failed to read or was pointed at the trimmed name when something else lived there.
+   */
+  @Test
+  void theCanonicalFormKeepsASignificantTrailingSpace() {
+    assertThat(DeltaLogStorageProbe.canonicalLocation("s3://warehouse/table "))
+        .isEqualTo("s3://warehouse/table%20");
+    // The same key the probe addresses, which is the agreement that matters.
+    assertThat(S3DeltaLogProbe.s3Location("s3://warehouse/table ").getPath()).isEqualTo("/table ");
+  }
+
+  /**
+   * A location carrying a secret is not one this will serve. bucketOf refuses an authority holding
+   * userinfo, but only on its fallback branch -- getHost() answers "bucket" here, so that check
+   * never ran and a provider stored the whole string as the table's storage_location, putting a
+   * password or a signed query into catalog metadata that every reader of the table can see.
+   */
+  @Test
+  void aLocationCarryingUserinfoQueryFragmentOrPortIsRefused() {
+    for (String location :
+        List.of(
+            "s3://user:password@warehouse/table",
+            "s3://warehouse/table?X-Amz-Signature=deadbeef",
+            "s3://warehouse/table#fragment",
+            "s3://warehouse:9000/table")) {
+      assertThat(S3DeltaLogProbe.s3Location(location)).as(location).isNull();
+      assertThat(DeltaLogStorageProbe.s3Serves(location)).as(location).isFalse();
+    }
+  }
+
+  /**
+   * The canonical form is the spelling the reader accepts. s3Serves folds s3, s3a and s3n in any
+   * case, while the reader matches a literal lowercase s3:// or s3a:// and throws on the rest -- so
+   * publishing the server's spelling let s3n:// and S3:// validate, reconcile, and fail every scan.
+   */
+  @Test
+  void theCanonicalFormNormalisesTheSchemeTheReaderAccepts() {
+    // Only the spellings the reader cannot parse are changed. resolvePath matches a literal
+    // lowercase s3:// or s3a://, so s3n and any uppercase form fold and s3a is left alone --
+    // folding it too would put the stored location in a different scheme namespace from the
+    // s3a:// prefix an operator may register, which matchesLocationPrefix compares literally.
+    assertThat(DeltaLogStorageProbe.canonicalLocation("s3n://warehouse/table"))
+        .isEqualTo("s3://warehouse/table");
+    assertThat(DeltaLogStorageProbe.canonicalLocation("S3://warehouse/table"))
+        .isEqualTo("s3://warehouse/table");
+    assertThat(DeltaLogStorageProbe.canonicalLocation("S3A://warehouse/table"))
+        .isEqualTo("s3a://warehouse/table");
+    assertThat(DeltaLogStorageProbe.canonicalLocation("s3a://warehouse/my table"))
+        .isEqualTo("s3a://warehouse/my%20table");
+    // Everything servable is publishable, in a spelling the reader accepts.
+    for (String location :
+        List.of("s3://w/t", "s3a://w/t", "s3n://w/t", "S3://w/t", "s3://w/my table")) {
+      assertThat(DeltaLogStorageProbe.s3Serves(location)).as(location).isTrue();
+      String canonical = DeltaLogStorageProbe.canonicalLocation(location);
+      assertThat(canonical.startsWith("s3://") || canonical.startsWith("s3a://"))
+          .as(location)
+          .isTrue();
+    }
+  }
+
+  /**
+   * A space is legal in an S3 object key and illegal in {@code java.net.URI}, so it is encoded
+   * before parsing rather than read as a location with no addressable bucket. The key has to
+   * survive the round trip: the probe asks S3 for the object it names, so an encoded space reaching
+   * the request would look for a key nothing wrote.
+   */
+  @Test
+  void aSpaceInAnObjectKeyIsAddressableAndKeepsItsKey() {
+    for (String location : List.of("s3://warehouse/db/my table", "s3://warehouse/db/x y/z")) {
+      assertThat(S3DeltaLogProbe.s3Location(location)).as(location).isNotNull();
+      assertThat(S3DeltaLogProbe.s3Bucket(location)).as(location).isEqualTo("warehouse");
+    }
+    assertThat(S3DeltaLogProbe.s3Location("s3://warehouse/db/my table").getPath())
+        .isEqualTo("/db/my table");
+  }
+
+  /**
+   * An S3 object key may begin with a slash, so {@code s3://bucket//table} names the key {@code
+   * /table}. The read path removes one leading slash and addresses that key; removing every one
+   * probed a different prefix, so validation either rejected a readable table or read whatever
+   * Delta log sat at the stripped prefix and reported success for a location no scan would reach.
+   */
+  @Test
+  void aKeyBeginningWithASlashKeepsIt() {
+    // The URI path, which is what the caller passes: getPath() on s3://warehouse//table is
+    // //table, and on s3://warehouse/table is /table.
+    assertThat(S3DeltaLogProbe.deltaLogPrefix("//table")).isEqualTo("/table/_delta_log/");
+    assertThat(S3DeltaLogProbe.deltaLogPrefix("/table")).isEqualTo("table/_delta_log/");
   }
 
   /** Only S3 is validated, and a location that is not one says so rather than failing obscurely. */
@@ -167,7 +258,7 @@ class UnityStorageAccessValidatorTest {
             Optional.empty());
     for (String location : List.of("gs://warehouse/orders", "abfss://c@a.dfs.core.windows.net/o")) {
       assertThatThrownBy(
-              () -> UnityStorageAccessValidator.s3().validate(location, credentials), location)
+              () -> DeltaLogStorageProbe.s3(SUBJECT).validate(location, credentials), location)
           .isInstanceOfSatisfying(
               CatalogAccessException.class,
               failure ->
@@ -192,7 +283,7 @@ class UnityStorageAccessValidatorTest {
       var credentials =
           new VendedStorageCredentials(c.properties(), "s3://warehouse/orders", Optional.empty());
       assertThatThrownBy(
-              () -> UnityStorageAccessValidator.s3().validate("s3://warehouse/orders", credentials),
+              () -> DeltaLogStorageProbe.s3(SUBJECT).validate("s3://warehouse/orders", credentials),
               c.name())
           .isInstanceOfSatisfying(
               CatalogAccessException.class,
@@ -213,11 +304,11 @@ class UnityStorageAccessValidatorTest {
    */
   @Test
   void aListingBodyIsRefusedOnceItPassesTheCap() throws Exception {
-    byte[] oversized = new byte[(int) UnityStorageAccessValidator.MAX_LISTING_RESPONSE_BYTES + 64];
+    byte[] oversized = new byte[(int) S3DeltaLogProbe.MAX_LISTING_RESPONSE_BYTES + 64];
     try (var bounded =
-        UnityStorageAccessValidator.limited(
+        S3DeltaLogProbe.limited(
             new java.io.ByteArrayInputStream(oversized),
-            UnityStorageAccessValidator.MAX_LISTING_RESPONSE_BYTES)) {
+            S3DeltaLogProbe.MAX_LISTING_RESPONSE_BYTES)) {
       assertThatThrownBy(() -> bounded.readAllBytes())
           .isInstanceOf(java.io.IOException.class)
           .hasMessageContaining("ignored max-keys");
@@ -229,13 +320,12 @@ class UnityStorageAccessValidatorTest {
         "<ListBucketResult><Contents><Key>a</Key></Contents></ListBucketResult>"
             .getBytes(java.nio.charset.StandardCharsets.UTF_8);
     try (var bounded =
-        UnityStorageAccessValidator.limited(
+        S3DeltaLogProbe.limited(
             new java.io.ByteArrayInputStream(ordinary),
-            UnityStorageAccessValidator.MAX_LISTING_RESPONSE_BYTES)) {
+            S3DeltaLogProbe.MAX_LISTING_RESPONSE_BYTES)) {
       assertThat(bounded.readAllBytes()).isEqualTo(ordinary);
     }
-    try (var bounded =
-        UnityStorageAccessValidator.limited(new java.io.ByteArrayInputStream(ordinary), 4L)) {
+    try (var bounded = S3DeltaLogProbe.limited(new java.io.ByteArrayInputStream(ordinary), 4L)) {
       assertThat(bounded.read()).isEqualTo(ordinary[0]);
       assertThatThrownBy(
               () -> {

--- a/catalog-access/unity/src/main/java/ai/floedb/floecat/catalog/unity/UnityCatalogAccessClient.java
+++ b/catalog-access/unity/src/main/java/ai/floedb/floecat/catalog/unity/UnityCatalogAccessClient.java
@@ -18,6 +18,7 @@ import ai.floedb.floecat.catalog.access.CatalogViewDefinition;
 import ai.floedb.floecat.catalog.access.ExternalObjectIdentity;
 import ai.floedb.floecat.catalog.access.NamespacePath;
 import ai.floedb.floecat.catalog.access.VendedStorageCredentials;
+import ai.floedb.floecat.catalog.delta.DeltaLogStorageProbe;
 import ai.floedb.floecat.client.unity.TemporaryTableCredentials;
 import ai.floedb.floecat.client.unity.UnityCatalogClient;
 import ai.floedb.floecat.client.unity.UnityCatalogException;
@@ -52,7 +53,7 @@ final class UnityCatalogAccessClient implements CatalogClient {
 
   private final UnityCatalogClient unity;
   private final AutoCloseable authenticationOwner;
-  private final UnityStorageAccessValidator storageValidator;
+  private final DeltaLogStorageProbe storageValidator;
   private final Map<String, String> storageRouting;
   private final AtomicBoolean closed = new AtomicBoolean();
 
@@ -87,7 +88,7 @@ final class UnityCatalogAccessClient implements CatalogClient {
   UnityCatalogAccessClient(
       UnityCatalogClient unity,
       AutoCloseable authenticationOwner,
-      UnityStorageAccessValidator storageValidator,
+      DeltaLogStorageProbe storageValidator,
       Map<String, String> storageRouting) {
     this.unity = Objects.requireNonNull(unity, "unity");
     this.authenticationOwner = authenticationOwner;
@@ -167,7 +168,11 @@ final class UnityCatalogAccessClient implements CatalogClient {
               schemaJson(name, table),
               partitionKeys(table),
               Optional.empty(),
-              optional(table.storageLocation()),
+              // Canonical, not raw. The shared probe percent-encodes a space before parsing,
+              // so it answers for a location this would otherwise publish unchanged -- and the
+              // read path calls URI.create on whatever was published. Publishing the raw form
+              // gives a table that validates clean and fails every scan.
+              optional(table.storageLocation()).map(DeltaLogStorageProbe::canonicalLocation),
               table.properties());
         });
   }
@@ -299,9 +304,12 @@ final class UnityCatalogAccessClient implements CatalogClient {
           // Refused by name rather than returned empty. An empty vend is now a refusal too, but a
           // generic one; naming the reason is the difference between an operator seeing "vended no
           // storage credentials" and seeing that the table has no location to scope against.
-          String scope = nonBlank(response.storageUrl());
+          String scope = DeltaLogStorageProbe.canonicalLocation(nonBlank(response.storageUrl()));
           if (scope == null) {
-            scope = optional(table.storageLocation()).orElse(null);
+            scope =
+                optional(table.storageLocation())
+                    .map(DeltaLogStorageProbe::canonicalLocation)
+                    .orElse(null);
           }
           if (scope == null) {
             throw new CatalogAccessException(
@@ -331,7 +339,8 @@ final class UnityCatalogAccessClient implements CatalogClient {
           }
           VendedStorageCredentials credentials =
               new VendedStorageCredentials(properties, scope, expiresAt);
-          String tableLocation = nonBlank(table.storageLocation());
+          String tableLocation =
+              DeltaLogStorageProbe.canonicalLocation(nonBlank(table.storageLocation()));
           if (tableLocation != null && !credentials.covers(tableLocation)) {
             throw new CatalogAccessException(
                 CatalogAccessException.Code.CREDENTIAL_SCOPE_INVALID,
@@ -353,6 +362,7 @@ final class UnityCatalogAccessClient implements CatalogClient {
           UnityCatalogTable table = vendedTableOrLoad(name);
           String location =
               optional(table.storageLocation())
+                  .map(DeltaLogStorageProbe::canonicalLocation)
                   .orElseThrow(
                       () ->
                           new CatalogAccessException(

--- a/catalog-access/unity/src/main/java/ai/floedb/floecat/catalog/unity/UnityCatalogClientProvider.java
+++ b/catalog-access/unity/src/main/java/ai/floedb/floecat/catalog/unity/UnityCatalogClientProvider.java
@@ -14,6 +14,7 @@ import ai.floedb.floecat.catalog.access.CatalogClientProvider;
 import ai.floedb.floecat.catalog.access.CatalogConnectionConfig;
 import ai.floedb.floecat.catalog.access.CatalogProtocol;
 import ai.floedb.floecat.catalog.access.ResolvedCatalogCredentials;
+import ai.floedb.floecat.catalog.delta.DeltaLogStorageProbe;
 import ai.floedb.floecat.client.unity.HttpUnityCatalogClient;
 import ai.floedb.floecat.client.unity.UnityCatalogAuthentication;
 import ai.floedb.floecat.client.unity.UnityCatalogClient;
@@ -23,6 +24,7 @@ import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 /** Opens Unity Catalog integrations without creating or reading Connector resources. */
 public final class UnityCatalogClientProvider implements CatalogClientProvider {
@@ -118,7 +120,10 @@ public final class UnityCatalogClientProvider implements CatalogClientProvider {
           clientFactory.create(
               config.endpoint(), connectTimeout, readTimeout, authentication, vendPath);
       return new UnityCatalogAccessClient(
-          unity, authenticationOwner, UnityStorageAccessValidator.s3(), routing(properties));
+          unity,
+          authenticationOwner,
+          DeltaLogStorageProbe.s3("Unity Catalog"),
+          routing(properties));
     } catch (RuntimeException | Error failure) {
       closeQuietly(unity);
       closeQuietly(authenticationOwner);
@@ -128,7 +133,19 @@ public final class UnityCatalogClientProvider implements CatalogClientProvider {
 
   private static UnityCatalogAuthentication bearer(
       String token, Map<String, String> resolvedHeaders) {
-    return () -> headers(token, resolvedHeaders);
+    // Not a lambda, so the token can be named for redaction. This is the operator-supplied one,
+    // which is under no obligation to match the token68 alphabet the generic pattern assumes.
+    return new UnityCatalogAuthentication() {
+      @Override
+      public Map<String, String> headers() {
+        return UnityCatalogClientProvider.headers(token, resolvedHeaders);
+      }
+
+      @Override
+      public Optional<String> redactableSecret() {
+        return Optional.of(token);
+      }
+    };
   }
 
   private static UnityCatalogAuthentication bearer(
@@ -174,11 +191,10 @@ public final class UnityCatalogClientProvider implements CatalogClientProvider {
   /**
    * The S3 routing an operator can set on the integration.
    *
-   * <p>No {@code s3.access-point}: nothing addresses one. {@code UnityStorageAccessValidator}
-   * deliberately probes the bucket named in the object URI, and {@code
-   * SourceCatalogCredentialVendor} strips the key before a credential leaves the service, so an
-   * operator who set it saw no effect and no error. Plumbing a key no consumer honours is how one
-   * starts being honoured inconsistently.
+   * <p>No {@code s3.access-point}: nothing addresses one. {@code DeltaLogStorageProbe} deliberately
+   * probes the bucket named in the object URI, and {@code SourceCatalogCredentialVendor} strips the
+   * key before a credential leaves the service, so an operator who set it saw no effect and no
+   * error. Plumbing a key no consumer honours is how one starts being honoured inconsistently.
    *
    * <p>A vended access point is different and still reported: Unity returning one on the
    * credentials response is a diagnostic for a later 403, which {@code noteIgnoredAccessPoint}

--- a/catalog-access/unity/src/test/java/ai/floedb/floecat/catalog/unity/UnityCatalogAccessClientTest.java
+++ b/catalog-access/unity/src/test/java/ai/floedb/floecat/catalog/unity/UnityCatalogAccessClientTest.java
@@ -8,6 +8,7 @@
 package ai.floedb.floecat.catalog.unity;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -19,10 +20,12 @@ import ai.floedb.floecat.catalog.access.CatalogCapability;
 import ai.floedb.floecat.catalog.access.CatalogObjectName;
 import ai.floedb.floecat.catalog.access.NamespacePath;
 import ai.floedb.floecat.catalog.access.VendedStorageCredentials;
+import ai.floedb.floecat.catalog.delta.DeltaLogStorageProbe;
 import ai.floedb.floecat.client.unity.TemporaryTableCredentials;
 import ai.floedb.floecat.client.unity.UnityCatalogClient;
 import ai.floedb.floecat.client.unity.UnityCatalogException;
 import ai.floedb.floecat.client.unity.UnityCatalogTable;
+import java.net.URI;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -34,8 +37,7 @@ class UnityCatalogAccessClientTest {
   private static final CatalogObjectName ORDERS = new CatalogObjectName(SALES, "orders");
 
   private final UnityCatalogClient unity = mock(UnityCatalogClient.class);
-  private final UnityStorageAccessValidator storageValidator =
-      mock(UnityStorageAccessValidator.class);
+  private final DeltaLogStorageProbe storageValidator = mock(DeltaLogStorageProbe.class);
   private final UnityCatalogAccessClient client =
       new UnityCatalogAccessClient(unity, null, storageValidator, Map.of("s3.region", "us-east-1"));
 
@@ -541,6 +543,63 @@ class UnityCatalogAccessClientTest {
       String name, String typeJson, boolean nullable) {
     return new UnityCatalogTable.Column(
         name, null, null, "{\"name\":\"" + name + "\",\"type\":" + typeJson + "}", nullable);
+  }
+
+  /**
+   * An s3a location stays s3a. The authority prefix an operator registers is compared literally by
+   * matchesLocationPrefix, and S3Location.parse accepts an s3a:// prefix, so storing the table
+   * under a folded s3:// would leave the two in different scheme namespaces and never match. Only
+   * the spellings the reader cannot parse are changed.
+   */
+  @Test
+  void loadTableKeepsAnS3aSchemeTheReaderAndTheAuthorityBothAccept() {
+    var table =
+        new UnityCatalogTable(
+            "orders",
+            "table-id",
+            "EXTERNAL",
+            "DELTA",
+            "s3a://warehouse/orders",
+            null,
+            List.of(
+                new UnityCatalogTable.Column(
+                    "order_id", "LONG", "bigint", "{\"type\":\"long\"}", false)),
+            Map.of());
+    when(unity.getTable("main.sales.orders")).thenReturn(Optional.of(table));
+
+    assertThat(client.loadTable(ORDERS).storageLocation()).contains("s3a://warehouse/orders");
+  }
+
+  /**
+   * The shared probe percent-encodes a space before parsing, so it answers for a location this used
+   * to publish unchanged -- and the read path calls {@code URI.create} on what was published.
+   * Before the probe accepted such a location it refused it outright, which was a recorded failure;
+   * accepting it on one side without canonicalising on the other made the table validate clean and
+   * fail every scan.
+   */
+  @Test
+  void loadTablePublishesALocationTheReadPathCanParse() {
+    var table =
+        new UnityCatalogTable(
+            "orders",
+            "table-id",
+            "EXTERNAL",
+            "DELTA",
+            "s3://warehouse/my orders",
+            null,
+            List.of(
+                new UnityCatalogTable.Column(
+                    "order_id", "LONG", "bigint", "{\"type\":\"long\"}", false)),
+            Map.of());
+    when(unity.getTable("main.sales.orders")).thenReturn(Optional.of(table));
+
+    var mapped = client.loadTable(ORDERS);
+
+    assertThat(mapped.storageLocation()).contains("s3://warehouse/my%20orders");
+    assertThatCode(() -> URI.create(mapped.storageLocation().orElseThrow()))
+        .doesNotThrowAnyException();
+    assertThat(URI.create(mapped.storageLocation().orElseThrow()).getPath())
+        .isEqualTo("/my orders");
   }
 
   /**

--- a/connectors/catalogs/delta/src/main/java/ai/floedb/floecat/connector/delta/uc/impl/S3V2FileSystemClient.java
+++ b/connectors/catalogs/delta/src/main/java/ai/floedb/floecat/connector/delta/uc/impl/S3V2FileSystemClient.java
@@ -26,6 +26,7 @@ import io.delta.kernel.utils.FileStatus;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.Iterator;
@@ -85,6 +86,65 @@ final class S3V2FileSystemClient implements FileIO {
         "Copying files not implemented for read-only S3V2FileIO");
   }
 
+  /**
+   * An {@code s3://} path for a listed object, in a form the rest of this client can parse.
+   *
+   * <p>Every path here comes back through {@code resolvePath}, which calls {@code URI.create} --
+   * and an S3 object key may hold characters that rejects, a space being the one that occurs. This
+   * was built by concatenating the raw key, so a table under {@code db/my table} listed its Delta
+   * log fine and then threw when the next entry was opened: the caller's own location could be
+   * encoded, but a listing rebuilt every later path from the raw key and lost that.
+   *
+   * <p>Round-trips: {@code getPath} decodes, so the key asked of S3 is the key that was written.
+   * For a key holding nothing {@code URI} objects to, the result is byte-identical to plain
+   * concatenation, so only a path that would otherwise fail to parse is affected at all.
+   */
+  static String s3Uri(String bucket, String key) {
+    // Segment by segment, so no leading slash is ever handed to URI as part of a "//" it would read
+    // as an authority. An S3 key may begin with a slash, and for such a key the path is "//table",
+    // whose first segment URI takes as a host and drops from getRawPath -- silently, so a fallback
+    // never runs and S3 is asked for a key missing its first segment. Splitting keeps the empty
+    // leading segment that slash represents, and no segment can hold a slash to re-parse.
+    StringBuilder path = new StringBuilder();
+    for (String segment : key.split("/", -1)) {
+      try {
+        String encoded = new URI(null, null, "/" + segment, null).getRawPath();
+        path.append('/').append(encoded, 1, encoded.length());
+      } catch (URISyntaxException notAUri) {
+        path.append('/').append(segment);
+      }
+    }
+    return "s3://" + bucket + path;
+  }
+
+  /**
+   * The bucket a location addresses, falling back to the authority when it is not a hostname.
+   *
+   * <p>S3 permitted bucket names {@code java.net.URI} will not parse as a host -- an underscore is
+   * the one that survives in older regions -- and for those {@code getHost} answers null while the
+   * authority carries the name. {@code S3DeltaLogProbe.bucketOf} accepts such a name, so this has
+   * to as well: a table the probe validates and the reader cannot address is one that reconciles
+   * and then fails every scan. The fallback's shape matches that method -- an authority holding
+   * userinfo or a port is not a bucket name.
+   *
+   * <p>Not shared with it because this module does not depend on catalog-access, and a connector
+   * depending on it to parse a URI would be the wrong direction.
+   */
+  static String bucketOf(URI location) {
+    String host = location.getHost();
+    if (host != null && !host.isEmpty()) {
+      return host;
+    }
+    String authority = location.getAuthority();
+    if (authority == null
+        || authority.isEmpty()
+        || authority.indexOf('@') >= 0
+        || authority.indexOf(':') >= 0) {
+      return null;
+    }
+    return authority;
+  }
+
   @Override
   public String resolvePath(String path) {
     if (path.startsWith("s3a://")) {
@@ -99,7 +159,7 @@ final class S3V2FileSystemClient implements FileIO {
   @Override
   public FileStatus getFileStatus(String path) throws IOException {
     var u = URI.create(resolvePath(path));
-    var bucket = u.getHost();
+    var bucket = bucketOf(u);
     var key = u.getPath().startsWith("/") ? u.getPath().substring(1) : u.getPath();
     try {
       var head = s3.call(client -> client.headObject(b -> b.bucket(bucket).key(key)));
@@ -115,7 +175,7 @@ final class S3V2FileSystemClient implements FileIO {
       return false;
     }
     URI u = URI.create(resolvedPath);
-    String bucket = u.getHost();
+    String bucket = bucketOf(u);
     String key = u.getPath().startsWith("/") ? u.getPath().substring(1) : u.getPath();
     try {
       s3.callUnchecked(client -> client.headObject(b -> b.bucket(bucket).key(key)));
@@ -132,7 +192,7 @@ final class S3V2FileSystemClient implements FileIO {
   public CloseableIterator<FileStatus> listFrom(String filePath) throws IOException {
     final String resolved = resolvePath(filePath);
     final URI u = URI.create(resolved);
-    final String bucket = u.getHost();
+    final String bucket = bucketOf(u);
     if (bucket == null || bucket.isEmpty()) {
       throw new IOException("Invalid S3 path for listFrom: " + filePath);
     }
@@ -244,7 +304,7 @@ final class S3V2FileSystemClient implements FileIO {
               continue;
             }
 
-            String fullPath = "s3://" + bucket + "/" + key;
+            String fullPath = s3Uri(bucket, key);
             long size = (o.size() != null) ? o.size() : 0L;
             long mod =
                 (o.lastModified() != null)
@@ -267,7 +327,7 @@ final class S3V2FileSystemClient implements FileIO {
   @Override
   public boolean mkdirs(String path) throws IOException {
     var u = URI.create(resolvePath(path));
-    if (u.getHost() == null) {
+    if (bucketOf(u) == null) {
       throw new IOException("Invalid S3 path for mkdirs: " + path);
     }
     return true;
@@ -291,7 +351,7 @@ final class S3V2FileSystemClient implements FileIO {
       this.resolvedPath = resolvedPath;
 
       var u = URI.create(resolvedPath);
-      this.bucket = u.getHost();
+      this.bucket = bucketOf(u);
       this.key = u.getPath().startsWith("/") ? u.getPath().substring(1) : u.getPath();
 
       try {

--- a/connectors/catalogs/delta/src/test/java/ai/floedb/floecat/connector/delta/uc/impl/S3V2FileSystemClientTest.java
+++ b/connectors/catalogs/delta/src/test/java/ai/floedb/floecat/connector/delta/uc/impl/S3V2FileSystemClientTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.connector.delta.uc.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.net.URI;
+import org.junit.jupiter.api.Test;
+
+/** Paths handed back from a listing have to be paths this client can parse again. */
+class S3V2FileSystemClientTest {
+
+  /**
+   * A listed key holding a space becomes a path {@code URI.create} accepts, and decodes back to the
+   * key that was written.
+   *
+   * <p>These paths come back through {@code resolvePath}, which parses them. Built by concatenating
+   * the raw key, a table under {@code db/my table} listed its Delta log and then threw when the
+   * next entry was opened -- so the location could be encoded by the caller and a listing would
+   * lose it again on every entry after the first.
+   */
+  @Test
+  void aListedKeyWithASpaceRoundTrips() {
+    String path = S3V2FileSystemClient.s3Uri("warehouse", "db/my table/_delta_log/000.json");
+
+    assertThat(path).isEqualTo("s3://warehouse/db/my%20table/_delta_log/000.json");
+    assertThatCode(() -> URI.create(path)).doesNotThrowAnyException();
+    assertThat(URI.create(path).getPath()).isEqualTo("/db/my table/_delta_log/000.json");
+  }
+
+  /**
+   * A bucket name {@code java.net.URI} will not parse as a host. S3 permitted an underscore in
+   * older regions, and for such a name {@code getHost} answers null while the authority carries it.
+   * The shared probe accepts such a name, so this client has to address it: a table the probe
+   * validates and the reader cannot open is one that reconciles and then fails every scan.
+   */
+  @Test
+  void aBucketNameThatIsNotAHostnameIsStillAddressed() {
+    assertThat(S3V2FileSystemClient.bucketOf(URI.create("s3://legacy_bucket/db/table")))
+        .isEqualTo("legacy_bucket");
+    assertThat(S3V2FileSystemClient.bucketOf(URI.create("s3://warehouse/db/table")))
+        .isEqualTo("warehouse");
+  }
+
+  /**
+   * And the call sites use it. {@code mkdirs} is the one path that needs no S3 call to reach the
+   * bucket derivation, so it is where the wiring can be asserted rather than only the helper:
+   * deriving from {@code getHost} alone rejects a legacy bucket name outright.
+   */
+  @Test
+  void aLegacyBucketNameIsAddressableThroughTheClient() throws Exception {
+    var client = new S3V2FileSystemClient(null);
+
+    assertThat(client.mkdirs("s3://legacy_bucket/db/table")).isTrue();
+    assertThat(client.mkdirs("s3://warehouse/db/table")).isTrue();
+  }
+
+  /**
+   * The fallback accepts a plain authority and nothing else, which is the probe's rule too.
+   *
+   * <p>Only the fallback is guarded, because {@code getHost} answers the host for a location
+   * carrying userinfo or a port -- it is not part of the host -- so those never reach it. Refusing
+   * them is the location gate's job, and it does refuse them before anything is published.
+   */
+  @Test
+  void theFallbackRefusesAnAuthorityCarryingMoreThanAName() {
+    assertThat(S3V2FileSystemClient.bucketOf(URI.create("s3://user:pw@legacy_bucket/db/t")))
+        .isNull();
+    assertThat(S3V2FileSystemClient.bucketOf(URI.create("s3://legacy_bucket/db/t")))
+        .isEqualTo("legacy_bucket");
+  }
+
+  /**
+   * A bucket name {@code URI} will not parse as a host still gets an encoded path. Passing the
+   * bucket as a host makes {@code URI} reject such a name, and the fallback then emits the raw key
+   * -- leaving the space this method exists to encode, for exactly the bucket shape {@code
+   * bucketOf} was added to support.
+   */
+  @Test
+  void aLegacyBucketNameStillGetsAnEncodedPath() {
+    String path = S3V2FileSystemClient.s3Uri("legacy_bucket", "db/my table/_delta_log/000.json");
+
+    assertThat(path).isEqualTo("s3://legacy_bucket/db/my%20table/_delta_log/000.json");
+    assertThat(URI.create(path).getPath()).isEqualTo("/db/my table/_delta_log/000.json");
+    assertThat(S3V2FileSystemClient.bucketOf(URI.create(path))).isEqualTo("legacy_bucket");
+  }
+
+  /**
+   * A key beginning with a slash keeps it. S3 permits such a key, and the location gate publishes
+   * the {@code s3://bucket//table} shape that produces one, so a listing under it reaches here.
+   *
+   * <p>Encoding the key as one path handed {@code URI} a string opening "//", which it parsed as an
+   * authority: {@code getRawPath} answered without the first segment and threw nothing, so the
+   * fallback never ran and every listed entry addressed a key missing its leading name.
+   */
+  @Test
+  void aKeyBeginningWithASlashKeepsIt() {
+    assertThat(S3V2FileSystemClient.s3Uri("warehouse", "/table/_delta_log/000.json"))
+        .isEqualTo("s3://warehouse//table/_delta_log/000.json");
+    assertThat(S3V2FileSystemClient.s3Uri("warehouse", "/my table/000.json"))
+        .isEqualTo("s3://warehouse//my%20table/000.json");
+    assertThat(URI.create(S3V2FileSystemClient.s3Uri("warehouse", "/my table/000.json")).getPath())
+        .isEqualTo("//my table/000.json");
+  }
+
+  /**
+   * And a key holding nothing {@code URI} objects to is byte-identical to plain concatenation, so
+   * only a path that would otherwise fail to parse is affected at all.
+   */
+  @Test
+  void anOrdinaryKeyIsUnchanged() {
+    for (String key : new String[] {"db/orders/_delta_log/000.json", "a/b/c.parquet", "x"}) {
+      assertThat(S3V2FileSystemClient.s3Uri("warehouse", key))
+          .as(key)
+          .isEqualTo("s3://warehouse/" + key);
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,7 @@
 
       <!-- Catalog access -->
       <module>catalog-access/iceberg-rest</module>
+      <module>catalog-access/delta-common</module>
       <module>catalog-access/unity</module>
       
       <!-- Connectors -->


### PR DESCRIPTION
# refactor(catalog-access): add delta-common and move the Delta log probe into it

Stack 2 of 6. Base branch: `kw-delta-sharing-integration-01`.

## What

- `catalog-access/delta-common` holds what a Delta-backed catalog provider needs regardless of which
  protocol reached the table, starting with the Delta log storage probe.
- The probe lists one object under a table's `_delta_log` with the vended credentials and reads a
  byte of it, naming the caller in every refusal. Listing alone would pass on a grant that cannot
  read, which is the failure an operator otherwise finds at query time.
- `DeltaLogStorageProbe` publishes `validate`, its s3 factory, whether a location is one the S3 probe
  can address at all, and `canonicalLocation`. The S3 client, the listing bound and the location
  helpers stay package-private, since interface members are implicitly public and none of those are
  the contract.
- Moved out of the Unity provider, which had the only copy.

## Review focus

The subject does not name it, but this also carries a change to the Delta reader in
`connectors/catalogs/delta`. It belongs here: a location the probe canonicalises has to be one
`S3V2FileSystemClient` can parse and list again, and canonicalising without it turns a table Unity
used to refuse outright into one that validates clean and fails at scan.

## Scope

13 files changed, 1167 insertions(+), 620 deletions(-)

- `catalog-access/delta-common`
- `catalog-access/unity`
- `connectors/catalogs`
- `pom.xml`

Full rationale and the review history behind these changes are in #519, which this
stack replaces.
