### PR TITLE
fix(validation): report an upstream refusal by capability as unsupported

### DIFF
--- a/service/src/main/java/ai/floedb/floecat/service/integration/CatalogIntegrationDiscovery.java
+++ b/service/src/main/java/ai/floedb/floecat/service/integration/CatalogIntegrationDiscovery.java
@@ -248,7 +248,9 @@ public class CatalogIntegrationDiscovery {
           failed(
               CatalogIntegrationValidationCheckType.CIVCT_STORAGE_ACCESS,
               credentialIssue(
-                  failure.failure(), CatalogIntegrationValidationIssue.CIVI_STORAGE_ACCESS_FAILED),
+                  failure.failure(),
+                  CatalogIntegrationValidationIssue.CIVI_STORAGE_ACCESS_FAILED,
+                  CatalogIntegrationValidationIssue.CIVI_STORAGE_ACCESS_UNSUPPORTED),
               safeSummary("Storage access validation failed.", failure.failure())));
       return new ValidationResult(false, checks, capabilities);
     } catch (CredentialVendingFailure failure) {
@@ -261,7 +263,8 @@ public class CatalogIntegrationDiscovery {
               CatalogIntegrationValidationCheckType.CIVCT_CREDENTIAL_VENDING,
               credentialIssue(
                   failure.failure(),
-                  CatalogIntegrationValidationIssue.CIVI_CREDENTIAL_VENDING_FAILED),
+                  CatalogIntegrationValidationIssue.CIVI_CREDENTIAL_VENDING_FAILED,
+                  CatalogIntegrationValidationIssue.CIVI_CREDENTIAL_VENDING_UNSUPPORTED),
               safeSummary("Storage credential vending failed.", failure.failure())));
       addStorageNotRun(checks);
       return new ValidationResult(false, checks, capabilities);
@@ -310,7 +313,9 @@ public class CatalogIntegrationDiscovery {
           failed(
               CatalogIntegrationValidationCheckType.CIVCT_STORAGE_ACCESS,
               credentialIssue(
-                  failure, CatalogIntegrationValidationIssue.CIVI_STORAGE_ACCESS_FAILED),
+                  failure,
+                  CatalogIntegrationValidationIssue.CIVI_STORAGE_ACCESS_FAILED,
+                  CatalogIntegrationValidationIssue.CIVI_STORAGE_ACCESS_UNSUPPORTED),
               safeSummary("Storage access validation failed.", failure)));
       return new ValidationResult(false, checks, capabilities);
     }
@@ -932,12 +937,24 @@ public class CatalogIntegrationDiscovery {
         || failure.code() == CatalogAccessException.Code.PERMISSION_DENIED;
   }
 
+  /**
+   * The issue an upstream refusal is reported as.
+   *
+   * <p>{@code unsupported} is separate from {@code fallback} because a capability can be per table
+   * rather than per integration: a Delta Sharing recipient vends credentials for a share offering
+   * directory access and cannot for one offering url access alone, and answers UNSUPPORTED for the
+   * second. Reporting that as a failure tells an operator to fix something, when what the provider
+   * said is that it will never do this.
+   */
   private static CatalogIntegrationValidationIssue credentialIssue(
-      CatalogAccessException failure, CatalogIntegrationValidationIssue fallback) {
+      CatalogAccessException failure,
+      CatalogIntegrationValidationIssue fallback,
+      CatalogIntegrationValidationIssue unsupported) {
     return switch (failure.code()) {
       case CREDENTIAL_EXPIRED -> CatalogIntegrationValidationIssue.CIVI_CREDENTIAL_EXPIRED;
       case CREDENTIAL_SCOPE_INVALID ->
           CatalogIntegrationValidationIssue.CIVI_CREDENTIAL_SCOPE_INVALID;
+      case UNSUPPORTED -> unsupported;
       default -> fallback;
     };
   }

--- a/service/src/test/java/ai/floedb/floecat/service/integration/CatalogIntegrationDiscoveryTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/integration/CatalogIntegrationDiscoveryTest.java
@@ -699,6 +699,71 @@ class CatalogIntegrationDiscoveryTest {
   }
 
   /**
+   * A provider that vends for some tables and refuses others by capability.
+   *
+   * <p>A Delta Sharing recipient does exactly this: it vends for a share offering directory access
+   * and answers UNSUPPORTED for one offering url access alone, where the server returns presigned
+   * per-file URLs rather than credentials. Reporting that as a vending failure tells an operator to
+   * fix something, when what the provider said is that it will never do this.
+   */
+  @Test
+  void aVendTheProviderCallsUnsupportedIsReportedAsUnsupportedNotFailed() {
+    NamespacePath sales = NamespacePath.of("main", "sales");
+    when(client.capabilities()).thenReturn(validationCapabilities());
+    when(client.listTables(NamespacePath.root())).thenReturn(List.of());
+    when(client.listNamespaces(NamespacePath.root())).thenReturn(List.of(NamespacePath.of("main")));
+    when(client.listNamespaces(NamespacePath.of("main"))).thenReturn(List.of(sales));
+    when(client.listTables(sales)).thenReturn(List.of(new CatalogObjectName(sales, "a")));
+    when(client.vendStorageCredentials(any()))
+        .thenThrow(
+            new CatalogAccessException(
+                CatalogAccessException.Code.UNSUPPORTED,
+                "share.schema.a offers url access only, which cannot be vended"));
+
+    var result = discovery.validate(integration);
+
+    assertFalse(result.valid());
+    assertEquals(
+        CatalogIntegrationValidationStatus.CIVS_PASSED,
+        result.checks().get(2).getStatus(),
+        "the share enumerated, so discovery must not be reported as the failure");
+    assertEquals(
+        CatalogIntegrationValidationIssue.CIVI_CREDENTIAL_VENDING_UNSUPPORTED,
+        result.checks().get(3).getIssue());
+    assertEquals(
+        "share.schema.a offers url access only, which cannot be vended",
+        result.checks().get(3).getSummary(),
+        "the provider named the table and the reason, and that is what an operator needs");
+  }
+
+  @Test
+  void aStorageProbeTheProviderCallsUnsupportedIsReportedAsUnsupportedNotFailed() {
+    NamespacePath sales = NamespacePath.of("main", "sales");
+    var vended = new VendedStorageCredentials(Map.of("key", "value"), "", Optional.empty());
+    when(client.capabilities()).thenReturn(validationCapabilities());
+    when(client.listTables(NamespacePath.root())).thenReturn(List.of());
+    when(client.listNamespaces(NamespacePath.root())).thenReturn(List.of(NamespacePath.of("main")));
+    when(client.listNamespaces(NamespacePath.of("main"))).thenReturn(List.of(sales));
+    when(client.listTables(sales)).thenReturn(List.of(new CatalogObjectName(sales, "a")));
+    when(client.vendStorageCredentials(any())).thenReturn(Optional.of(vended));
+    doThrow(
+            new CatalogAccessException(
+                CatalogAccessException.Code.UNSUPPORTED,
+                "share.schema.a reports no location to validate access against"))
+        .when(client)
+        .validateStorageAccess(any(), any());
+
+    var result = discovery.validate(integration);
+
+    assertFalse(result.valid());
+    assertEquals(
+        CatalogIntegrationValidationStatus.CIVS_PASSED, result.checks().get(3).getStatus());
+    assertEquals(
+        CatalogIntegrationValidationIssue.CIVI_STORAGE_ACCESS_UNSUPPORTED,
+        result.checks().get(4).getIssue());
+  }
+
+  /**
    * A storage failure that will answer the same for every table stops the search where it stands,
    * rather than paying for a probe per sampled table to collect it again.
    */


### PR DESCRIPTION
# fix(validation): report an upstream refusal by capability as unsupported

Stack 3 of 6. Base branch: `kw-delta-sharing-integration-02`.

## What

- A provider that answers `UNSUPPORTED` for a vend or a storage probe now reports
  `CIVI_CREDENTIAL_VENDING_UNSUPPORTED` or `CIVI_STORAGE_ACCESS_UNSUPPORTED` rather than the
  matching `_FAILED` issue.
- A capability can be per table rather than per integration, so a provider may vend for one table
  and refuse another by name.
- `FAILED` tells an operator to fix something; what the provider said is that it will never do this.
  The summary already carries the provider's own sentence.

## Review focus

The smallest change in the stack, and the only one that is not about Delta Sharing -- it changes
validation reporting for any provider that answers `UNSUPPORTED`.

## Scope

2 files changed, 86 insertions(+), 4 deletions(-)

- `service/src`

Full rationale and the review history behind these changes are in #519, which this
stack replaces.
