### PR TITLE
feat(delta-sharing): add the catalog-access provider

### DIFF
--- a/catalog-access/delta-sharing/pom.xml
+++ b/catalog-access/delta-sharing/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright 2026 Yellowbrick Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>ai.floedb.floecat</groupId>
+    <artifactId>floecat</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <relativePath>../..</relativePath>
+  </parent>
+
+  <artifactId>floecat-catalog-access-delta-sharing</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>ai.floedb.floecat</groupId>
+      <artifactId>floecat-catalog-access-spi</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>ai.floedb.floecat</groupId>
+      <artifactId>floecat-catalog-access-delta-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>ai.floedb.floecat</groupId>
+      <artifactId>floecat-http-endpoint-guards</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>ai.floedb.floecat</groupId>
+      <artifactId>floecat-delta-sharing-client</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/catalog-access/delta-sharing/src/main/java/ai/floedb/floecat/catalog/sharing/DeltaSharingCatalogClient.java
+++ b/catalog-access/delta-sharing/src/main/java/ai/floedb/floecat/catalog/sharing/DeltaSharingCatalogClient.java
@@ -1,0 +1,856 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.catalog.sharing;
+
+import ai.floedb.floecat.catalog.access.CatalogAccessException;
+import ai.floedb.floecat.catalog.access.CatalogCapabilities;
+import ai.floedb.floecat.catalog.access.CatalogCapability;
+import ai.floedb.floecat.catalog.access.CatalogClient;
+import ai.floedb.floecat.catalog.access.CatalogObjectName;
+import ai.floedb.floecat.catalog.access.CatalogTable;
+import ai.floedb.floecat.catalog.access.CatalogView;
+import ai.floedb.floecat.catalog.access.ExternalObjectIdentity;
+import ai.floedb.floecat.catalog.access.NamespacePath;
+import ai.floedb.floecat.catalog.access.StorageLocations;
+import ai.floedb.floecat.catalog.access.VendedStorageCredentials;
+import ai.floedb.floecat.catalog.delta.DeltaLogStorageProbe;
+import ai.floedb.floecat.client.sharing.DeltaSharingClient;
+import ai.floedb.floecat.client.sharing.DeltaSharingException;
+import ai.floedb.floecat.client.sharing.DeltaSharingModel.AccessMode;
+import ai.floedb.floecat.client.sharing.DeltaSharingModel.Schema;
+import ai.floedb.floecat.client.sharing.DeltaSharingModel.Share;
+import ai.floedb.floecat.client.sharing.DeltaSharingModel.Table;
+import ai.floedb.floecat.client.sharing.DeltaSharingModel.TableDescription;
+import ai.floedb.floecat.client.sharing.DeltaSharingModel.TemporaryCredentials;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * A Delta Sharing recipient behind the catalog-access SPI.
+ *
+ * <p>The sharing hierarchy is share, then schema, then table, which maps onto {@link NamespacePath}
+ * without translation: an empty parent lists shares as one-segment paths and a one-segment parent
+ * lists schemas as two.
+ *
+ * <p>Directory access only. A table advertising url alone is discoverable and describable, and
+ * refused at the vend by name rather than returning nothing, because a caller that got an empty
+ * answer would report a missing storage authority for a table whose provider simply does not
+ * delegate storage.
+ */
+public final class DeltaSharingCatalogClient implements CatalogClient {
+
+  private static final CatalogCapabilities CAPABILITIES =
+      CatalogCapabilities.of(
+          CatalogCapability.VALIDATE,
+          CatalogCapability.LIST_NAMESPACES,
+          CatalogCapability.LIST_TABLES,
+          CatalogCapability.LOAD_TABLE,
+          CatalogCapability.VEND_STORAGE_CREDENTIALS,
+          CatalogCapability.VALIDATE_STORAGE_ACCESS,
+          CatalogCapability.STABLE_OBJECT_IDS);
+
+  /** Names the property in the refusal it produces, so an operator can find what caused it. */
+  static final String STRICT_ACCESS_MODES = "delta.sharing.strict-access-modes";
+
+  /**
+   * What {@code delta.sharing.access-modes} reads when the server stated nothing.
+   *
+   * <p>Not {@code url}. That is the protocol's reading of an absent field, and it is the reading
+   * this client deliberately does not apply before vending, so writing it onto the reconciled table
+   * would report a fact the share never communicated.
+   */
+  static final String UNSTATED_ACCESS_MODES = "unstated";
+
+  private final DeltaSharingClient client;
+  private final Map<String, String> storageProperties;
+  private final boolean strictAccessModes;
+  private final DeltaLogStorageProbe storageProbe;
+  private final Map<Schema, List<Table>> listedTables =
+      new java.util.concurrent.ConcurrentHashMap<>();
+
+  public DeltaSharingCatalogClient(
+      DeltaSharingClient client, Map<String, String> storageProperties) {
+    this(client, storageProperties, false);
+  }
+
+  /**
+   * @param strictAccessModes whether a table that states no access modes is read as url only. The
+   *     protocol says it is, and the reference server implements the credential endpoint while
+   *     stating nothing, so the default asks and lets the server answer.
+   */
+  public DeltaSharingCatalogClient(
+      DeltaSharingClient client, Map<String, String> storageProperties, boolean strictAccessModes) {
+    this(client, storageProperties, strictAccessModes, DeltaLogStorageProbe.s3("Delta Sharing"));
+  }
+
+  DeltaSharingCatalogClient(
+      DeltaSharingClient client,
+      Map<String, String> storageProperties,
+      boolean strictAccessModes,
+      DeltaLogStorageProbe storageProbe) {
+    this.client = Objects.requireNonNull(client, "client");
+    this.storageProperties = storageProperties == null ? Map.of() : Map.copyOf(storageProperties);
+    this.strictAccessModes = strictAccessModes;
+    this.storageProbe = Objects.requireNonNull(storageProbe, "storageProbe");
+  }
+
+  /** Whether a table stating no access modes is read as url only rather than asked about. */
+  boolean strictAccessModes() {
+    return strictAccessModes;
+  }
+
+  /** The storage properties published alongside every vended credential. */
+  Map<String, String> storageProperties() {
+    return storageProperties;
+  }
+
+  @Override
+  public CatalogCapabilities capabilities() {
+    return CAPABILITIES;
+  }
+
+  @Override
+  public void validate() {
+    // Listing shares is the smallest call that proves the endpoint is a sharing server and that the
+    // recipient token is accepted. It answers with an empty list for a recipient granted nothing,
+    // which is a valid configuration rather than a failure.
+    translate("validation", client::listShares);
+  }
+
+  @Override
+  public List<NamespacePath> listNamespaces(NamespacePath parent) {
+    List<String> segments = parent == null ? List.of() : parent.segments();
+    if (segments.isEmpty()) {
+      List<NamespacePath> shares = new ArrayList<>();
+      for (Share share : translate("listing shares", client::listShares)) {
+        shares.add(new NamespacePath(List.of(share.name())));
+      }
+      return List.copyOf(shares);
+    }
+    if (segments.size() == 1) {
+      String share = segments.get(0);
+      List<NamespacePath> schemas = new ArrayList<>();
+      for (Schema schema :
+          translate("listing schemas of " + share, () -> client.listSchemas(share))) {
+        schemas.add(new NamespacePath(List.of(share, schema.name())));
+      }
+      return List.copyOf(schemas);
+    }
+    // Share and schema are the only levels the protocol defines. Deeper is not an error, it is
+    // simply empty, which is what a caller walking a tree expects at a leaf.
+    return List.of();
+  }
+
+  @Override
+  public List<CatalogObjectName> listTables(NamespacePath namespace) {
+    // Tables live at share.schema and nowhere else. The root and a share are real levels of the
+    // hierarchy that simply hold none, and the reconciler lists tables at every selected namespace
+    // before descending, so raising here abandoned any overlay whose include named a whole share.
+    List<String> segments = namespace == null ? List.of() : namespace.segments();
+    if (segments.size() != 2) {
+      return List.of();
+    }
+    Schema addressed = requireSchema(namespace);
+    List<CatalogObjectName> tables = new ArrayList<>();
+    // Through the memo the load path reads. The reconciler lists a schema and then loads every
+    // table in it, so without this the schema is paged twice per pass: once here and once by the
+    // first findTable.
+    for (Table table : listing(addressed)) {
+      tables.add(new CatalogObjectName(namespace, table.name()));
+    }
+    return List.copyOf(tables);
+  }
+
+  @Override
+  public CatalogTable loadTable(CatalogObjectName name) {
+    Schema addressed = requireSchema(name.namespace());
+    Table listed = findTable(addressed, name.name());
+    TableDescription described =
+        translate(
+            "describing " + listed.fullName(),
+            () -> client.describeTable(addressed.share(), addressed.name(), name.name()));
+
+    ExternalObjectIdentity identity = identityOf(listed);
+
+    Map<String, String> properties = new HashMap<>(described.metadata().configuration());
+    described.version().ifPresent(v -> properties.put("delta.sharing.version", Long.toString(v)));
+    properties.put("delta.sharing.file-format", described.metadata().format());
+    List<AccessMode> modes = statedModes(listed, described);
+    properties.put(
+        "delta.sharing.access-modes",
+        modes.isEmpty()
+            ? UNSTATED_ACCESS_MODES
+            : modes.stream()
+                .map(mode -> mode.name().toLowerCase(java.util.Locale.ROOT))
+                .reduce((a, b) -> a + "," + b)
+                .orElse(UNSTATED_ACCESS_MODES));
+
+    // Either surface, because the protocol states auxiliary locations on the listing and on the
+    // metadata action and a server may use either. Refused here rather than at the vend, because
+    // this is where both are known and because a table refused here never reconciles. The protocol
+    // requires a client to
+    // ask for credentials once per location, root and auxiliary alike, and tells a client that
+    // cannot read from several to fall back to url access or raise. The storage contract carries
+    // one credential over one scope prefix, so there is nothing here to carry the rest.
+    if (listed.hasAuxiliaryLocations() || described.metadata().hasAuxiliaryLocations()) {
+      throw new CatalogAccessException(
+          CatalogAccessException.Code.UNSUPPORTED,
+          "Delta Sharing table "
+              + listed.fullName()
+              + " reports auxiliary storage locations, which need a credential each and cannot be"
+              + " published as one scoped credential");
+    }
+
+    return new CatalogTable(
+        name,
+        identity,
+        // Always DELTA. A shared table is a Delta table; the metaData action's format.provider
+        // names
+        // the data file format underneath it -- parquet -- which is a different question, and
+        // reporting it here is a table format the reconciler does not recognise.
+        "DELTA",
+        described.metadata().schemaJson(),
+        described.metadata().partitionColumns(),
+        Optional.empty(),
+        // Present for directory access and absent otherwise, which is the protocol being explicit
+        // that a url-only recipient is never told where the table lives.
+        Optional.of(requireStorageLocation(addressed, name, listed, described, modes)),
+        Map.copyOf(properties));
+  }
+
+  @Override
+  public List<CatalogObjectName> listViews(NamespacePath namespace) {
+    // Delta Sharing shares tables. There is no view concept to enumerate.
+    return List.of();
+  }
+
+  @Override
+  public CatalogView loadView(CatalogObjectName view) {
+    throw new CatalogAccessException(
+        CatalogAccessException.Code.UNSUPPORTED, "Delta Sharing does not share views");
+  }
+
+  @Override
+  public Optional<VendedStorageCredentials> vendStorageCredentials(CatalogObjectName name) {
+    Schema addressed = requireSchema(name.namespace());
+    // The metadata endpoint, not the table listing. This is the per-read path -- a credential is
+    // vended on every storage-authority resolve -- and listing the schema to find one table paged
+    // the whole schema before every credential POST, which is unbounded in the schema's table
+    // count and made a reconcile quadratic. The delta response format this client asks for carries
+    // the access modes and auxiliary locations here, which is all the listing was consulted for.
+    String qualified = addressed.share() + "." + addressed.name() + "." + name.name();
+    TableDescription described =
+        translate(
+            "describing " + qualified,
+            () -> client.describeTable(addressed.share(), addressed.name(), name.name()));
+    List<AccessMode> modes = described.metadata().accessModes();
+    if (modes.isEmpty() && strictAccessModes) {
+      // The listing is the other place the protocol lets a server state modes, and a server may
+      // use either. Strict mode refuses without asking the server, so it must not refuse a table
+      // the share marked directory-accessible somewhere this path had not looked. The extra
+      // listing is confined to the path an operator opted into.
+      modes = findTable(addressed, name.name()).accessModes();
+    }
+
+    if (described.metadata().hasAuxiliaryLocations()) {
+      throw new CatalogAccessException(
+          CatalogAccessException.Code.UNSUPPORTED,
+          "Delta Sharing table "
+              + qualified
+              + " reports auxiliary storage locations, which need a credential each and cannot be"
+              + " published as one scoped credential");
+    }
+
+    // A table that states its modes is believed. One that states none is ambiguous: the protocol
+    // reads that as url only, and the reference server implements the credential endpoint while
+    // stating nothing at all, so the default is to ask and let the server answer.
+    boolean unstated = modes.isEmpty();
+    if (!modes.contains(AccessMode.DIR) && (strictAccessModes || !unstated)) {
+      throw new CatalogAccessException(
+          CatalogAccessException.Code.UNSUPPORTED,
+          unstated
+              ? "Delta Sharing table "
+                  + qualified
+                  + " states no access modes, which "
+                  + STRICT_ACCESS_MODES
+                  + " reads as url only"
+              // The same distinction the load draws. Validation's sampler sends names straight from
+              // listTables to this method without loading them, so for a table stating only modes
+              // this client does not know, "offers url access only" is the message an operator
+              // running a validation actually sees -- about a url mode the table never mentioned.
+              : onlyUnrecognised(modes)
+                  ? "Delta Sharing table "
+                      + qualified
+                      + " states only access modes this provider does not recognise"
+                  : "Delta Sharing table "
+                      + qualified
+                      + " offers url access only, which cannot be vended as storage credentials");
+    }
+
+    TemporaryCredentials credentials =
+        askForCredentials(addressed, name, qualified, "vending credentials for " + qualified);
+
+    if (!credentials.hasAwsSession()) {
+      // Named by cloud. A recipient on Azure or GCP is a supported configuration of the protocol
+      // and an unsupported one here, and the difference between those is what an operator needs.
+      throw new CatalogAccessException(
+          CatalogAccessException.Code.UNSUPPORTED,
+          "Delta Sharing vended "
+              + credentials.cloud()
+              + " credentials for "
+              + qualified
+              + ", and only AWS session credentials can be published");
+    }
+
+    // Checked on the path that actually runs per read. validateStorageAccess makes the same check
+    // and is only ever called from validation, so without this a server returning a credential
+    // scoped somewhere unrelated or far broader than the table would go unchallenged on every
+    // storage-authority resolve. The Unity provider checks it in its own vend for this reason.
+    // The metadata action only. Paging the schema to look for a location was waste on exactly the
+    // servers that need this path: one that omits it from its metadata omits it from its listing
+    // too, and this runs on every storage-authority resolve with a fresh client, so the memo never
+    // absorbs it.
+    //
+    // That leaves one shape unchecked, and it is a narrower claim than "loadTable already refused
+    // a table without a location". loadTable resolves the listing first, so a server stating the
+    // location only there reconciles, and here there is nothing to compare the scope against. The
+    // check is skipped rather than failed, because the alternative is a schema listing per read --
+    // the cost this path exists to avoid. validateStorageAccess does consult both surfaces, so an
+    // operator sees a mis-scoped credential at validation; what is not caught is a server that
+    // starts mis-scoping after that. Closing it means carrying the load's location to the vend,
+    // which the vendor's fresh-client-per-resolve shape gives nowhere to put.
+    // Canonical on both sides. covers() is a prefix test on strings, so encoding one side and not
+    // the other makes every table whose key holds a space look scoped elsewhere.
+    Optional<String> tableLocation =
+        described.metadata().location().map(DeltaSharingCatalogClient::canonical);
+    if (tableLocation.isPresent()) {
+      // One direction only: the credential has to reach the table. A scope broader than the table
+      // -- a share root, a bucket, an external-location prefix -- is left alone deliberately.
+      // StorageLocations states the rule this sits under: never be stricter than the component
+      // that will actually use the credential, because this path is reached only once no storage
+      // authority matched, so refusing here fails a read that the catalog's own client would have
+      // attempted and that S3 would have answered on the real grant.
+      if (!StorageLocations.covers(canonical(credentials.location()), tableLocation.get())) {
+        throw new CatalogAccessException(
+            CatalogAccessException.Code.CREDENTIAL_SCOPE_INVALID,
+            "Delta Sharing vended credentials that do not reach " + qualified);
+      }
+    }
+
+    Map<String, String> properties = new HashMap<>(storageProperties);
+    properties.put("s3.access-key-id", credentials.accessKeyId().orElseThrow());
+    properties.put("s3.secret-access-key", credentials.secretAccessKey().orElseThrow());
+    properties.put("s3.session-token", credentials.sessionToken().orElseThrow());
+
+    // Servable, checked here too. requireServable ran only at the load, so on the reference-server
+    // shape -- where the metaData action names no location and the coverage check above is skipped
+    // -- whatever the credential endpoint returned was canonicalised and published unexamined. A
+    // table reconciled from an earlier good credential could then start receiving an AWS tuple
+    // scoped to a gs:// location, or one carrying userinfo, and the read failed at query time
+    // instead of the provider refusing it. This needs no listing, so the shape the vend was changed
+    // to avoid is unaffected.
+    String scope = requireServable(credentials.location(), qualified);
+
+    return Optional.of(
+        new VendedStorageCredentials(Map.copyOf(properties), scope, credentials.expiresAt()));
+  }
+
+  @Override
+  public void validateStorageAccess(
+      CatalogObjectName name, VendedStorageCredentials vendedStorageCredentials) {
+    Objects.requireNonNull(vendedStorageCredentials, "vendedStorageCredentials");
+    Schema addressed = requireSchema(name.namespace());
+    // The metadata endpoint rather than the listing, for the reason the vend uses it: one request
+    // for one table instead of paging the schema to find it.
+    String qualified = addressed.share() + "." + addressed.name() + "." + name.name();
+    // Every surface the protocol lets a server state a location on, in the order all three paths
+    // use: the metaData action, then the listing, then the scope the credential itself named. That
+    // last one matters for the reference server, which states a location on neither of the first
+    // two -- without it this refused every table on exactly the servers the ask-rather-than-refuse
+    // default exists to support, before attempting any read.
+    Optional<String> stated =
+        translate(
+                "describing " + qualified,
+                () -> client.describeTable(addressed.share(), addressed.name(), name.name()))
+            .metadata()
+            .location()
+            .or(() -> findTable(addressed, name.name()).location());
+    String location =
+        canonical(
+            stated.orElseGet(
+                () ->
+                    Optional.of(vendedStorageCredentials.scopePrefix())
+                        .filter(prefix -> !prefix.isBlank())
+                        .orElseThrow(
+                            () ->
+                                new CatalogAccessException(
+                                    CatalogAccessException.Code.UNSUPPORTED,
+                                    "Delta Sharing table "
+                                        + qualified
+                                        + " reports no location to validate access against"))));
+    // Scope first, because it answers without a network call and a credential scoped elsewhere is
+    // a provider bug rather than a permission the operator can grant. Skipped where the credential
+    // supplied the location, since checking a scope against itself asserts nothing; the probe below
+    // still reads the store, which is what this validation is for.
+    if (stated.isPresent() && !vendedStorageCredentials.covers(location)) {
+      throw new CatalogAccessException(
+          CatalogAccessException.Code.CREDENTIAL_SCOPE_INVALID,
+          "Delta Sharing credentials do not cover " + qualified);
+    }
+    // Then the store itself. A shared table is a Delta table, so this is the same probe the Unity
+    // provider runs: list one object under the Delta log and read a byte of it. Scope alone would
+    // pass on a grant that cannot read, which is the failure an operator finds at query time.
+    storageProbe.validate(location, vendedStorageCredentials);
+  }
+
+  @Override
+  public void close() {
+    client.close();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  /** Whether a surface stated modes and none of them are ones this client knows. */
+  private static boolean onlyUnrecognised(List<AccessMode> modes) {
+    return !modes.isEmpty() && modes.stream().allMatch(mode -> mode == AccessMode.OTHER);
+  }
+
+  /** Whether a surface stated its modes and directory access was not among them. */
+  private static boolean refusesDir(List<AccessMode> modes) {
+    return !modes.isEmpty() && !modes.contains(AccessMode.DIR);
+  }
+
+  /**
+   * What the server actually stated about how this table may be read.
+   *
+   * <p>Two places carry it. The listing states it in either response format; the metaData action
+   * states it only in the delta format, which is what this client asks for. Neither is required to,
+   * so an empty answer means the server said nothing rather than that it said url.
+   *
+   * <p>Which surface this prefers decides nothing about whether a table may be read that way --
+   * {@link #refusesDir} is asked of both surfaces separately, because the vend sees only one of
+   * them. This answers the narrower question of whether anything was stated at all.
+   */
+  private static List<AccessMode> statedModes(Table listed, TableDescription described) {
+    return listed.accessModes().isEmpty()
+        ? described.metadata().accessModes()
+        : listed.accessModes();
+  }
+
+  /**
+   * Two components joined so that the pair can be recovered from the result.
+   *
+   * <p>The protocol treats a share id and a table id as opaque strings, so a bare delimiter makes
+   * {@code a:b} plus {@code c} indistinguishable from {@code a} plus {@code b:c}. The reconciler
+   * checks stable identities for duplicates and abandons the whole overlay on a collision, which is
+   * the failure this identity exists to prevent rather than cause. Percent-encoding the delimiter
+   * inside each component is enough to keep the join unambiguous.
+   */
+  private static String joined(String first, String second) {
+    return escape(first) + ":" + escape(second);
+  }
+
+  private static String escape(String component) {
+    return component.replace("%", "%25").replace(":", "%3A");
+  }
+
+  /**
+   * An identity that names the share as well as the table.
+   *
+   * <p>The protocol scopes a table id to its share and makes {@code shareId} unique across the
+   * server, so a bare table id is not unique across an Integration: two shares may carry the same
+   * id, including for the same underlying table shared twice. The reconciler requires stable
+   * identities to be unique across every selected table and abandons the overlay on a duplicate.
+   *
+   * <p>Stable only when both components are the server's own ids. Falling back to the share name,
+   * or to the qualified name where the listing states no table id, keeps the identity unambiguous
+   * but promises nothing about a rename surviving, so those forms are reported unstable rather than
+   * claiming more than the server offered.
+   */
+  private static ExternalObjectIdentity identityOf(Table listed) {
+    // The listing's id only. The metaData action's id identifies the underlying Delta table, which
+    // the protocol calls the unique identifier for the table itself -- a different namespace from
+    // the share-scoped id here. A share exposing one physical table under two names, which is a
+    // legitimate configuration, reports the same value for both entries, and the reconciler
+    // abandons the whole overlay on a duplicate stable identity. Falling back to it looked like it
+    // recovered stability and instead risked dropping the share.
+    Optional<String> tableId = listed.id();
+    if (tableId.isEmpty()) {
+      return new ExternalObjectIdentity(listed.fullName(), false);
+    }
+    return listed
+        .shareId()
+        .map(shareId -> new ExternalObjectIdentity(joined(shareId, tableId.get()), true))
+        .orElseGet(() -> new ExternalObjectIdentity(joined(listed.share(), tableId.get()), false));
+  }
+
+  /**
+   * The schema's tables, listed once for the client's lifetime.
+   *
+   * <p>Which is one reconcile pass: the reconciler lists a schema and then loads every table in it,
+   * and each load looked the table up by paging the listing again. A table appearing mid-pass is
+   * not something the pass would have seen anyway.
+   */
+  private List<Table> listing(Schema schema) {
+    return listedTables.computeIfAbsent(
+        schema,
+        key ->
+            translate(
+                "listing tables of " + key.share() + "." + key.name(),
+                () -> client.listTables(key.share(), key.name())));
+  }
+
+  /**
+   * Where the table's data lives, or a refusal.
+   *
+   * <p>Three surfaces, because a server need not use the first two. The reference implementation
+   * states a location in neither its listing nor its metadata action -- both predate directory
+   * access, as its absent {@code accessModes} shows -- and names it only on the credential
+   * response. Reconciling without one is not harmless: the reconciler stores no storage location
+   * and leaves the Integration's own HTTPS catalog URI as the table's upstream reference, so the
+   * table materializes and cannot be opened by anything that reads object storage.
+   *
+   * <p>So every path here ends in a location or a refusal, and nothing reconciles unreadable. A
+   * table this Integration cannot read is refused at the load and counted in {@code
+   * objects_skipped} rather than materialized and left to fail at query time:
+   *
+   * <ul>
+   *   <li>url access alone, which the storage contract cannot express at all.
+   *   <li>no stated modes under {@code delta.sharing.strict-access-modes}, which is the reading
+   *       that knob exists to apply -- refused here without a request, since asking is exactly what
+   *       it turns off.
+   *   <li>no location on any surface, including the credential response.
+   * </ul>
+   */
+  private String requireStorageLocation(
+      Schema addressed,
+      CatalogObjectName name,
+      Table listed,
+      TableDescription described,
+      List<AccessMode> modes) {
+    String qualified = addressed.share() + "." + addressed.name() + "." + name.name();
+    // Both surfaces, not whichever one spoke first. statedModes prefers the listing, and the vend
+    // reads the metaData action alone, so a server saying dir on its listing and url on its
+    // metaData would otherwise load here and be refused there -- on every read, for the life of
+    // the table. The load must not be more permissive than the vend, and the vend sees only the
+    // metaData action, so a stated refusal on either surface is decisive. A table whose listing
+    // says url and whose metaData says dir is refused too: that direction only costs a table
+    // nothing could read through this path anyway, and no reading of two contradictory answers is
+    // worth a vend that fails later.
+    if (refusesDir(listed.accessModes()) || refusesDir(described.metadata().accessModes())) {
+      // Named for what was actually stated. A table stating only modes this client does not know
+      // is not a table offering url access, and saying so sent an operator looking for a url-mode
+      // problem that does not exist.
+      boolean unrecognised =
+          onlyUnrecognised(listed.accessModes())
+              || onlyUnrecognised(described.metadata().accessModes());
+      throw new CatalogAccessException(
+          CatalogAccessException.Code.UNSUPPORTED,
+          unrecognised
+              ? "Delta Sharing table "
+                  + qualified
+                  + " states only access modes this provider does not recognise"
+              : "Delta Sharing table "
+                  + qualified
+                  + " offers url access only, which cannot be vended as storage credentials");
+    }
+    // Only where the modes were genuinely absent. A table stating dir is not the ambiguous case
+    // this knob governs, and refusing it here said "states no access modes" about a table that had
+    // stated them.
+    //
+    // Ahead of the location, not after it. This sat below the early return, so a table with no
+    // stated modes and a location on its listing was loaded and then refused by the vend, which
+    // applies the same rule with no such exemption -- it reconciled and every read of it failed.
+    // Knowing where a table lives says nothing about whether it may be read that way, which is the
+    // only question this knob answers.
+    if (modes.isEmpty() && strictAccessModes) {
+      throw new CatalogAccessException(
+          CatalogAccessException.Code.UNSUPPORTED,
+          "Delta Sharing table "
+              + qualified
+              + " states no access modes, which "
+              + STRICT_ACCESS_MODES
+              + " reads as url only");
+    }
+    // The metaData action first, then the listing, which is the order all three paths use. A
+    // server may state a location on both surfaces and state them differently, so the paths have
+    // to agree on which one wins: otherwise the table reconciles at one location, validation
+    // probes another, and the vend compares the credential's scope against a third, and a passing
+    // storage-access check says nothing about where a read will go. The metaData action is the
+    // surface they can all reach -- the vend cannot see a listing without paging the schema on
+    // every read.
+    Optional<String> stated = described.metadata().location().or(listed::location);
+    // Whether to ask is decided on the metaData action alone, which is the surface the vend reads.
+    // statedModes prefers the listing, so a table stating dir only there took this early return
+    // while the vend saw nothing stated, treated the table as ambiguous and asked -- and a server
+    // that states dir on its listing and then refuses the credential endpoint reconciled here and
+    // failed every read. Same regression as the unstated case, reached by the other surface.
+    //
+    // What both paths still share is trusting a dir the metaData action does state: neither probes
+    // that, so a server contradicting its own metaData is believed. That is a policy rather than an
+    // oversight -- a stated dir followed by a refusal is a server disagreeing with itself, where an
+    // unstated table refusing is the ordinary shape the ask exists for -- and it costs no request
+    // on the common shape. The two paths agree on it, which is what matters here.
+    // Under the strict setting the vend falls back to the listing when the metaData action states
+    // nothing, so the load consults it too and the two still agree. Both surfaces are already in
+    // hand here, so this costs no request -- it only stops the strict setting from spending a
+    // credential POST per table on a server that states its modes where the protocol defines them.
+    List<AccessMode> decidedOn = strictAccessModes ? modes : described.metadata().accessModes();
+    if (!decidedOn.isEmpty() && stated.isPresent()) {
+      return requireServable(stated.get(), qualified);
+    }
+    // No blank check on what comes back. The transport refuses a credentials response that names
+    // no location, as INVALID_RESPONSE, before it reaches here -- so a guard here was unreachable
+    // and, by naming a per-table refusal, implied a graceful skip that does not exist. A server
+    // whose credential endpoint answers 200 without a location ends the pass instead, which is the
+    // rule every unreadable response follows: a response shape this client cannot read is not a
+    // property of one table, and absorbing it per table leaves a broken share looking partly
+    // healthy.
+    // Reached two ways: dir was stated and no surface named a location, or no surface stated
+    // modes at all. In the second case the credential endpoint is the only thing that can answer
+    // whether directory access exists, and a stated location does not answer it -- the protocol
+    // lets a url-only server name one. So a server that omits its access modes, names a location
+    // and refuses this endpoint has to be asked, not assumed: asking is what the default setting
+    // is. askForCredentials classifies the answer, so a refusal arrives as UNSUPPORTED and skips
+    // this table rather than reconciling one whose every read fails.
+    TemporaryCredentials answered =
+        askForCredentials(addressed, name, qualified, "asking where " + qualified + " lives");
+    String vended = answered.location();
+    // The location the credential names is the table's root, whatever shape its path has. The
+    // protocol answers a request naming no location with the table's main location, and a Delta
+    // table may sit directly at a bucket root -- deltaLogPrefix("") answers _delta_log/ for that
+    // case on purpose.
+    //
+    // Whether a credential is scoped where the table actually lives is settled by reading the
+    // Delta log under it, which validateStorageAccess does. The shape of a path cannot settle it,
+    // and a check here that guessed from the shape would refuse tables validation reads happily.
+    // A location a surface stated outranks the credential's scope, which only stands in for one --
+    // but it has to be reachable with the credential the server just answered with. Where both are
+    // known and disjoint, reconciling the stated one materialises a table every read of which is
+    // scoped elsewhere, and validation is optional so nothing else need catch it. The vend makes
+    // this comparison for a location the metaData action states; making it here covers the surface
+    // the vend cannot see.
+    if (stated.isPresent()
+        && !StorageLocations.covers(canonical(vended), canonical(stated.get()))) {
+      throw new CatalogAccessException(
+          CatalogAccessException.Code.CREDENTIAL_SCOPE_INVALID,
+          "Delta Sharing answered for " + qualified + " with credentials that do not reach it");
+    }
+    return requireServable(stated.orElse(vended), qualified);
+  }
+
+  /**
+   * A location this provider can actually read, or a refusal.
+   *
+   * <p>The storage probe addresses S3 and the vend publishes an AWS session, so an {@code abfss://}
+   * or {@code gs://} table would load, reconcile, and then fail at every scan when the vend refused
+   * its cloud -- the unreadable materialized table the other refusals here exist to prevent,
+   * reached by a different route and not counted in {@code objects_skipped} either.
+   */
+  private static String requireServable(String location, String qualified) {
+    if (!DeltaLogStorageProbe.s3Serves(location)) {
+      // The scheme, never the location. This message reaches operator logs through the throwable
+      // the reconciler records, and the location is the server's: a query or fragment on one is a
+      // signature or a SAS token, userinfo is a password, and a control character in it forges a
+      // log line. The scheme is the whole answer to which cloud, and cannot carry any of those.
+      String scheme = schemeOf(location);
+      throw new CatalogAccessException(
+          CatalogAccessException.Code.UNSUPPORTED,
+          "s3".equals(scheme)
+              // Same answer from s3Serves, two different problems. Reporting the cloud for an s3
+              // location whose bucket would not parse told an operator the opposite of what was
+              // wrong, and sent them to look at a provider that reads S3 perfectly well.
+              ? "Delta Sharing table "
+                  + qualified
+                  + " names an s3 location this provider could not read a bucket from"
+              : "Delta Sharing table "
+                  + qualified
+                  + " lives on "
+                  + scheme
+                  + ", which this provider cannot read: it vends AWS session credentials for S3");
+    }
+    // The canonical form, not the one the server sent. This is the value that reaches
+    // CatalogTable.storageLocation and then UpstreamRef, so it has to be one the read path can
+    // parse; see canonical().
+    return canonical(location);
+  }
+
+  /**
+   * The form of a location this provider publishes, vends and compares.
+   *
+   * <p>The rule lives in {@link DeltaLogStorageProbe#canonicalLocation}, beside the probe whose
+   * space encoding created the need for it, because the Unity provider needs the same answer and
+   * had received the probe half of this without the publish half.
+   */
+  private static String canonical(String location) {
+    return DeltaLogStorageProbe.canonicalLocation(location);
+  }
+
+  /** A location's scheme alone, which names the cloud and can hold nothing else. */
+  private static String schemeOf(String location) {
+    try {
+      // Spaces encoded first. An S3 object key may hold one and java.net.URI may not, so a legal
+      // location threw here and was reported as having no readable scheme at all. Other characters
+      // URI rejects and S3 permits are still refused; a space is the one that occurs.
+      String scheme = java.net.URI.create(canonical(location)).getScheme();
+      return scheme == null ? "no addressable scheme" : scheme.toLowerCase(java.util.Locale.ROOT);
+    } catch (IllegalArgumentException notAUri) {
+      return "no addressable scheme";
+    }
+  }
+
+  /**
+   * The credential call, classified as the capability boundary it answers.
+   *
+   * <p>A server without the endpoint answers NOT_FOUND, and the refusal the protocol defines for a
+   * table not offering directory access is INVALID_REQUEST. Both mean the same thing to a caller --
+   * directory access is not available for this table -- so both are reported as unsupported rather
+   * than as a missing table or a bad request.
+   *
+   * <p>Not gated on whether the table stated its modes, so that one HTTP 400 means the same thing
+   * on the load path and the vend path. The server's answer settles it either way: a table whose
+   * listing claims dir and whose credential endpoint refuses does not have directory access,
+   * whatever the listing said.
+   */
+  private TemporaryCredentials askForCredentials(
+      Schema addressed, CatalogObjectName name, String qualified, String action) {
+    try {
+      return client.temporaryTableCredentials(
+          addressed.share(), addressed.name(), name.name(), null);
+    } catch (DeltaSharingException failure) {
+      // A 3xx is excluded. The transport folds a refused redirect into INVALID_REQUEST, and its
+      // own comment says what that means: the base URI names something other than a sharing
+      // server. Read here as the protocol's per-table refusal, an auth proxy or a trailing-slash
+      // redirect in front of the server reported every table as offering no directory access --
+      // a configuration error arriving as a per-table capability limit, table by table, with the
+      // integration looking partly healthy rather than misconfigured.
+      // 400 exactly, not every INVALID_REQUEST. The transport folds 400, 405 and 422 into that
+      // one failure, and only 400 is the protocol's own statement that a table does not offer
+      // directory access. A 405 is a GET-only proxy or a gateway rule and a 422 is neither -- both
+      // are configuration in front of the server, and reading them as a capability limit reported
+      // every table as lacking dir access while the real fault went unnamed. They stay a per-table
+      // skip either way, since INVALID_CONFIGURATION also describes one branch; what changes is
+      // the issue an operator is shown and the message that comes with it.
+      boolean protocolRefusal =
+          failure.failure() == DeltaSharingException.Failure.NOT_FOUND
+              || (failure.failure() == DeltaSharingException.Failure.INVALID_REQUEST
+                  && failure.statusCode() == 400);
+      if (protocolRefusal) {
+        throw new CatalogAccessException(
+            CatalogAccessException.Code.UNSUPPORTED,
+            "Delta Sharing did not offer directory access for " + qualified,
+            failure);
+      }
+      throw new CatalogAccessException(
+          codeFor(failure.failure()), messageFor(action, failure), failure);
+    }
+  }
+
+  private Schema requireSchema(NamespacePath namespace) {
+    List<String> segments = namespace == null ? List.of() : namespace.segments();
+    if (segments.size() != 2) {
+      throw new CatalogAccessException(
+          CatalogAccessException.Code.INVALID_CONFIGURATION,
+          "Delta Sharing addresses a table as share.schema.table, so its namespace has two"
+              + " segments, not "
+              + segments.size());
+    }
+    return new Schema(segments.get(0), segments.get(1));
+  }
+
+  /**
+   * The listed table, which carries the share id that describing it does not.
+   *
+   * <p>Only the load needs this. The vend and the storage probe read one table's metadata instead,
+   * because paging a whole schema to find one table is not something a per-read path should do.
+   */
+  private Table findTable(Schema schema, String name) {
+    // Memoised for the client's lifetime, which is one reconcile pass: the reconciler lists a
+    // schema once and then loads every table in it, and each load looked the table up by paging
+    // the whole listing again. Only loadTable reaches here -- the vend and the storage probe read
+    // one table's metadata instead -- so the window is a single traversal of a schema it has just
+    // listed, and a table appearing mid-pass is not something the pass would have seen anyway.
+    for (Table table : listing(schema)) {
+      if (table.name().equals(name)) {
+        return table;
+      }
+    }
+    throw new CatalogAccessException(
+        CatalogAccessException.Code.NOT_FOUND,
+        "Delta Sharing share " + schema.share() + "." + schema.name() + " does not share " + name);
+  }
+
+  private <T> T translate(String action, java.util.function.Supplier<T> call) {
+    try {
+      return call.get();
+    } catch (DeltaSharingException e) {
+      throw new CatalogAccessException(codeFor(e.failure()), messageFor(action, e), e);
+    }
+  }
+
+  private void translate(String action, Runnable call) {
+    translate(
+        action,
+        () -> {
+          call.run();
+          return null;
+        });
+  }
+
+  private static String messageFor(String action, DeltaSharingException e) {
+    return "Delta Sharing failed while " + action + ": " + e.getMessage();
+  }
+
+  /**
+   * The recipient's classification, mapped to the SPI's.
+   *
+   * <p>The distinction that matters is terminal against retryable. A rejected token and a share not
+   * granted will answer the same way on every attempt; a rate limit, a server error and a transport
+   * failure will not.
+   */
+  private static CatalogAccessException.Code codeFor(DeltaSharingException.Failure failure) {
+    return switch (failure) {
+      case UNAUTHENTICATED -> CatalogAccessException.Code.UNAUTHENTICATED;
+      case PERMISSION_DENIED -> CatalogAccessException.Code.PERMISSION_DENIED;
+      case NOT_FOUND -> CatalogAccessException.Code.NOT_FOUND;
+      case RATE_LIMITED, SERVER_ERROR, TRANSPORT, TRANSIENT ->
+          CatalogAccessException.Code.UNAVAILABLE;
+      case INTERRUPTED -> CatalogAccessException.Code.TIMEOUT;
+      // Split, because they describe different scopes. INVALID_REQUEST is the protocol's own
+      // per-table refusal, and INVALID_CONFIGURATION is per-branch, so the walk steps over it.
+      // INVALID_RESPONSE is a body this client cannot read -- a proxy error page, a version
+      // mismatch reshaping every table -- which describes the catalog. INTERNAL is outside
+      // describesOneBranch, so a reconcile fails on it rather than recording every table as
+      // unobserved and leaving a broken share looking partially healthy. Unity splits them the
+      // same way and for the same reason.
+      case INVALID_REQUEST -> CatalogAccessException.Code.INVALID_CONFIGURATION;
+      case INVALID_RESPONSE -> CatalogAccessException.Code.INTERNAL;
+      // Not UNSUPPORTED. That code now means the provider will never do this: the service skips
+      // the table and reports CIVI_..._UNSUPPORTED, and the vendor reports a deterministic refusal.
+      // OTHER is the catch-all for a status this client does not classify -- 402, 407, 409, 423,
+      // 451 -- which is a real upstream or configuration problem, and naming it unsupported tells
+      // an operator there is nothing to fix. UNAVAILABLE keeps the status in the message and
+      // treats an unknown condition as one a later attempt might not meet.
+      case OTHER -> CatalogAccessException.Code.UNAVAILABLE;
+    };
+  }
+}

--- a/catalog-access/delta-sharing/src/main/java/ai/floedb/floecat/catalog/sharing/DeltaSharingClientProvider.java
+++ b/catalog-access/delta-sharing/src/main/java/ai/floedb/floecat/catalog/sharing/DeltaSharingClientProvider.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.catalog.sharing;
+
+import ai.floedb.floecat.catalog.access.CatalogAccessException;
+import ai.floedb.floecat.catalog.access.CatalogAuthenticationScheme;
+import ai.floedb.floecat.catalog.access.CatalogClient;
+import ai.floedb.floecat.catalog.access.CatalogClientProvider;
+import ai.floedb.floecat.catalog.access.CatalogConnectionConfig;
+import ai.floedb.floecat.catalog.access.CatalogProtocol;
+import ai.floedb.floecat.catalog.access.ResolvedCatalogCredentials;
+import ai.floedb.floecat.client.sharing.DeltaSharingClient;
+import ai.floedb.floecat.client.sharing.HttpDeltaSharingClient;
+import ai.floedb.floecat.http.guards.HttpEndpointGuards;
+import java.net.URI;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/** Opens Delta Sharing recipients for the catalog-access SPI. */
+public final class DeltaSharingClientProvider implements CatalogClientProvider {
+
+  private static final Duration DEFAULT_CONNECT_TIMEOUT = Duration.ofSeconds(10);
+  private static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofSeconds(30);
+
+  /**
+   * Storage properties carried through to a vended credential.
+   *
+   * <p>The temporary-table-credentials response names the location and the key material and nothing
+   * else, so a non-standard object store still has to be told where it is and how to address it.
+   * Against real AWS these are inferable and an operator sets none of them.
+   */
+  private static final List<String> STORAGE_PROPERTY_KEYS =
+      List.of("s3.endpoint", "s3.region", "client.region", "s3.path-style-access");
+
+  static final String READER_FEATURES = "delta.sharing.reader-features";
+
+  /** Seam for tests: builds the recipient without opening a connection. */
+  interface ClientFactory {
+    DeltaSharingClient create(
+        URI endpoint,
+        String bearerToken,
+        Duration connectTimeout,
+        Duration requestTimeout,
+        List<String> readerFeatures);
+  }
+
+  private final ClientFactory clientFactory;
+
+  public DeltaSharingClientProvider() {
+    this(HttpDeltaSharingClient::new);
+  }
+
+  DeltaSharingClientProvider(ClientFactory clientFactory) {
+    this.clientFactory = Objects.requireNonNull(clientFactory, "clientFactory");
+  }
+
+  @Override
+  public CatalogProtocol protocol() {
+    return CatalogProtocol.DELTA_SHARING;
+  }
+
+  @Override
+  public CatalogClient open(
+      CatalogConnectionConfig config, ResolvedCatalogCredentials resolvedCredentials) {
+    Objects.requireNonNull(config, "config");
+    Objects.requireNonNull(resolvedCredentials, "resolvedCredentials");
+    // Cheap defence against a registry mis-dispatch, as the Unity provider makes at its entry.
+    if (config.protocol() != CatalogProtocol.DELTA_SHARING) {
+      throw new CatalogAccessException(
+          CatalogAccessException.Code.INVALID_CONFIGURATION,
+          "Delta Sharing provider was asked for " + config.protocol());
+    }
+
+    // A recipient token, and nothing else. The protocol defines bearer authorization and no other
+    // scheme, so anything else here is a configuration error rather than an unused field. A bearer
+    // token reaches a provider as OAUTH2 carrying a token property, which is how the service
+    // resolves one.
+    if (config.authentication().scheme() != CatalogAuthenticationScheme.OAUTH2) {
+      throw new CatalogAccessException(
+          CatalogAccessException.Code.INVALID_CONFIGURATION,
+          "Delta Sharing authenticates with a recipient bearer token, not "
+              + config.authentication().scheme());
+    }
+    String token = resolvedCredentials.properties().get("token");
+    if (token == null || token.isBlank()) {
+      throw new CatalogAccessException(
+          CatalogAccessException.Code.INVALID_CONFIGURATION,
+          "Delta Sharing requires a resolved recipient token");
+    }
+
+    Map<String, String> properties = config.properties();
+    Map<String, String> storage = new HashMap<>();
+    for (String key : STORAGE_PROPERTY_KEYS) {
+      String value = properties.get(key);
+      if (value != null && !value.isBlank()) {
+        storage.put(key, value.trim());
+      }
+    }
+    // The same gate the Unity provider holds its own s3.endpoint to, for the same reason: this
+    // vend publishes an AWS session token, and the endpoint travels on to query workers.
+    try {
+      HttpEndpointGuards.requireUsableStorageEndpoint(
+          storage.get("s3.endpoint"), "Delta Sharing s3.endpoint");
+    } catch (IllegalArgumentException refused) {
+      throw new CatalogAccessException(
+          CatalogAccessException.Code.INVALID_CONFIGURATION, refused.getMessage(), refused);
+    }
+
+    // Before the client exists. Arguments evaluate left to right, so resolving this inside the
+    // constructor call built the transport first and leaked it when the property was malformed --
+    // once per open, which is once per vend and once per validation.
+    boolean strict = strictAccessModes(properties);
+
+    // The transport is open by the time the wrapper's constructor runs, so anything it raises
+    // leaks it -- once per vend and once per validation, the same window the flag above is
+    // resolved early to avoid.
+    DeltaSharingClient recipient;
+    try {
+      recipient =
+          clientFactory.create(
+              config.endpoint(),
+              token,
+              durationProperty(properties, "http.connect.ms", DEFAULT_CONNECT_TIMEOUT),
+              durationProperty(properties, "http.read.ms", DEFAULT_REQUEST_TIMEOUT),
+              readerFeatures(properties));
+    } catch (IllegalArgumentException refused) {
+      // The message as the transport wrote it. Naming a property here was wrong: the constructor
+      // raises this for the endpoint gates, the two floecat.delta-sharing.* limits and a blank
+      // token as well as for a reader feature, so an operator pointing at an http:// endpoint was
+      // told about delta.sharing.reader-features, which they had never set.
+      throw new CatalogAccessException(
+          CatalogAccessException.Code.INVALID_CONFIGURATION, refused.getMessage(), refused);
+    }
+    try {
+      return new DeltaSharingCatalogClient(recipient, storage, strict);
+    } catch (RuntimeException | Error failure) {
+      closeQuietly(recipient);
+      throw failure;
+    }
+  }
+
+  private static void closeQuietly(DeltaSharingClient recipient) {
+    try {
+      recipient.close();
+    } catch (RuntimeException ignored) {
+      // Closing is what releases the transport; a failure to close adds nothing to report.
+    }
+  }
+
+  /**
+   * Whether a table stating no access modes is read as url only, off by default.
+   *
+   * <p>The protocol reads an absent field as url only, and the reference server implements the
+   * credential endpoint while stating nothing at all, so holding to that reading refuses every
+   * table on a server that would have vended. The default asks and lets the server answer; an
+   * operator who wants the protocol reading enforced without a round trip sets this.
+   */
+  private static boolean strictAccessModes(Map<String, String> properties) {
+    String value = properties.get(DeltaSharingCatalogClient.STRICT_ACCESS_MODES);
+    if (value == null || value.isBlank()) {
+      return false;
+    }
+    String trimmed = value.trim();
+    if (trimmed.equalsIgnoreCase("true")) {
+      return true;
+    }
+    if (trimmed.equalsIgnoreCase("false")) {
+      return false;
+    }
+    throw new CatalogAccessException(
+        CatalogAccessException.Code.INVALID_CONFIGURATION,
+        DeltaSharingCatalogClient.STRICT_ACCESS_MODES + " must be true or false, not " + value);
+  }
+
+  /**
+   * Delta reader features this deployment can process, empty by default.
+   *
+   * <p>Empty rather than everything the protocol names. The capability header tells the server what
+   * the client can handle, and claiming a feature the read path cannot process turns a refusal the
+   * server would have made into a failure partway through a scan. An operator opts in per feature
+   * once the read path is known to support it.
+   *
+   * <p>Enforcement is the server's. This list reaches it in {@code delta-sharing-capabilities} on
+   * the metadata call, and nothing here compares it against the {@code readerFeatures} the protocol
+   * action reports back. Under directory access the data read goes straight to object storage with
+   * the vended credential, so there is no later point at which the server could refuse -- which
+   * means a server that ignores the header is not caught, and a table needing more than the opt-in
+   * would be read rather than rejected. Checking it locally is a policy this does not yet take.
+   */
+  private static List<String> readerFeatures(Map<String, String> properties) {
+    String configured = properties.get(READER_FEATURES);
+    if (configured == null || configured.isBlank()) {
+      return List.of();
+    }
+    List<String> features = new ArrayList<>();
+    for (String feature : configured.split(",")) {
+      String trimmed = feature.trim();
+      if (trimmed.isEmpty()) {
+        continue;
+      }
+      // Not checked here. The transport validates each token where it interpolates it into the
+      // capability header, which is the only place the shape matters and the one place every
+      // construction path goes through; open() turns that refusal into this property's name.
+      features.add(trimmed);
+    }
+    return List.copyOf(features);
+  }
+
+  private static Duration durationProperty(
+      Map<String, String> properties, String key, Duration fallback) {
+    String value = properties.get(key);
+    if (value == null || value.isBlank()) {
+      return fallback;
+    }
+    long millis;
+    try {
+      millis = Long.parseLong(value.trim());
+    } catch (NumberFormatException notANumber) {
+      throw new CatalogAccessException(
+          CatalogAccessException.Code.INVALID_CONFIGURATION,
+          key + " must be a number of milliseconds, not " + value);
+    }
+    if (millis <= 0) {
+      throw new CatalogAccessException(
+          CatalogAccessException.Code.INVALID_CONFIGURATION, key + " must be above zero");
+    }
+    return Duration.ofMillis(millis);
+  }
+}

--- a/catalog-access/delta-sharing/src/main/resources/META-INF/services/ai.floedb.floecat.catalog.access.CatalogClientProvider
+++ b/catalog-access/delta-sharing/src/main/resources/META-INF/services/ai.floedb.floecat.catalog.access.CatalogClientProvider
@@ -1,0 +1,6 @@
+# Copyright 2026 Yellowbrick Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+ai.floedb.floecat.catalog.sharing.DeltaSharingClientProvider

--- a/catalog-access/delta-sharing/src/test/java/ai/floedb/floecat/catalog/sharing/DeltaSharingCatalogClientTest.java
+++ b/catalog-access/delta-sharing/src/test/java/ai/floedb/floecat/catalog/sharing/DeltaSharingCatalogClientTest.java
@@ -1,0 +1,1560 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.catalog.sharing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import ai.floedb.floecat.catalog.access.CatalogAccessException;
+import ai.floedb.floecat.catalog.access.CatalogCapability;
+import ai.floedb.floecat.catalog.access.CatalogObjectName;
+import ai.floedb.floecat.catalog.access.CatalogTable;
+import ai.floedb.floecat.catalog.access.CatalogTraversalFailures;
+import ai.floedb.floecat.catalog.access.NamespacePath;
+import ai.floedb.floecat.catalog.access.VendedStorageCredentials;
+import ai.floedb.floecat.catalog.delta.DeltaLogStorageProbe;
+import ai.floedb.floecat.client.sharing.DeltaSharingClient;
+import ai.floedb.floecat.client.sharing.DeltaSharingException;
+import ai.floedb.floecat.client.sharing.DeltaSharingModel.AccessMode;
+import ai.floedb.floecat.client.sharing.DeltaSharingModel.CredentialCloud;
+import ai.floedb.floecat.client.sharing.DeltaSharingModel.Protocol;
+import ai.floedb.floecat.client.sharing.DeltaSharingModel.Schema;
+import ai.floedb.floecat.client.sharing.DeltaSharingModel.Share;
+import ai.floedb.floecat.client.sharing.DeltaSharingModel.Table;
+import ai.floedb.floecat.client.sharing.DeltaSharingModel.TableDescription;
+import ai.floedb.floecat.client.sharing.DeltaSharingModel.TableMetadata;
+import ai.floedb.floecat.client.sharing.DeltaSharingModel.TemporaryCredentials;
+import java.net.URI;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class DeltaSharingCatalogClientTest {
+
+  private static final String LOCATION = "s3://sharing/gold/events";
+
+  @Test
+  void capabilitiesCoverDiscoveryAndVending() {
+    try (DeltaSharingCatalogClient client = client(new FakeSharingClient())) {
+      assertThat(client.capabilities().supports(CatalogCapability.LIST_NAMESPACES)).isTrue();
+      assertThat(client.capabilities().supports(CatalogCapability.VEND_STORAGE_CREDENTIALS))
+          .isTrue();
+      assertThat(client.capabilities().supports(CatalogCapability.STABLE_OBJECT_IDS)).isTrue();
+    }
+  }
+
+  @Test
+  void rootListsSharesAndOneSegmentListsSchemas() {
+    FakeSharingClient fake = new FakeSharingClient();
+    try (DeltaSharingCatalogClient client = client(fake)) {
+      assertThat(client.listNamespaces(new NamespacePath(List.of())))
+          .containsExactly(new NamespacePath(List.of("prod")));
+      assertThat(client.listNamespaces(new NamespacePath(List.of("prod"))))
+          .containsExactly(new NamespacePath(List.of("prod", "gold")));
+    }
+  }
+
+  @Test
+  void belowSchemaIsEmptyRatherThanAnError() {
+    try (DeltaSharingCatalogClient client = client(new FakeSharingClient())) {
+      assertThat(client.listNamespaces(new NamespacePath(List.of("prod", "gold", "events"))))
+          .isEmpty();
+    }
+  }
+
+  /**
+   * A share holds schemas, not tables. The reconciler lists tables at every selected namespace
+   * before descending into it, so raising here abandoned any overlay whose include named a whole
+   * share rather than a schema within it.
+   */
+  @Test
+  void listingTablesAtAShareIsEmptyRatherThanAnError() {
+    FakeSharingClient fake = new FakeSharingClient();
+    try (DeltaSharingCatalogClient client = client(fake)) {
+      assertThat(client.listTables(new NamespacePath(List.of("prod")))).isEmpty();
+      assertThat(client.listTables(NamespacePath.root())).isEmpty();
+      assertThat(client.listTables(new NamespacePath(List.of("prod", "gold", "deeper")))).isEmpty();
+    }
+    // Empty because the level holds none, not because the upstream was asked and said so.
+    assertThat(fake.listTablesCalls).isZero();
+  }
+
+  /** Addressing a table still has to name one, so the load path keeps its shape check. */
+  @Test
+  void loadingATableOutsideShareDotSchemaIsAConfigurationError() {
+    try (DeltaSharingCatalogClient client = client(new FakeSharingClient())) {
+      assertThatThrownBy(
+              () ->
+                  client.loadTable(new CatalogObjectName(new NamespacePath(List.of("prod")), "t")))
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure ->
+                  assertThat(failure.code())
+                      .isEqualTo(CatalogAccessException.Code.INVALID_CONFIGURATION));
+    }
+  }
+
+  /**
+   * A table id is unique within its share, not across the server, so an identity built from it
+   * alone would collide between two shares carrying the same id -- which the reconciler treats as a
+   * duplicate and abandons the overlay over.
+   */
+  @Test
+  void loadTableScopesTheStableIdentityToItsShare() {
+    try (DeltaSharingCatalogClient client = client(new FakeSharingClient())) {
+      CatalogTable table = client.loadTable(events());
+      assertThat(table.identity().value()).isEqualTo("share-uuid:tbl-1");
+      assertThat(table.identity().stable()).isTrue();
+      assertThat(table.storageLocation()).contains(LOCATION);
+      assertThat(table.properties()).containsEntry("delta.sharing.access-modes", "url,dir");
+      assertThat(table.properties()).containsEntry("delta.sharing.version", "12");
+      // The reconciler accepts ICEBERG or DELTA and nothing else. The metaData action's
+      // format.provider names the data file format underneath the table, which is a different
+      // question, and is kept as a property rather than reported as the table's format.
+      assertThat(table.format()).isEqualTo("DELTA");
+      assertThat(table.properties()).containsEntry("delta.sharing.file-format", "parquet");
+    }
+  }
+
+  @Test
+  void aShareWithoutAServerIdIsNamedButNotClaimedStable() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.shareId = Optional.empty();
+    try (DeltaSharingCatalogClient client = client(fake)) {
+      CatalogTable table = client.loadTable(events());
+      // Unambiguous, because the share name still separates two shares. Not stable, because the
+      // protocol promises nothing about a share name surviving.
+      assertThat(table.identity().value()).isEqualTo("prod:tbl-1");
+      assertThat(table.identity().stable()).isFalse();
+    }
+  }
+
+  /**
+   * The metaData action's id is the underlying Delta table's, not the share entry's. A share
+   * exposing one physical table under two names reports the same value for both, and the reconciler
+   * abandons the whole overlay on a duplicate stable identity -- so the listing's id or nothing.
+   */
+  @Test
+  void aListingWithoutATableIdDoesNotBorrowThePhysicalTableId() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.tableId = Optional.empty();
+    fake.metadataId = Optional.of("physical-table-uuid");
+    try (DeltaSharingCatalogClient client = client(fake)) {
+      CatalogTable table = client.loadTable(events());
+      assertThat(table.identity().value()).isEqualTo("prod.gold.events");
+      assertThat(table.identity().stable()).isFalse();
+    }
+  }
+
+  /** Two entries on one physical table must not collide, which is what dropped the overlay. */
+  @Test
+  void twoEntriesSharingOnePhysicalTableGetDistinctIdentities() {
+    FakeSharingClient first = new FakeSharingClient();
+    first.tableId = Optional.empty();
+    first.metadataId = Optional.of("physical-table-uuid");
+    FakeSharingClient second = new FakeSharingClient();
+    second.tableId = Optional.empty();
+    second.metadataId = Optional.of("physical-table-uuid");
+    second.schemaName = "silver";
+    try (DeltaSharingCatalogClient one = client(first);
+        DeltaSharingCatalogClient two = client(second)) {
+      assertThat(one.loadTable(events()).identity().value())
+          .isNotEqualTo(
+              two.loadTable(
+                      new CatalogObjectName(new NamespacePath(List.of("prod", "silver")), "events"))
+                  .identity()
+                  .value());
+    }
+  }
+
+  @Test
+  void aTableWithNoIdAnywhereFallsBackToItsNameAndReportsThatAsUnstable() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.tableId = Optional.empty();
+    fake.metadataId = Optional.empty();
+    try (DeltaSharingCatalogClient client = client(fake)) {
+      CatalogTable table = client.loadTable(events());
+      assertThat(table.identity().value()).isEqualTo("prod.gold.events");
+      assertThat(table.identity().stable()).isFalse();
+    }
+  }
+
+  /**
+   * The property is a report of what the share said, so it must not say url when the share said
+   * nothing -- that is the reading the vend deliberately declines to apply.
+   */
+  @Test
+  void aServerStatingNoModesIsReportedAsUnstatedRatherThanUrl() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.accessModes = List.of();
+    try (DeltaSharingCatalogClient client = client(fake)) {
+      assertThat(client.loadTable(events()).properties())
+          .containsEntry("delta.sharing.access-modes", "unstated");
+    }
+  }
+
+  /** In the delta response format the metaData action states the modes, not only the listing. */
+  @Test
+  void modesStatedOnlyByTheMetadataActionAreStillReported() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.accessModes = List.of();
+    fake.metadataAccessModes = List.of(AccessMode.DIR);
+    try (DeltaSharingCatalogClient client = client(fake)) {
+      assertThat(client.loadTable(events()).properties())
+          .containsEntry("delta.sharing.access-modes", "dir");
+    }
+  }
+
+  /**
+   * The protocol wants a credential per location, root and auxiliary alike, and tells a client that
+   * cannot read from several to fall back to url access or raise. One scoped credential cannot
+   * carry the rest, so the table is refused before it can reconcile.
+   */
+  @Test
+  void aTableWithAuxiliaryLocationsIsRefusedBeforeItCanReconcile() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.auxiliaryLocations = List.of("s3://sharing/gold/events-aux");
+    try (DeltaSharingCatalogClient client = client(fake)) {
+      assertThatThrownBy(() -> client.loadTable(events()))
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure -> {
+                assertThat(failure.code()).isEqualTo(CatalogAccessException.Code.UNSUPPORTED);
+                assertThat(failure.getMessage())
+                    .contains("prod.gold.events", "auxiliary storage locations");
+              });
+    }
+  }
+
+  @Test
+  void aTableTheShareDoesNotCarryIsNotFound() {
+    try (DeltaSharingCatalogClient client = client(new FakeSharingClient())) {
+      assertThatThrownBy(() -> client.loadTable(new CatalogObjectName(schemaPath(), "not_shared")))
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure ->
+                  assertThat(failure.code()).isEqualTo(CatalogAccessException.Code.NOT_FOUND));
+    }
+  }
+
+  @Test
+  void vendingPublishesTheSessionTriadScopedToTheServersLocation() {
+    try (DeltaSharingCatalogClient client =
+        new DeltaSharingCatalogClient(new FakeSharingClient(), Map.of("s3.region", "us-east-1"))) {
+      VendedStorageCredentials vended = client.vendStorageCredentials(events()).orElseThrow();
+      assertThat(vended.properties())
+          .containsEntry("s3.access-key-id", "AKIA")
+          .containsEntry("s3.secret-access-key", "secret")
+          .containsEntry("s3.session-token", "session")
+          .containsEntry("s3.region", "us-east-1");
+      assertThat(vended.scopePrefix()).isEqualTo(LOCATION);
+      assertThat(vended.expiresAt()).isPresent();
+    }
+  }
+
+  @Test
+  void aUrlOnlyTableIsRefusedByNameRatherThanVendingNothing() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.accessModes = List.of(AccessMode.URL);
+    try (DeltaSharingCatalogClient client = client(fake)) {
+      assertThatThrownBy(() -> client.vendStorageCredentials(events()))
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure -> {
+                assertThat(failure.code()).isEqualTo(CatalogAccessException.Code.UNSUPPORTED);
+                assertThat(failure.getMessage()).contains("prod.gold.events", "url access only");
+              });
+    }
+  }
+
+  /**
+   * A server that states nothing is asked rather than refused.
+   *
+   * <p>The protocol reads an absent field as url only. The reference implementation vends through
+   * {@code temporary-table-credentials} while never sending the field at all, so holding to that
+   * reading refuses every table on a server that would have answered.
+   */
+  @Test
+  void aServerThatStatesNoAccessModesIsAskedRatherThanRefused() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.accessModes = List.of();
+    try (DeltaSharingCatalogClient client = client(fake)) {
+      VendedStorageCredentials vended = client.vendStorageCredentials(events()).orElseThrow();
+      assertThat(vended.scopePrefix()).isEqualTo(LOCATION);
+    }
+  }
+
+  @Test
+  void theStrictSettingReadsAnUnstatedTableAsUrlOnlyWithoutAsking() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.accessModes = List.of();
+    fake.credentialFailure = DeltaSharingException.Failure.SERVER_ERROR;
+    try (DeltaSharingCatalogClient client = new DeltaSharingCatalogClient(fake, Map.of(), true)) {
+      assertThatThrownBy(() -> client.vendStorageCredentials(events()))
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure -> {
+                assertThat(failure.code()).isEqualTo(CatalogAccessException.Code.UNSUPPORTED);
+                assertThat(failure.getMessage())
+                    .contains("delta.sharing.strict-access-modes", "prod.gold.events");
+              });
+    }
+  }
+
+  @Test
+  void theStrictSettingStillVendsForATableThatStatesDirectoryAccess() {
+    FakeSharingClient fake = new FakeSharingClient();
+    try (DeltaSharingCatalogClient client = new DeltaSharingCatalogClient(fake, Map.of(), true)) {
+      assertThat(client.vendStorageCredentials(events())).isPresent();
+    }
+  }
+
+  @Test
+  void aServerWithoutTheCredentialEndpointIsReportedAsUnsupportedNotMissing() {
+    for (DeltaSharingException.Failure refusal :
+        List.of(
+            DeltaSharingException.Failure.NOT_FOUND,
+            DeltaSharingException.Failure.INVALID_REQUEST)) {
+      FakeSharingClient fake = new FakeSharingClient();
+      fake.accessModes = List.of();
+      fake.credentialFailure = refusal;
+      // The status the protocol defines for each: 404 for a server without the endpoint, 400 for
+      // its refusal of a table that does not offer directory access.
+      fake.credentialStatus = refusal == DeltaSharingException.Failure.NOT_FOUND ? 404 : 400;
+      try (DeltaSharingCatalogClient client = client(fake)) {
+        assertThatThrownBy(() -> client.vendStorageCredentials(events()))
+            .describedAs("%s", refusal)
+            .isInstanceOfSatisfying(
+                CatalogAccessException.class,
+                failure -> {
+                  assertThat(failure.code()).isEqualTo(CatalogAccessException.Code.UNSUPPORTED);
+                  assertThat(failure.getMessage()).contains("prod.gold.events");
+                });
+      }
+    }
+  }
+
+  @Test
+  void askingDoesNotTurnARejectedTokenIntoAnUnsupportedTable() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.accessModes = List.of();
+    fake.credentialFailure = DeltaSharingException.Failure.UNAUTHENTICATED;
+    try (DeltaSharingCatalogClient client = client(fake)) {
+      assertThatThrownBy(() -> client.vendStorageCredentials(events()))
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure ->
+                  assertThat(failure.code())
+                      .isEqualTo(CatalogAccessException.Code.UNAUTHENTICATED));
+    }
+  }
+
+  @Test
+  void aTableThatStatesUrlOnlyIsRefusedEvenWithoutTheStrictSetting() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.accessModes = List.of(AccessMode.URL);
+    fake.credentialFailure = DeltaSharingException.Failure.SERVER_ERROR;
+    try (DeltaSharingCatalogClient client = client(fake)) {
+      assertThatThrownBy(() -> client.vendStorageCredentials(events()))
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure ->
+                  assertThat(failure.code()).isEqualTo(CatalogAccessException.Code.UNSUPPORTED));
+    }
+  }
+
+  @Test
+  void aListingWithoutALocationFallsBackToTheMetadataEndpoint() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.listedLocation = Optional.empty();
+    RecordingProbe probe = new RecordingProbe();
+    try (DeltaSharingCatalogClient client =
+        new DeltaSharingCatalogClient(fake, Map.of(), false, probe)) {
+      client.validateStorageAccess(
+          events(),
+          new VendedStorageCredentials(
+              Map.of("s3.access-key-id", "AKIA"), "s3://sharing/gold", Optional.empty()));
+    }
+    assertThat(probe.location).isEqualTo(LOCATION);
+  }
+
+  @Test
+  void aNonAwsCredentialIsRefusedByCloud() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.credentials =
+        new TemporaryCredentials(
+            CredentialCloud.AZURE,
+            LOCATION,
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty());
+    try (DeltaSharingCatalogClient client = client(fake)) {
+      assertThatThrownBy(() -> client.vendStorageCredentials(events()))
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure -> {
+                assertThat(failure.code()).isEqualTo(CatalogAccessException.Code.UNSUPPORTED);
+                assertThat(failure.getMessage()).contains("AZURE");
+              });
+    }
+  }
+
+  @Test
+  void validateStorageAccessProbesTheTableItWasAskedAbout() {
+    RecordingProbe probe = new RecordingProbe();
+    VendedStorageCredentials credentials =
+        new VendedStorageCredentials(
+            Map.of("s3.access-key-id", "AKIA"), "s3://sharing/gold", Optional.empty());
+    try (DeltaSharingCatalogClient client =
+        new DeltaSharingCatalogClient(new FakeSharingClient(), Map.of(), false, probe)) {
+      client.validateStorageAccess(events(), credentials);
+    }
+    assertThat(probe.location).isEqualTo(LOCATION);
+    assertThat(probe.credentials).isSameAs(credentials);
+  }
+
+  /** Scope answers without a network call, so a credential scoped elsewhere never reaches it. */
+  @Test
+  void aCredentialScopedElsewhereIsRefusedBeforeTheProbeRuns() {
+    RecordingProbe probe = new RecordingProbe();
+    try (DeltaSharingCatalogClient client =
+        new DeltaSharingCatalogClient(new FakeSharingClient(), Map.of(), false, probe)) {
+      assertThatThrownBy(
+              () ->
+                  client.validateStorageAccess(
+                      events(),
+                      new VendedStorageCredentials(
+                          Map.of("s3.access-key-id", "AKIA"), "s3://other/gold", Optional.empty())))
+          .isInstanceOf(CatalogAccessException.class);
+    }
+    assertThat(probe.location).isNull();
+  }
+
+  @Test
+  void validateStorageAccessRejectsACredentialScopedElsewhere() {
+    try (DeltaSharingCatalogClient client = client(new FakeSharingClient())) {
+      assertThatThrownBy(
+              () ->
+                  client.validateStorageAccess(
+                      events(),
+                      new VendedStorageCredentials(
+                          Map.of("s3.access-key-id", "AKIA"), "s3://other/gold", Optional.empty())))
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure ->
+                  assertThat(failure.code())
+                      .isEqualTo(CatalogAccessException.Code.CREDENTIAL_SCOPE_INVALID));
+    }
+  }
+
+  @Test
+  void validateProvesTheEndpointAndTokenByListingShares() {
+    FakeSharingClient fake = new FakeSharingClient();
+    try (DeltaSharingCatalogClient client = client(fake)) {
+      client.validate();
+      assertThat(fake.listSharesCalls).isEqualTo(1);
+    }
+  }
+
+  @Test
+  void aRejectedTokenStaysTerminalAndAServerErrorStaysRetryable() {
+    FakeSharingClient rejected = new FakeSharingClient();
+    rejected.failure = DeltaSharingException.Failure.UNAUTHENTICATED;
+    try (DeltaSharingCatalogClient client = client(rejected)) {
+      assertThatThrownBy(client::validate)
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure ->
+                  assertThat(failure.code())
+                      .isEqualTo(CatalogAccessException.Code.UNAUTHENTICATED));
+    }
+
+    FakeSharingClient down = new FakeSharingClient();
+    down.failure = DeltaSharingException.Failure.SERVER_ERROR;
+    try (DeltaSharingCatalogClient client = client(down)) {
+      assertThatThrownBy(client::validate)
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure ->
+                  assertThat(failure.code()).isEqualTo(CatalogAccessException.Code.UNAVAILABLE));
+    }
+  }
+
+  @Test
+  void viewsAreEmptyAndLoadingOneIsUnsupported() {
+    try (DeltaSharingCatalogClient client = client(new FakeSharingClient())) {
+      assertThat(client.listViews(schemaPath())).isEmpty();
+      assertThatThrownBy(() -> client.loadView(events()))
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure ->
+                  assertThat(failure.code()).isEqualTo(CatalogAccessException.Code.UNSUPPORTED));
+    }
+  }
+
+  @Test
+  void closingTheCatalogClientClosesTheRecipient() {
+    FakeSharingClient fake = new FakeSharingClient();
+    client(fake).close();
+    assertThat(fake.closed).isTrue();
+  }
+
+  private static DeltaSharingCatalogClient client(DeltaSharingClient sharing) {
+    return new DeltaSharingCatalogClient(sharing, Map.of());
+  }
+
+  private static NamespacePath schemaPath() {
+    return new NamespacePath(List.of("prod", "gold"));
+  }
+
+  private static CatalogObjectName events() {
+    return new CatalogObjectName(schemaPath(), "events");
+  }
+
+  /** Records what the storage probe was asked, instead of reaching an object store. */
+  private static final class RecordingProbe implements DeltaLogStorageProbe {
+    private String location;
+    private VendedStorageCredentials credentials;
+
+    @Override
+    public void validate(String tableLocation, VendedStorageCredentials vended) {
+      this.location = tableLocation;
+      this.credentials = vended;
+    }
+  }
+
+  /**
+   * A credential is vended on every storage-authority resolve, so listing the schema to find one
+   * table paged the whole schema before every credential POST -- unbounded in the schema's table
+   * count, and quadratic across a reconcile.
+   */
+  @Test
+  void vendingDoesNotListTheSchema() {
+    FakeSharingClient fake = new FakeSharingClient();
+    try (DeltaSharingCatalogClient client = client(fake)) {
+      client.vendStorageCredentials(events());
+    }
+    assertThat(fake.listTablesCalls).isZero();
+  }
+
+  @Test
+  void validatingStorageAccessDoesNotListTheSchema() {
+    FakeSharingClient fake = new FakeSharingClient();
+    try (DeltaSharingCatalogClient client =
+        new DeltaSharingCatalogClient(fake, Map.of(), false, new RecordingProbe())) {
+      client.validateStorageAccess(
+          events(),
+          new VendedStorageCredentials(
+              Map.of("s3.access-key-id", "AKIA"), "s3://sharing/gold", Optional.empty()));
+    }
+    assertThat(fake.listTablesCalls).isZero();
+  }
+
+  /**
+   * UNSUPPORTED now means the provider will never do this, which the service acts on by skipping
+   * the table and reporting a vending-unsupported issue. An unclassified upstream status is a real
+   * problem instead, and must not be reported as a capability boundary.
+   */
+  @Test
+  void anUnclassifiedUpstreamStatusIsNotReportedAsUnsupported() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.credentialFailure = DeltaSharingException.Failure.OTHER;
+    try (DeltaSharingCatalogClient client = client(fake)) {
+      assertThatThrownBy(() -> client.vendStorageCredentials(events()))
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure ->
+                  assertThat(failure.code()).isEqualTo(CatalogAccessException.Code.UNAVAILABLE));
+    }
+  }
+
+  /**
+   * The reconciler lists a schema once and then loads every table in it. Looking each one up by
+   * paging the listing again made that pass quadratic in the schema's table count.
+   */
+  @Test
+  void loadingSeveralTablesListsTheSchemaOnce() {
+    FakeSharingClient fake = new FakeSharingClient();
+    try (DeltaSharingCatalogClient client = client(fake)) {
+      client.loadTable(events());
+      client.loadTable(events());
+      client.loadTable(events());
+    }
+    assertThat(fake.listTablesCalls).isEqualTo(1);
+  }
+
+  /**
+   * Either place may state the modes and neither is required to. Strict mode refuses without asking
+   * the server, so refusing on the metadata action alone would reject a table the share had marked
+   * directory-accessible in its listing.
+   */
+  @Test
+  void theStrictSettingConsultsTheListingBeforeRefusing() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.accessModes = List.of(AccessMode.DIR);
+    fake.metadataAccessModes = List.of();
+    try (DeltaSharingCatalogClient client =
+        new DeltaSharingCatalogClient(fake, Map.of(), true, new RecordingProbe())) {
+      assertThat(client.vendStorageCredentials(events())).isPresent();
+    }
+  }
+
+  /**
+   * The runtime path never reaches validateStorageAccess, so a credential scoped somewhere
+   * unrelated would otherwise be published on every storage-authority resolve.
+   */
+  @Test
+  void aCredentialScopedOutsideTheTableIsRefusedByTheVend() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.credentials =
+        new TemporaryCredentials(
+            CredentialCloud.AWS,
+            "s3://somewhere-else/entirely",
+            Optional.of("AKIA"),
+            Optional.of("secret"),
+            Optional.of("session"),
+            Optional.of(Instant.parse("2026-01-01T00:00:00Z")));
+    try (DeltaSharingCatalogClient client = client(fake)) {
+      assertThatThrownBy(() -> client.vendStorageCredentials(events()))
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure ->
+                  assertThat(failure.code())
+                      .isEqualTo(CatalogAccessException.Code.CREDENTIAL_SCOPE_INVALID));
+    }
+  }
+
+  /** The listing states a location too, so a share using only that is not unvalidatable. */
+  @Test
+  void storageValidationFallsBackToTheListingLocation() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.metadataLocation = Optional.empty();
+    RecordingProbe probe = new RecordingProbe();
+    try (DeltaSharingCatalogClient client =
+        new DeltaSharingCatalogClient(fake, Map.of(), false, probe)) {
+      client.validateStorageAccess(
+          events(),
+          new VendedStorageCredentials(
+              Map.of("s3.access-key-id", "AKIA"), "s3://sharing/gold", Optional.empty()));
+    }
+    assertThat(probe.location).isEqualTo(LOCATION);
+  }
+
+  /**
+   * A body this client cannot read describes the catalog, not one table in it.
+   * INVALID_CONFIGURATION is per-branch, so a reconcile would record every table as unobserved and
+   * leave a broken share looking partially healthy.
+   */
+  @Test
+  void anUnreadableResponseIsNotAPerBranchFailure() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.failure = DeltaSharingException.Failure.INVALID_RESPONSE;
+    try (DeltaSharingCatalogClient client = client(fake)) {
+      assertThatThrownBy(client::validate)
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure -> {
+                assertThat(failure.code()).isEqualTo(CatalogAccessException.Code.INTERNAL);
+                assertThat(CatalogTraversalFailures.describesOneBranch(failure)).isFalse();
+              });
+    }
+  }
+
+  /**
+   * A share root, a bucket, an external-location prefix: broader than the table and left alone.
+   * StorageLocations states the rule -- never be stricter than the component that will use the
+   * credential, because this path is reached only once no storage authority matched, so refusing
+   * fails a read the catalog's own client would have attempted.
+   */
+  @Test
+  void aCredentialScopedAboveTheTableIsPublished() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.credentials =
+        new TemporaryCredentials(
+            CredentialCloud.AWS,
+            "s3://sharing",
+            Optional.of("AKIA"),
+            Optional.of("secret"),
+            Optional.of("session"),
+            Optional.of(Instant.parse("2026-01-01T00:00:00Z")));
+    try (DeltaSharingCatalogClient client = client(fake)) {
+      assertThat(client.vendStorageCredentials(events()).orElseThrow().scopePrefix())
+          .isEqualTo("s3://sharing");
+    }
+  }
+
+  /** An id carrying the delimiter must not collide with a different pair of components. */
+  @Test
+  void identityComponentsAreEscapedSoThePairCannotCollide() {
+    FakeSharingClient first = new FakeSharingClient();
+    first.shareId = Optional.of("a:b");
+    first.tableId = Optional.of("c");
+    first.metadataId = Optional.of("c");
+    FakeSharingClient second = new FakeSharingClient();
+    second.shareId = Optional.of("a");
+    second.tableId = Optional.of("b:c");
+    second.metadataId = Optional.of("b:c");
+    try (DeltaSharingCatalogClient one = client(first);
+        DeltaSharingCatalogClient two = client(second)) {
+      assertThat(one.loadTable(events()).identity().value())
+          .isNotEqualTo(two.loadTable(events()).identity().value());
+    }
+  }
+
+  /**
+   * The reconciler lists a schema and then loads every table in it; that is one listing, not two.
+   */
+  @Test
+  void listingThenLoadingPagesTheSchemaOnce() {
+    FakeSharingClient fake = new FakeSharingClient();
+    try (DeltaSharingCatalogClient client = client(fake)) {
+      client.listTables(schemaPath());
+      client.loadTable(events());
+    }
+    assertThat(fake.listTablesCalls).isEqualTo(1);
+  }
+
+  /**
+   * The protocol states auxiliary locations on the listing as well as the metadata action, and says
+   * a client that cannot read one should fall back to url access or fail the request.
+   */
+  @Test
+  void auxiliaryLocationsStatedOnlyByTheListingAlsoRefuseTheLoad() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.listedAuxiliaryLocations = List.of("s3://sharing/gold/events-aux");
+    try (DeltaSharingCatalogClient client = client(fake)) {
+      assertThatThrownBy(() -> client.loadTable(events()))
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure -> {
+                assertThat(failure.code()).isEqualTo(CatalogAccessException.Code.UNSUPPORTED);
+                assertThat(failure.getMessage()).contains("auxiliary storage locations");
+              });
+    }
+  }
+
+  /**
+   * The reference implementation names a location on neither its listing nor its metadata action,
+   * only on the credential response. Reconciling without one stores no storage location and falls
+   * back to the Integration's HTTPS catalog URI, so the table materializes and cannot be opened.
+   */
+  @Test
+  void aLocationStatedOnlyByTheCredentialResponseStillReachesTheTable() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.listedLocation = Optional.empty();
+    fake.metadataLocation = Optional.empty();
+    fake.accessModes = List.of();
+    try (DeltaSharingCatalogClient client = client(fake)) {
+      assertThat(client.loadTable(events()).storageLocation()).contains(LOCATION);
+    }
+  }
+
+  /**
+   * A url-only table is refused at the load, not left to fail at read time. Materializing it stores
+   * no storage location and leaves the share's own HTTPS endpoint as the upstream reference, which
+   * is the unreadable shape the location work exists to prevent -- so the two cases are refused the
+   * same way rather than one of each.
+   */
+  @Test
+  void aUrlOnlyTableIsRefusedAtTheLoadWithoutBeingAsked() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.accessModes = List.of(AccessMode.URL);
+    try (DeltaSharingCatalogClient client = client(fake)) {
+      assertThatThrownBy(() -> client.loadTable(events()))
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure -> {
+                assertThat(failure.code()).isEqualTo(CatalogAccessException.Code.UNSUPPORTED);
+                assertThat(failure.getMessage()).contains("url access only");
+              });
+    }
+    assertThat(fake.credentialCalls).isZero();
+  }
+
+  /**
+   * The load and the vend answer the same question the same way. The strict refusal sat below the
+   * early return on a stated location, so a table with no stated modes whose listing named a
+   * location loaded, and then the vend refused it on the rule the load had skipped: it reconciled
+   * and every read of it failed. Knowing where a table lives says nothing about whether it may be
+   * read that way.
+   */
+  @Test
+  void strictModeRefusesAnUnstatedTableAtBothPathsEvenWhenTheListingNamesALocation() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.accessModes = List.of();
+    fake.listedLocation = Optional.of(LOCATION);
+    fake.metadataLocation = Optional.empty();
+    try (DeltaSharingCatalogClient client =
+        new DeltaSharingCatalogClient(fake, Map.of(), true, new RecordingProbe())) {
+      assertThatThrownBy(() -> client.loadTable(events()))
+          .as("load")
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure -> {
+                assertThat(failure.code()).isEqualTo(CatalogAccessException.Code.UNSUPPORTED);
+                assertThat(failure.getMessage())
+                    .contains(DeltaSharingCatalogClient.STRICT_ACCESS_MODES);
+              });
+      assertThatThrownBy(() -> client.vendStorageCredentials(events()))
+          .as("vend")
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure ->
+                  assertThat(failure.code()).isEqualTo(CatalogAccessException.Code.UNSUPPORTED));
+    }
+    assertThat(fake.credentialCalls).isZero();
+  }
+
+  /**
+   * One location, whichever path asks. The load preferred the listing while validation and the vend
+   * read the metaData action, so a server stating a location on both surfaces that differ had the
+   * table reconciling at one, being probed at another, and having the credential's scope compared
+   * against that other -- a passing storage-access check saying nothing about where a read would
+   * go. All three agree on the metaData action, because the vend cannot see a listing without
+   * paging the schema on every read.
+   */
+  @Test
+  void allThreePathsResolveTheSameLocationWhenTheSurfacesDisagree() {
+    String listingLocation = "s3://sharing/gold/from-listing";
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.accessModes = List.of(AccessMode.DIR);
+    fake.listedLocation = Optional.of(listingLocation);
+    fake.metadataLocation = Optional.of(LOCATION);
+    RecordingProbe probe = new RecordingProbe();
+    try (DeltaSharingCatalogClient client =
+        new DeltaSharingCatalogClient(fake, Map.of(), false, probe)) {
+      assertThat(client.loadTable(events()).storageLocation()).as("load").contains(LOCATION);
+      assertThat(client.vendStorageCredentials(events()))
+          .as("vend")
+          .get()
+          .extracting(VendedStorageCredentials::scopePrefix)
+          .isEqualTo(LOCATION);
+      client.validateStorageAccess(
+          events(),
+          new VendedStorageCredentials(
+              Map.of("s3.access-key-id", "AKIA"), LOCATION, Optional.empty()));
+    }
+    assertThat(probe.location).as("probed").isEqualTo(LOCATION);
+  }
+
+  /**
+   * The last surface pairing where the two paths disagreed, and it ran the wrong way. statedModes
+   * prefers the listing, so a table stating dir only there took the load's early return without
+   * asking, while the vend -- which reads the metaData action alone -- saw nothing stated, treated
+   * the table as ambiguous and asked. A server advertising dir on its listing and then refusing the
+   * credential endpoint reconciled and failed every read.
+   */
+  @Test
+  void aDirStatedOnlyOnTheListingIsStillAskedAboutAtTheLoad() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.accessModes = List.of(AccessMode.DIR);
+    fake.metadataAccessModes = List.of();
+    fake.listedLocation = Optional.of(LOCATION);
+    fake.metadataLocation = Optional.of(LOCATION);
+    fake.credentialFailure = DeltaSharingException.Failure.INVALID_REQUEST;
+    fake.credentialStatus = 400;
+    try (DeltaSharingCatalogClient client =
+        new DeltaSharingCatalogClient(fake, Map.of(), false, new RecordingProbe())) {
+      assertThatThrownBy(() -> client.loadTable(events()))
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure ->
+                  assertThat(failure.code()).isEqualTo(CatalogAccessException.Code.UNSUPPORTED));
+    }
+    assertThat(fake.credentialCalls).isPositive();
+  }
+
+  /**
+   * A dir the metaData action does state is trusted, and no request is spent on it. Both paths
+   * agree on that, which is the property that matters; a server contradicting its own metaData is a
+   * different problem from one that left the question open.
+   */
+  @Test
+  void aDirStatedOnTheMetadataActionCostsNoCredentialCallAtTheLoad() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.accessModes = List.of(AccessMode.DIR);
+    fake.metadataAccessModes = List.of(AccessMode.DIR);
+    try (DeltaSharingCatalogClient client =
+        new DeltaSharingCatalogClient(fake, Map.of(), false, new RecordingProbe())) {
+      assertThat(client.loadTable(events()).storageLocation()).contains(LOCATION);
+    }
+    assertThat(fake.credentialCalls).isZero();
+  }
+
+  /**
+   * The location that reconciles has to be one the read path can parse. Encoding the space only
+   * inside the probe was half a fix: the raw string was still what got published, so the table
+   * materialised as {@code s3://.../my table} and every scan threw on {@code URI.create} after
+   * validation had passed. The read path derives its key with {@code URI.getPath}, which decodes,
+   * so the encoded form asks S3 for the key that was written.
+   */
+  @Test
+  void aLocationWithASpaceIsPublishedInAFormTheReadPathCanParse() {
+    String raw = "s3://sharing/gold/my table";
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.accessModes = List.of(AccessMode.DIR);
+    fake.listedLocation = Optional.of(raw);
+    fake.metadataLocation = Optional.of(raw);
+    fake.credentials =
+        new TemporaryCredentials(
+            CredentialCloud.AWS,
+            raw,
+            Optional.of("AKIA"),
+            Optional.of("secret"),
+            Optional.of("session"),
+            Optional.of(Instant.parse("2026-01-01T00:00:00Z")));
+    RecordingProbe probe = new RecordingProbe();
+    try (DeltaSharingCatalogClient client =
+        new DeltaSharingCatalogClient(fake, Map.of(), false, probe)) {
+      String published = client.loadTable(events()).storageLocation().orElseThrow();
+      assertThat(published).isEqualTo("s3://sharing/gold/my%20table");
+      assertThatCode(() -> URI.create(published)).doesNotThrowAnyException();
+      assertThat(URI.create(published).getPath()).isEqualTo("/gold/my table");
+
+      // And the vend publishes the same form, so covers() compares like with like.
+      assertThat(client.vendStorageCredentials(events()))
+          .get()
+          .extracting(VendedStorageCredentials::scopePrefix)
+          .isEqualTo("s3://sharing/gold/my%20table");
+    }
+  }
+
+  /**
+   * Only 400 is the protocol's own refusal. The transport folds 400, 405 and 422 into one failure,
+   * so a GET-only proxy answering 405 was read as every table lacking directory access while the
+   * real fault went unnamed. Both stay a per-table skip; what changes is what the operator is told.
+   */
+  @Test
+  void aMethodNotAllowedIsNotReadAsMissingDirectoryAccess() {
+    for (int status : List.of(405, 422)) {
+      FakeSharingClient fake = new FakeSharingClient();
+      fake.accessModes = List.of(AccessMode.DIR);
+      fake.credentialFailure = DeltaSharingException.Failure.INVALID_REQUEST;
+      fake.credentialStatus = status;
+      try (DeltaSharingCatalogClient client =
+          new DeltaSharingCatalogClient(fake, Map.of(), false, new RecordingProbe())) {
+        assertThatThrownBy(() -> client.vendStorageCredentials(events()))
+            .describedAs("%s", status)
+            .isInstanceOfSatisfying(
+                CatalogAccessException.class,
+                failure ->
+                    assertThat(failure.code())
+                        .isNotEqualTo(CatalogAccessException.Code.UNSUPPORTED));
+      }
+    }
+  }
+
+  /**
+   * Under the strict setting the vend falls back to the listing, so the load consults it too. Both
+   * surfaces are already in hand, so this costs no request -- it stops the knob from spending a
+   * credential POST per table against a server stating its modes where the protocol defines them.
+   */
+  @Test
+  void strictModeTrustsADirStatedOnTheListingWithoutAsking() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.accessModes = List.of(AccessMode.DIR);
+    fake.metadataAccessModes = List.of();
+    fake.listedLocation = Optional.of(LOCATION);
+    try (DeltaSharingCatalogClient client =
+        new DeltaSharingCatalogClient(fake, Map.of(), true, new RecordingProbe())) {
+      assertThat(client.loadTable(events()).storageLocation()).contains(LOCATION);
+    }
+    assertThat(fake.credentialCalls).isZero();
+  }
+
+  /**
+   * The scope the vend publishes is checked the way the load checks a location. requireServable ran
+   * only at the load, so on the reference-server shape -- no location on the metaData action, so
+   * the coverage check is skipped -- whatever the credential endpoint returned was published
+   * unexamined, and a table reconciled from an earlier good credential could start receiving a
+   * tuple scoped somewhere this provider cannot read.
+   */
+  @Test
+  void theVendRefusesACredentialScopedSomewhereItCannotRead() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.accessModes = List.of(AccessMode.DIR);
+    fake.metadataLocation = Optional.empty();
+    fake.listedLocation = Optional.empty();
+    fake.credentials =
+        new TemporaryCredentials(
+            CredentialCloud.AWS,
+            "gs://elsewhere/table",
+            Optional.of("AKIA"),
+            Optional.of("secret"),
+            Optional.of("session"),
+            Optional.of(Instant.parse("2026-01-01T00:00:00Z")));
+    try (DeltaSharingCatalogClient client =
+        new DeltaSharingCatalogClient(fake, Map.of(), false, new RecordingProbe())) {
+      assertThatThrownBy(() -> client.vendStorageCredentials(events()))
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure -> {
+                assertThat(failure.code()).isEqualTo(CatalogAccessException.Code.UNSUPPORTED);
+                assertThat(failure.getMessage()).contains("gs");
+              });
+    }
+  }
+
+  /**
+   * The vend says the same thing the load does. Validation's sampler sends names straight from
+   * listTables to vendStorageCredentials without loading them, so for a table stating only modes
+   * this client does not know, this is the message an operator running a validation actually sees.
+   */
+  @Test
+  void theVendAlsoNamesUnrecognisedModesRatherThanClaimingUrlAccess() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.accessModes = List.of(AccessMode.OTHER);
+    fake.metadataAccessModes = List.of(AccessMode.OTHER);
+    try (DeltaSharingCatalogClient client =
+        new DeltaSharingCatalogClient(fake, Map.of(), false, new RecordingProbe())) {
+      assertThatThrownBy(() -> client.vendStorageCredentials(events()))
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure -> {
+                assertThat(failure.code()).isEqualTo(CatalogAccessException.Code.UNSUPPORTED);
+                assertThat(failure.getMessage()).contains("does not recognise");
+                assertThat(failure.getMessage()).doesNotContain("url access only");
+              });
+    }
+  }
+
+  /**
+   * And a table stating only modes this client does not recognise is refused for that, not told it
+   * offers url access.
+   */
+  @Test
+  void aTableStatingOnlyUnrecognisedModesSaysSo() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.accessModes = List.of(AccessMode.OTHER);
+    fake.metadataAccessModes = List.of(AccessMode.OTHER);
+    try (DeltaSharingCatalogClient client =
+        new DeltaSharingCatalogClient(fake, Map.of(), false, new RecordingProbe())) {
+      assertThatThrownBy(() -> client.loadTable(events()))
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure -> {
+                assertThat(failure.code()).isEqualTo(CatalogAccessException.Code.UNSUPPORTED);
+                assertThat(failure.getMessage()).contains("does not recognise");
+              });
+    }
+  }
+
+  /**
+   * A redirect is a wrong base URI, not a table without directory access. The transport folds a
+   * refused 3xx into INVALID_REQUEST, which this path read as the protocol's per-table refusal, so
+   * an auth proxy in front of the server reported every table as offering no directory access -- a
+   * configuration error arriving table by table as a capability limit, leaving the integration
+   * looking partly healthy instead of misconfigured.
+   */
+  @Test
+  void aRedirectOnTheCredentialEndpointIsNotReadAsMissingDirectoryAccess() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.accessModes = List.of(AccessMode.DIR);
+    fake.credentialFailure = DeltaSharingException.Failure.INVALID_REQUEST;
+    fake.credentialStatus = 302;
+    try (DeltaSharingCatalogClient client =
+        new DeltaSharingCatalogClient(fake, Map.of(), false, new RecordingProbe())) {
+      assertThatThrownBy(() -> client.vendStorageCredentials(events()))
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure ->
+                  assertThat(failure.code()).isNotEqualTo(CatalogAccessException.Code.UNSUPPORTED));
+    }
+  }
+
+  /** A 400 is still the protocol's own per-table refusal, which is what UNSUPPORTED is for. */
+  @Test
+  void aBadRequestOnTheCredentialEndpointIsStillATableRefusal() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.accessModes = List.of(AccessMode.DIR);
+    fake.credentialFailure = DeltaSharingException.Failure.INVALID_REQUEST;
+    fake.credentialStatus = 400;
+    try (DeltaSharingCatalogClient client =
+        new DeltaSharingCatalogClient(fake, Map.of(), false, new RecordingProbe())) {
+      assertThatThrownBy(() -> client.vendStorageCredentials(events()))
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure ->
+                  assertThat(failure.code()).isEqualTo(CatalogAccessException.Code.UNSUPPORTED));
+    }
+  }
+
+  /**
+   * The two surfaces disagreeing is refused, not resolved in the load's favour. statedModes prefers
+   * the listing and the vend reads the metaData action alone, so a server saying dir on one and url
+   * on the other reconciled here and was refused on every read for the life of the table. Whichever
+   * surface refuses, the load has to be no more permissive than the vend.
+   */
+  @Test
+  void surfacesDisagreeingAboutAccessModesAreRefusedAtBothPaths() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.accessModes = List.of(AccessMode.DIR);
+    fake.metadataAccessModes = List.of(AccessMode.URL);
+    try (DeltaSharingCatalogClient client =
+        new DeltaSharingCatalogClient(fake, Map.of(), false, new RecordingProbe())) {
+      assertThatThrownBy(() -> client.loadTable(events()))
+          .as("load")
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure -> {
+                assertThat(failure.code()).isEqualTo(CatalogAccessException.Code.UNSUPPORTED);
+                assertThat(failure.getMessage()).contains("url access only");
+              });
+      assertThatThrownBy(() -> client.vendStorageCredentials(events()))
+          .as("vend")
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure ->
+                  assertThat(failure.code()).isEqualTo(CatalogAccessException.Code.UNSUPPORTED));
+    }
+  }
+
+  /**
+   * A location does not establish directory access. The protocol lets a url-only server state one,
+   * so a legacy server that omits its access modes, names a location and refuses the credential
+   * endpoint has to be refused at the load -- the early return on a stated location was skipping
+   * the request the default setting exists to make, and the table reconciled with every read of it
+   * failing.
+   */
+  @Test
+  void anUnstatedTableIsAskedAboutEvenWhenTheListingNamesALocation() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.accessModes = List.of();
+    fake.metadataAccessModes = List.of();
+    fake.listedLocation = Optional.of(LOCATION);
+    fake.credentialFailure = DeltaSharingException.Failure.INVALID_REQUEST;
+    fake.credentialStatus = 400;
+    try (DeltaSharingCatalogClient client =
+        new DeltaSharingCatalogClient(fake, Map.of(), false, new RecordingProbe())) {
+      assertThatThrownBy(() -> client.loadTable(events()))
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure ->
+                  assertThat(failure.code()).isEqualTo(CatalogAccessException.Code.UNSUPPORTED));
+    }
+    assertThat(fake.credentialCalls).isPositive();
+  }
+
+  /**
+   * The same shape with a server that does vend: the ask is what establishes directory access, and
+   * the location a surface stated is still what the table reconciles with rather than the scope the
+   * credential happened to name.
+   */
+  @Test
+  void anUnstatedTableThatVendsKeepsTheLocationItsListingStated() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.accessModes = List.of();
+    fake.metadataAccessModes = List.of();
+    fake.listedLocation = Optional.of(LOCATION);
+    fake.metadataLocation = Optional.empty();
+    try (DeltaSharingCatalogClient client =
+        new DeltaSharingCatalogClient(fake, Map.of(), false, new RecordingProbe())) {
+      assertThat(client.loadTable(events()).storageLocation()).contains(LOCATION);
+    }
+    assertThat(fake.credentialCalls).isPositive();
+  }
+
+  /**
+   * Strict mode refuses without asking, which is the point of it. Asking for a location would be
+   * the round trip the knob turns off, and answering would reconcile a table whose every vend then
+   * fails -- a configuration choice turned into a runtime failure.
+   */
+  @Test
+  void strictModeRefusesAnUnstatedTableAtTheLoadWithoutAsking() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.accessModes = List.of();
+    fake.listedLocation = Optional.empty();
+    fake.metadataLocation = Optional.empty();
+    try (DeltaSharingCatalogClient client =
+        new DeltaSharingCatalogClient(fake, Map.of(), true, new RecordingProbe())) {
+      assertThatThrownBy(() -> client.loadTable(events()))
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure -> {
+                assertThat(failure.code()).isEqualTo(CatalogAccessException.Code.UNSUPPORTED);
+                assertThat(failure.getMessage())
+                    .contains(DeltaSharingCatalogClient.STRICT_ACCESS_MODES);
+              });
+    }
+    assertThat(fake.credentialCalls).isZero();
+  }
+
+  /**
+   * The reference-server shape again: neither surface states a location, so validation has only the
+   * scope the credential itself named. Without that it refused every table before attempting a
+   * read, on exactly the servers the ask default exists to support.
+   */
+  @Test
+  void storageValidationFallsBackToTheVendedScopeWhenNoSurfaceStatesALocation() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.listedLocation = Optional.empty();
+    fake.metadataLocation = Optional.empty();
+    RecordingProbe probe = new RecordingProbe();
+    try (DeltaSharingCatalogClient client =
+        new DeltaSharingCatalogClient(fake, Map.of(), false, probe)) {
+      client.validateStorageAccess(
+          events(),
+          new VendedStorageCredentials(
+              Map.of("s3.access-key-id", "AKIA"), LOCATION, Optional.empty()));
+    }
+    assertThat(probe.location).isEqualTo(LOCATION);
+  }
+
+  /** Better a named refusal than a table that materializes and cannot be opened. */
+  @Test
+  void aTableWhoseLocationNoSurfaceStatesIsRefused() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.listedLocation = Optional.empty();
+    fake.metadataLocation = Optional.empty();
+    fake.accessModes = List.of();
+    fake.credentialNamesNoLocation = true;
+    try (DeltaSharingCatalogClient client = client(fake)) {
+      assertThatThrownBy(() -> client.loadTable(events()))
+          .isInstanceOf(CatalogAccessException.class);
+    }
+  }
+
+  /** The vend runs per resolve with a fresh client, so it must not page a schema to find one. */
+  @Test
+  void vendingDoesNotPageTheSchemaLookingForALocation() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.metadataLocation = Optional.empty();
+    try (DeltaSharingCatalogClient client = client(fake)) {
+      client.vendStorageCredentials(events());
+    }
+    assertThat(fake.listTablesCalls).isZero();
+  }
+
+  /** The knob governs the ambiguous case; a table stating dir is not ambiguous. */
+  @Test
+  void strictModeStillLoadsATableThatStatesDirectoryAccess() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.accessModes = List.of(AccessMode.DIR);
+    fake.listedLocation = Optional.empty();
+    fake.metadataLocation = Optional.empty();
+    try (DeltaSharingCatalogClient client =
+        new DeltaSharingCatalogClient(fake, Map.of(), true, new RecordingProbe())) {
+      assertThat(client.loadTable(events()).storageLocation()).contains(LOCATION);
+    }
+  }
+
+  /**
+   * The probe addresses S3 and the vend publishes an AWS session, so a table elsewhere would load,
+   * reconcile, and fail at every scan -- the unreadable materialized table by another route.
+   */
+  @Test
+  void aTableOnACloudThisProviderCannotReadIsRefused() {
+    for (String elsewhere :
+        List.of("abfss://c@a.dfs.core.windows.net/gold/events", "gs://sharing/gold/events")) {
+      FakeSharingClient fake = new FakeSharingClient();
+      fake.listedLocation = Optional.of(elsewhere);
+      fake.metadataLocation = Optional.of(elsewhere);
+      try (DeltaSharingCatalogClient client = client(fake)) {
+        assertThatThrownBy(() -> client.loadTable(events()))
+            .describedAs("%s", elsewhere)
+            .isInstanceOfSatisfying(
+                CatalogAccessException.class,
+                failure -> {
+                  assertThat(failure.code()).isEqualTo(CatalogAccessException.Code.UNSUPPORTED);
+                  assertThat(failure.getMessage()).contains("cannot read");
+                });
+      }
+    }
+  }
+
+  /**
+   * The refusal reaches operator logs through the throwable the reconciler records, and the
+   * location is the server's: a query is a signature or a SAS token, userinfo is a password, and a
+   * newline forges a log line. The scheme answers which cloud and can hold none of them.
+   */
+  @Test
+  void refusingACloudNamesTheSchemeAndNotTheLocation() {
+    String withSecrets = "abfss://user:pa55word@a.dfs.core.windows.net/gold/events?sig=SECRET-SAS";
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.listedLocation = Optional.of(withSecrets);
+    fake.metadataLocation = Optional.of(withSecrets);
+    try (DeltaSharingCatalogClient client = client(fake)) {
+      assertThatThrownBy(() -> client.loadTable(events()))
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure -> {
+                assertThat(failure.getMessage()).contains("abfss");
+                assertThat(failure.getMessage())
+                    .doesNotContain("SECRET-SAS", "pa55word", "a.dfs.core.windows.net");
+              });
+    }
+  }
+
+  /**
+   * The load's speculative ask is the same question the vend asks, so it is classified the same
+   * way: a server with no credential endpoint is an unsupported capability, not a missing table.
+   */
+  @Test
+  void aServerWithoutTheCredentialEndpointIsUnsupportedOnTheLoadPathToo() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.listedLocation = Optional.empty();
+    fake.metadataLocation = Optional.empty();
+    fake.credentialFailure = DeltaSharingException.Failure.NOT_FOUND;
+    try (DeltaSharingCatalogClient client = client(fake)) {
+      assertThatThrownBy(() -> client.loadTable(events()))
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure ->
+                  assertThat(failure.code()).isEqualTo(CatalogAccessException.Code.UNSUPPORTED));
+    }
+  }
+
+  /**
+   * The same answer from the same server, classified the same way whichever path asked. Gating this
+   * on whether the table stated its modes would make one refusal a capability boundary on one path
+   * and a configuration error on the other.
+   */
+  @Test
+  void theSameCredentialRefusalIsClassifiedAlikeOnBothPaths() {
+    for (DeltaSharingException.Failure refusal :
+        List.of(
+            DeltaSharingException.Failure.NOT_FOUND,
+            DeltaSharingException.Failure.INVALID_REQUEST)) {
+      FakeSharingClient onVend = new FakeSharingClient();
+      onVend.accessModes = List.of(AccessMode.DIR);
+      onVend.credentialFailure = refusal;
+      onVend.credentialStatus = refusal == DeltaSharingException.Failure.NOT_FOUND ? 404 : 400;
+      FakeSharingClient onLoad = new FakeSharingClient();
+      onLoad.accessModes = List.of(AccessMode.DIR);
+      onLoad.listedLocation = Optional.empty();
+      onLoad.metadataLocation = Optional.empty();
+      onLoad.credentialFailure = refusal;
+      onLoad.credentialStatus = refusal == DeltaSharingException.Failure.NOT_FOUND ? 404 : 400;
+      try (DeltaSharingCatalogClient vending = client(onVend);
+          DeltaSharingCatalogClient loading = client(onLoad)) {
+        assertThatThrownBy(() -> vending.vendStorageCredentials(events()))
+            .describedAs("vend %s", refusal)
+            .isInstanceOfSatisfying(
+                CatalogAccessException.class,
+                failure ->
+                    assertThat(failure.code()).isEqualTo(CatalogAccessException.Code.UNSUPPORTED));
+        assertThatThrownBy(() -> loading.loadTable(events()))
+            .describedAs("load %s", refusal)
+            .isInstanceOfSatisfying(
+                CatalogAccessException.class,
+                failure ->
+                    assertThat(failure.code()).isEqualTo(CatalogAccessException.Code.UNSUPPORTED));
+      }
+    }
+  }
+
+  /**
+   * A stated location has to be reachable with the credential the server answered with.
+   *
+   * <p>Where both are known and disjoint, reconciling the stated one materialises a table every
+   * read of which is scoped elsewhere, and validation is optional so nothing else need catch it.
+   * The vend makes this comparison for a location the metaData action states; this covers the
+   * surface the vend cannot see.
+   */
+  @Test
+  void aStatedLocationTheCredentialDoesNotReachIsRefused() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.accessModes = List.of();
+    fake.metadataAccessModes = List.of();
+    fake.listedLocation = Optional.of("s3://sharing/gold/events");
+    fake.metadataLocation = Optional.empty();
+    fake.credentials =
+        new TemporaryCredentials(
+            CredentialCloud.AWS,
+            "s3://sharing/silver/elsewhere",
+            Optional.of("AKIA"),
+            Optional.of("secret"),
+            Optional.of("session"),
+            Optional.of(Instant.parse("2026-01-01T00:00:00Z")));
+    try (DeltaSharingCatalogClient client =
+        new DeltaSharingCatalogClient(fake, Map.of(), false, new RecordingProbe())) {
+      assertThatThrownBy(() -> client.loadTable(events()))
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure ->
+                  assertThat(failure.code())
+                      .isEqualTo(CatalogAccessException.Code.CREDENTIAL_SCOPE_INVALID));
+    }
+  }
+
+  /** A credential scoped above the stated location still reaches it, and is left alone. */
+  @Test
+  void aStatedLocationUnderABroaderCredentialScopeIsAccepted() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.accessModes = List.of();
+    fake.metadataAccessModes = List.of();
+    fake.listedLocation = Optional.of(LOCATION);
+    fake.metadataLocation = Optional.empty();
+    fake.credentials =
+        new TemporaryCredentials(
+            CredentialCloud.AWS,
+            "s3://sharing/gold",
+            Optional.of("AKIA"),
+            Optional.of("secret"),
+            Optional.of("session"),
+            Optional.of(Instant.parse("2026-01-01T00:00:00Z")));
+    try (DeltaSharingCatalogClient client =
+        new DeltaSharingCatalogClient(fake, Map.of(), false, new RecordingProbe())) {
+      assertThat(client.loadTable(events()).storageLocation()).contains(LOCATION);
+    }
+  }
+
+  /**
+   * A credential scoped to a bucket is the table's root.
+   *
+   * <p>The protocol answers a request naming no location with the table's main location, and a
+   * Delta table may sit directly at a bucket root -- {@code deltaLogPrefix("")} answers {@code
+   * _delta_log/} for that case. Whether the scope matches where the table lives is settled by
+   * reading the Delta log under it, which validation does; the shape of the path cannot settle it,
+   * and a load that refused on shape would skip tables validation reports as readable.
+   */
+  @Test
+  void aCredentialScopedToAWholeBucketIsTakenAsTheTableRoot() {
+    FakeSharingClient fake = new FakeSharingClient();
+    fake.accessModes = List.of(AccessMode.DIR);
+    fake.listedLocation = Optional.empty();
+    fake.metadataLocation = Optional.empty();
+    fake.credentials =
+        new TemporaryCredentials(
+            CredentialCloud.AWS,
+            "s3://sharing-bucket/",
+            Optional.of("AKIA"),
+            Optional.of("secret"),
+            Optional.of("session"),
+            Optional.of(Instant.parse("2026-01-01T00:00:00Z")));
+    try (DeltaSharingCatalogClient client =
+        new DeltaSharingCatalogClient(fake, Map.of(), false, new RecordingProbe())) {
+      assertThat(client.loadTable(events()).storageLocation()).contains("s3://sharing-bucket/");
+    }
+  }
+
+  /** A sharing server whose answers each test bends to the one shape it is about. */
+  private static final class FakeSharingClient implements DeltaSharingClient {
+
+    private Optional<String> tableId = Optional.of("tbl-1");
+    private Optional<String> metadataId = Optional.of("tbl-1");
+    private String schemaName = "gold";
+    private Optional<String> shareId = Optional.of("share-uuid");
+    private List<String> auxiliaryLocations = List.of();
+    private List<String> listedAuxiliaryLocations = List.of();
+    // Null means "same as the listing", which is what a delta-format server does: it states the
+    // modes in both places. A test sets this only to make the two disagree.
+    private List<AccessMode> metadataAccessModes;
+    private List<AccessMode> accessModes = List.of(AccessMode.URL, AccessMode.DIR);
+    private Optional<String> listedLocation = Optional.of(LOCATION);
+    private Optional<String> metadataLocation = Optional.of(LOCATION);
+    private DeltaSharingException.Failure failure;
+    private DeltaSharingException.Failure credentialFailure;
+    private int credentialStatus;
+    private int credentialCalls;
+    private boolean credentialNamesNoLocation;
+    private TemporaryCredentials credentials =
+        new TemporaryCredentials(
+            CredentialCloud.AWS,
+            LOCATION,
+            Optional.of("AKIA"),
+            Optional.of("secret"),
+            Optional.of("session"),
+            Optional.of(Instant.parse("2026-01-01T00:00:00Z")));
+    private int listSharesCalls;
+    private int listTablesCalls;
+    private boolean closed;
+
+    @Override
+    public List<Share> listShares() {
+      listSharesCalls++;
+      raiseIfConfigured();
+      return List.of(new Share("prod", Optional.of("share-1")));
+    }
+
+    @Override
+    public List<Schema> listSchemas(String share) {
+      raiseIfConfigured();
+      return List.of(new Schema(share, schemaName));
+    }
+
+    @Override
+    public List<Table> listTables(String share, String schema) {
+      listTablesCalls++;
+      raiseIfConfigured();
+      List<Table> tables = new ArrayList<>();
+      tables.add(
+          new Table(
+              share,
+              schema,
+              "events",
+              tableId,
+              shareId,
+              listedLocation,
+              listedAuxiliaryLocations,
+              accessModes));
+      return tables;
+    }
+
+    @Override
+    public TableDescription describeTable(String share, String schema, String table) {
+      raiseIfConfigured();
+      return new TableDescription(
+          new Protocol(1, List.of()),
+          new TableMetadata(
+              metadataId,
+              Optional.of(table),
+              "parquet",
+              "{\"type\":\"struct\",\"fields\":[]}",
+              List.of("day"),
+              Map.of(),
+              Optional.of(12L),
+              metadataLocation,
+              auxiliaryLocations,
+              metadataAccessModes == null ? accessModes : metadataAccessModes),
+          Optional.of(12L));
+    }
+
+    @Override
+    public TemporaryCredentials temporaryTableCredentials(
+        String share, String schema, String table, String location) {
+      credentialCalls++;
+      raiseIfConfigured();
+      if (credentialFailure != null) {
+        throw new DeltaSharingException(
+            credentialFailure, credentialStatus, "configured for " + credentialFailure);
+      }
+      if (credentialNamesNoLocation) {
+        // The record forbids a blank location, so this stands in for a server naming none by
+        // answering somewhere the client's own filter will not accept as the table's.
+        throw new DeltaSharingException(
+            DeltaSharingException.Failure.INVALID_RESPONSE, 200, "named no location");
+      }
+      return credentials;
+    }
+
+    @Override
+    public void close() {
+      closed = true;
+    }
+
+    private void raiseIfConfigured() {
+      if (failure != null) {
+        throw new DeltaSharingException(failure, 0, "configured for " + failure);
+      }
+    }
+  }
+}

--- a/catalog-access/delta-sharing/src/test/java/ai/floedb/floecat/catalog/sharing/DeltaSharingClientProviderTest.java
+++ b/catalog-access/delta-sharing/src/test/java/ai/floedb/floecat/catalog/sharing/DeltaSharingClientProviderTest.java
@@ -1,0 +1,325 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.catalog.sharing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+import ai.floedb.floecat.catalog.access.CatalogAccessException;
+import ai.floedb.floecat.catalog.access.CatalogAuthentication;
+import ai.floedb.floecat.catalog.access.CatalogAuthenticationScheme;
+import ai.floedb.floecat.catalog.access.CatalogClient;
+import ai.floedb.floecat.catalog.access.CatalogClientProvider;
+import ai.floedb.floecat.catalog.access.CatalogConnectionConfig;
+import ai.floedb.floecat.catalog.access.CatalogProtocol;
+import ai.floedb.floecat.catalog.access.ResolvedCatalogCredentials;
+import ai.floedb.floecat.client.sharing.DeltaSharingClient;
+import ai.floedb.floecat.http.guards.HttpEndpointGuards;
+import java.net.URI;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceLoader;
+import org.junit.jupiter.api.Test;
+
+class DeltaSharingClientProviderTest {
+
+  @Test
+  void serviceLoaderFindsTheProviderForItsProtocol() {
+    assertThat(ServiceLoader.load(CatalogClientProvider.class))
+        .filteredOn(provider -> provider.protocol() == CatalogProtocol.DELTA_SHARING)
+        .hasSize(1)
+        .allSatisfy(
+            provider -> assertThat(provider).isInstanceOf(DeltaSharingClientProvider.class));
+  }
+
+  @Test
+  void aResolvedTokenAndTheDefaultTimeoutsReachTheRecipient() {
+    Recording recording = new Recording();
+    try (CatalogClient client =
+        new DeltaSharingClientProvider(recording)
+            .open(config(Map.of()), credentials("recipient"))) {
+      assertThat(client).isInstanceOf(DeltaSharingCatalogClient.class);
+    }
+    assertThat(recording.endpoint).isEqualTo(URI.create("https://sharing.example/delta-sharing"));
+    assertThat(recording.bearerToken).isEqualTo("recipient");
+    assertThat(recording.connectTimeout).isEqualTo(Duration.ofSeconds(10));
+    assertThat(recording.requestTimeout).isEqualTo(Duration.ofSeconds(30));
+  }
+
+  @Test
+  void noReaderFeatureIsClaimedUnlessAnOperatorOptsIn() {
+    Recording recording = new Recording();
+    new DeltaSharingClientProvider(recording).open(config(Map.of()), credentials("recipient"));
+    assertThat(recording.readerFeatures).isEmpty();
+
+    Recording opted = new Recording();
+    new DeltaSharingClientProvider(opted)
+        .open(
+            config(Map.of("delta.sharing.reader-features", "deletionVectors, columnMapping")),
+            credentials("recipient"));
+    assertThat(opted.readerFeatures).containsExactly("deletionVectors", "columnMapping");
+  }
+
+  @Test
+  void onlyTheStoragePropertiesAnObjectStoreNeedsAreCarriedThrough() {
+    Recording recording = new Recording();
+    DeltaSharingCatalogClient client =
+        (DeltaSharingCatalogClient)
+            new DeltaSharingClientProvider(recording)
+                .open(
+                    config(
+                        Map.of(
+                            "s3.endpoint", "https://minio.internal:9000",
+                            "s3.region", "us-east-1",
+                            "unrelated", "value")),
+                    credentials("recipient"));
+    assertThat(client.storageProperties())
+        .containsOnlyKeys("s3.endpoint", "s3.region")
+        .containsEntry("s3.region", "us-east-1");
+  }
+
+  @Test
+  void theStrictAccessModeSettingIsOffUnlessAnOperatorTurnsItOn() {
+    Recording recording = new Recording();
+    DeltaSharingCatalogClient asking =
+        (DeltaSharingCatalogClient)
+            new DeltaSharingClientProvider(recording)
+                .open(config(Map.of()), credentials("recipient"));
+    assertThat(asking.strictAccessModes()).isFalse();
+
+    DeltaSharingCatalogClient strict =
+        (DeltaSharingCatalogClient)
+            new DeltaSharingClientProvider(recording)
+                .open(
+                    config(Map.of(DeltaSharingCatalogClient.STRICT_ACCESS_MODES, "TRUE")),
+                    credentials("recipient"));
+    assertThat(strict.strictAccessModes()).isTrue();
+  }
+
+  @Test
+  void aStrictAccessModeSettingThatIsNeitherTrueNorFalseIsReported() {
+    assertThatThrownBy(
+            () ->
+                new DeltaSharingClientProvider(new Recording())
+                    .open(
+                        config(Map.of(DeltaSharingCatalogClient.STRICT_ACCESS_MODES, "yes")),
+                        credentials("recipient")))
+        .isInstanceOfSatisfying(
+            CatalogAccessException.class,
+            failure -> {
+              assertThat(failure.code())
+                  .isEqualTo(CatalogAccessException.Code.INVALID_CONFIGURATION);
+              assertThat(failure.getMessage())
+                  .contains(DeltaSharingCatalogClient.STRICT_ACCESS_MODES);
+            });
+  }
+
+  /**
+   * The storage endpoint is held to the gate the Unity provider uses, for the same reason: this
+   * vend publishes an AWS session token, which travels in a header and is replayable, and {@code
+   * s3.endpoint} travels on to query workers.
+   */
+  @Test
+  void refusesAStorageEndpointThatIsCleartextOrNamesAnAddressClassThatIsNotAllowed() {
+    DeltaSharingClientProvider provider = new DeltaSharingClientProvider(new Recording());
+
+    for (String refused :
+        List.of(
+            "http://minio.internal:9000", "https://169.254.169.254", "not-a-uri", "/no/scheme")) {
+      assertThatThrownBy(
+              () -> provider.open(config(Map.of("s3.endpoint", refused)), credentials("recipient")))
+          .describedAs("%s", refused)
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure ->
+                  assertThat(failure.code())
+                      .isEqualTo(CatalogAccessException.Code.INVALID_CONFIGURATION));
+    }
+
+    // HTTPS needs no opt-in.
+    provider
+        .open(config(Map.of("s3.endpoint", "https://storage.example")), credentials("recipient"))
+        .close();
+
+    System.setProperty(HttpEndpointGuards.ALLOW_CLEARTEXT_S3_PROPERTY, "true");
+    try {
+      provider
+          .open(
+              config(Map.of("s3.endpoint", "http://minio.internal:9000")), credentials("recipient"))
+          .close();
+    } finally {
+      System.clearProperty(HttpEndpointGuards.ALLOW_CLEARTEXT_S3_PROPERTY);
+    }
+  }
+
+  /**
+   * The transport's own message survives. Naming a property here was wrong: its constructor raises
+   * IllegalArgumentException for the endpoint gates and the response limits as well as for a reader
+   * feature, so an operator pointing at an http:// endpoint was told about a property they had
+   * never set.
+   */
+  @Test
+  void aTransportRefusalKeepsItsOwnMessage() {
+    DeltaSharingClientProvider.ClientFactory refusing =
+        (endpoint, token, connect, read, features) -> {
+          throw new IllegalArgumentException("Delta reader feature must be letters: x;y");
+        };
+    assertThatThrownBy(
+            () ->
+                new DeltaSharingClientProvider(refusing)
+                    .open(
+                        config(Map.of(DeltaSharingClientProvider.READER_FEATURES, "x;y")),
+                        credentials("recipient")))
+        .isInstanceOfSatisfying(
+            CatalogAccessException.class,
+            failure -> {
+              assertThat(failure.code())
+                  .isEqualTo(CatalogAccessException.Code.INVALID_CONFIGURATION);
+              assertThat(failure.getMessage()).contains("Delta reader feature must be letters");
+              assertThat(failure.getMessage())
+                  .doesNotContain(DeltaSharingClientProvider.READER_FEATURES);
+            });
+  }
+
+  /** A registry mis-dispatch is cheap to refuse, and the Unity provider refuses it too. */
+  @Test
+  void aConfigForAnotherProtocolIsRefused() {
+    assertThatThrownBy(
+            () ->
+                new DeltaSharingClientProvider(new Recording())
+                    .open(
+                        new CatalogConnectionConfig(
+                            CatalogProtocol.UNITY_CATALOG,
+                            URI.create("https://sharing.example/delta-sharing"),
+                            Map.of(),
+                            new CatalogAuthentication(
+                                CatalogAuthenticationScheme.OAUTH2, Map.of())),
+                        credentials("recipient")))
+        .isInstanceOfSatisfying(
+            CatalogAccessException.class,
+            failure ->
+                assertThat(failure.code())
+                    .isEqualTo(CatalogAccessException.Code.INVALID_CONFIGURATION));
+  }
+
+  @Test
+  void aSchemeOtherThanBearerIsAConfigurationError() {
+    assertThatThrownBy(
+            () ->
+                new DeltaSharingClientProvider(new Recording())
+                    .open(
+                        new CatalogConnectionConfig(
+                            CatalogProtocol.DELTA_SHARING,
+                            URI.create("https://sharing.example/delta-sharing"),
+                            Map.of(),
+                            CatalogAuthentication.none()),
+                        ResolvedCatalogCredentials.none()))
+        .isInstanceOfSatisfying(
+            CatalogAccessException.class,
+            failure -> {
+              assertThat(failure.code())
+                  .isEqualTo(CatalogAccessException.Code.INVALID_CONFIGURATION);
+              assertThat(failure.getMessage()).contains("NONE");
+            });
+  }
+
+  @Test
+  void anUnresolvedTokenIsAConfigurationErrorRatherThanAnAnonymousRequest() {
+    assertThatThrownBy(
+            () ->
+                new DeltaSharingClientProvider(new Recording())
+                    .open(config(Map.of()), ResolvedCatalogCredentials.none()))
+        .isInstanceOfSatisfying(
+            CatalogAccessException.class,
+            failure ->
+                assertThat(failure.code())
+                    .isEqualTo(CatalogAccessException.Code.INVALID_CONFIGURATION));
+  }
+
+  /**
+   * Arguments evaluate left to right, so resolving the flag inside the constructor call built the
+   * transport first and leaked it when the property was malformed -- once per open, which is once
+   * per vend and once per validation.
+   */
+  @Test
+  void aMalformedStrictSettingDoesNotLeaveAClientBehind() {
+    Recording recording = new Recording();
+    assertThatThrownBy(
+            () ->
+                new DeltaSharingClientProvider(recording)
+                    .open(
+                        config(Map.of(DeltaSharingCatalogClient.STRICT_ACCESS_MODES, "yes")),
+                        credentials("recipient")))
+        .isInstanceOf(CatalogAccessException.class);
+    assertThat(recording.created).isFalse();
+  }
+
+  @Test
+  void anUnreadableTimeoutIsReportedRatherThanSilentlyDefaulted() {
+    for (String bad : List.of("soon", "0", "-1")) {
+      assertThatThrownBy(
+              () ->
+                  new DeltaSharingClientProvider(new Recording())
+                      .open(config(Map.of("http.read.ms", bad)), credentials("recipient")))
+          .describedAs("http.read.ms=%s", bad)
+          .isInstanceOfSatisfying(
+              CatalogAccessException.class,
+              failure ->
+                  assertThat(failure.code())
+                      .isEqualTo(CatalogAccessException.Code.INVALID_CONFIGURATION));
+    }
+  }
+
+  private static CatalogConnectionConfig config(Map<String, String> properties) {
+    return new CatalogConnectionConfig(
+        CatalogProtocol.DELTA_SHARING,
+        URI.create("https://sharing.example/delta-sharing"),
+        properties,
+        new CatalogAuthentication(CatalogAuthenticationScheme.OAUTH2, Map.of()));
+  }
+
+  private static ResolvedCatalogCredentials credentials(String token) {
+    return new ResolvedCatalogCredentials(Map.of("token", token), Map.of(), null);
+  }
+
+  /** Captures what the provider built the recipient from, without opening a connection. */
+  private static final class Recording implements DeltaSharingClientProvider.ClientFactory {
+    private URI endpoint;
+    private String bearerToken;
+    private Duration connectTimeout;
+    private Duration requestTimeout;
+    private List<String> readerFeatures;
+    private boolean created;
+
+    @Override
+    public DeltaSharingClient create(
+        URI endpoint,
+        String bearerToken,
+        Duration connectTimeout,
+        Duration requestTimeout,
+        List<String> readerFeatures) {
+      this.endpoint = endpoint;
+      this.bearerToken = bearerToken;
+      this.connectTimeout = connectTimeout;
+      this.requestTimeout = requestTimeout;
+      this.readerFeatures = readerFeatures;
+      this.created = true;
+      return mock(DeltaSharingClient.class);
+    }
+  }
+}

--- a/client-cli/src/main/java/ai/floedb/floecat/client/cli/IntegrationCliSupport.java
+++ b/client-cli/src/main/java/ai/floedb/floecat/client/cli/IntegrationCliSupport.java
@@ -108,7 +108,7 @@ final class IntegrationCliSupport {
       case "create" -> {
         if (args.size() < 4) {
           out.println(
-              "usage: integration create <name> <iceberg-rest|unity> <uri>"
+              "usage: integration create <name> <iceberg-rest|unity|delta-sharing> <uri>"
                   + " --auth-type <type> [--auth k=v ...] [--cred k=v ...]"
                   + " [--props k=v ...]");
           return;
@@ -647,6 +647,7 @@ final class IntegrationCliSupport {
     return switch (normalized(value)) {
       case "ICEBERG_REST", "ICEBERG-REST", "ICEBERG" -> CatalogIntegrationType.CIT_ICEBERG_REST;
       case "UNITY" -> CatalogIntegrationType.CIT_UNITY;
+      case "DELTA_SHARING", "DELTA-SHARING", "SHARING" -> CatalogIntegrationType.CIT_DELTA_SHARING;
       default -> throw new IllegalArgumentException("Unknown integration type: " + value);
     };
   }

--- a/client-cli/src/main/java/ai/floedb/floecat/client/cli/Shell.java
+++ b/client-cli/src/main/java/ai/floedb/floecat/client/cli/Shell.java
@@ -581,7 +581,7 @@ public class Shell implements Runnable {
          query fetch-scan <query_id> <table_id>
          integrations
          integration get <name|id>
-         integration create <name> <iceberg-rest|unity> <uri> --auth-type <type>
+         integration create <name> <iceberg-rest|unity|delta-sharing> <uri> --auth-type <type>
              [--auth k=v ...] [--cred k=v ...] [--props k=v ...]
          integration update <name|id> [--display <name>] [--uri <uri>] [--props k=v ...] [--etag <etag>]
          integration update-auth <name|id> --auth-type <type>

--- a/core/catalog-access-spi/src/main/java/ai/floedb/floecat/catalog/access/CatalogProtocol.java
+++ b/core/catalog-access-spi/src/main/java/ai/floedb/floecat/catalog/access/CatalogProtocol.java
@@ -20,5 +20,6 @@ package ai.floedb.floecat.catalog.access;
 public enum CatalogProtocol {
   ICEBERG_REST,
   UNITY_CATALOG,
+  DELTA_SHARING,
   AWS_GLUE
 }

--- a/core/proto/src/main/proto/floecat/integration/catalog_integration.proto
+++ b/core/proto/src/main/proto/floecat/integration/catalog_integration.proto
@@ -27,6 +27,9 @@ enum CatalogIntegrationType {
   CIT_UNSPECIFIED = 0;
   CIT_ICEBERG_REST = 1;
   CIT_UNITY = 2;
+  // A Delta Sharing recipient. Directory access only: url mode returns presigned per-file URLs
+  // rather than credentials, which the storage contract cannot represent.
+  CIT_DELTA_SHARING = 3;
 }
 
 message OAuthClientCredentialsAuthentication {

--- a/docs/catalog-integration-design.md
+++ b/docs/catalog-integration-design.md
@@ -92,10 +92,19 @@ protocol-specific values such as the Iceberg REST warehouse; secret-bearing prop
 Its immutable resource ID is operational identity; its display name is mutable metadata and must be
 unique among integrations in the account.
 
-The API initially supports Iceberg REST and Unity integration types. Authentication is required and
-represented by typed protobuf messages for OAuth client credentials, bearer tokens, AWS assume role,
-AWS access keys, and AWS SigV4. Unity initially accepts only OAuth client credentials or bearer
-authentication. The base service validates structural compatibility; endpoint and provider support
+The API supports Iceberg REST, Unity, and Delta Sharing integration types. Authentication is
+required and represented by typed protobuf messages for OAuth client credentials, bearer tokens, AWS
+assume role, AWS access keys, and AWS SigV4. Unity initially accepts only OAuth client credentials or
+bearer authentication. Delta Sharing accepts only bearer authentication, the recipient token its
+provider issued, because the sharing protocol defines no other scheme. A Delta Sharing table is
+usable only where its provider offers directory access; a share that offers url access alone returns
+presigned per-file URLs rather than credentials, which the storage contract cannot represent, and the
+vend refuses it by name. A table that states no access modes at all is asked rather than refused: the
+protocol reads an absent field as url only, and the reference server implements the credential
+endpoint while never sending the field, so holding to that reading would refuse every table on a
+server that would have answered. Setting the connection property
+`delta.sharing.strict-access-modes` to `true` restores the protocol reading and refuses without
+asking. The base service validates structural compatibility; endpoint and provider support
 remain the responsibility of the catalog-access adapter and provider.
 
 Integration type is immutable through update. The catalog URI and connection properties are mutable

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -84,7 +84,7 @@ query fetch-scan <query_id> <table_id>
 integrations
 integration list
 integration get <name|id>
-integration create <name> <iceberg-rest|unity> <uri> --auth-type <type>
+integration create <name> <iceberg-rest|unity|delta-sharing> <uri> --auth-type <type>
   [--auth k=v ...] [--cred k=v ...] [--props k=v ...]
 integration update <name|id> [--display <name>] [--uri <uri>] [--props k=v ...] [--etag <etag>]
 integration update-auth <name|id> --auth-type <type>

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -92,11 +92,12 @@ Important behavior:
 
 ### Cleartext S3 endpoints
 
-A Unity Catalog Integration may set `s3.endpoint` to reach an S3-compatible store. Floecat requires
-HTTPS there by default, because a Unity storage vend is only published when it carries an AWS
-session token: that token travels in the `X-Amz-Security-Token` header on every signed request, and
-anyone who observes it can replay it against the table's storage prefix until it expires. The value
-is also republished to reconcile and query workers, so the exposure is not limited to validation.
+A Unity Catalog or Delta Sharing Integration may set `s3.endpoint` to reach an S3-compatible store.
+Floecat requires HTTPS there by default, because a storage vend on either is only published when it
+carries an AWS session token: that token travels in the `X-Amz-Security-Token` header on every signed
+request, and anyone who observes it can replay it against the table's storage prefix until it
+expires. The value is also republished to reconcile and query workers, so the exposure is not limited
+to validation.
 
 - `FLOECAT_SECURITY_ALLOW_CLEARTEXT_S3_ENDPOINTS=true` – permits an `http://` `s3.endpoint`. Set
   this only where the network between Floecat, its workers, and the object store is trusted; MinIO
@@ -115,6 +116,81 @@ As with the catalog URI, these checks apply only to address *literals*: a hostna
 during validation, so an endpoint written as a hostname passes the address guard regardless of what
 it resolves to. That is why the bundled Compose stack, which addresses LocalStack as `localstack`,
 needs only the cleartext setting.
+
+### Delta Sharing access modes
+
+A Delta Sharing table is readable through this integration only where its provider offers directory
+access. A table that offers `url` access alone returns presigned per-file URLs rather than
+credentials, which the storage contract cannot represent, and the vend refuses it by name.
+
+A table that states no access modes at all is asked rather than refused. The protocol reads an absent
+field as `url` only, but the reference server implements the `temporary-table-credentials` endpoint
+while never sending the field, so holding to that reading refuses every table on a server that would
+have answered. Floecat attempts the vend and reports what the server says: a refusal or a missing
+endpoint becomes `CIVI_CREDENTIAL_VENDING_UNSUPPORTED` on validation, while a rejected token or an
+unreachable server is reported as itself.
+
+A table this Integration cannot read is refused when the overlay reconciles, and counted in
+`objects_skipped`, rather than materialized and left to fail at query time. That covers a table
+offering `url` access alone; a table stating no access modes under
+`delta.sharing.strict-access-modes`; a table reporting `auxiliaryLocations` on either surface, since
+the storage contract carries one credential over one scope prefix and vending only the root would
+fail at scan time on the files it does not reach; a table whose location is on a cloud this
+provider cannot vend for, meaning `abfss://`, `gs://`, or an `s3://` whose bucket cannot be read;
+and a table whose location no surface states, where the credential endpoint then refuses with a 404
+or the protocol's own 400.
+
+Two shapes nearby are not skips. Where the credential endpoint answers 200 without a location, or
+with a location the stated one is not under, the result is a classified failure rather than a
+skipped table -- a response this client cannot read is not a property of one table. And where the
+storage probe finds no Delta log object under the location, validation reports
+`CIVI_STORAGE_ACCESS_FAILED`: that means the location is not a table root -- a wrong region, a wrong
+prefix, a broadly scoped credential -- which is correctable, unlike a capability the provider does
+not have. The reason for refusing the rest is
+that a table reconciled without a storage location keeps the Integration's own catalog URI as its
+upstream reference, so it exists in the catalog and cannot be opened by anything reading object
+storage. A share offering only `url` access is therefore unsupported here, not partially supported.
+
+A table's access modes are reported by `integration validate`, which names the table and the reason
+when it refuses one. They are not stored on the reconciled table: the overlay reconciler builds a
+table's properties from the Integration and Overlay identities and the storage location, and does
+not carry the upstream properties a provider reports. That is true of every provider, not only this
+one, so reading a share's access modes means validating the Integration rather than describing the
+materialized table.
+
+- `delta.sharing.strict-access-modes=true` -- a connection property that restores the protocol
+  reading, refusing a table that states no modes without asking. Set it against a server known to
+  advertise its modes correctly, where a doomed request per table is waste. It carries a cost on
+  the vend, and against a large schema the cost is the wrong way round. Where the metaData action
+  states no modes, strict mode consults the table listing before refusing, because the listing is
+  where the protocol defines `accessModes` and the metaData spelling is the newer one -- refusing
+  without looking there would refuse a conforming table. A credential is vended on every
+  storage-authority resolve with a client that lives for that one resolve, so that fallback pages
+  the whole schema listing once per read. It is bounded by
+  `floecat.delta-sharing.max-listing-bytes` rather than unbounded, but it is a listing per read.
+  Leave this off for a share whose schemas hold many tables, or set it only against a server that
+  states modes on the metaData action, where the fallback never runs.
+- `delta.sharing.reader-features` -- a comma-separated list of Delta reader features this deployment
+  can process, empty by default. The capability header tells the server what the client can handle,
+  and claiming a feature the read path cannot process turns a refusal the server would have made
+  into a failure partway through a scan. Enforcement is the server's: the list is sent on the
+  metadata call and is not compared against the features the server reports back, so a server that
+  ignores the header is not caught here.
+- `floecat.delta-sharing.max-pages` (system property) -- maximum pages fetched by one listing,
+  default 10,000. A repeated page token is refused outright; this bound is what stops a server
+  minting a fresh one forever. Exceeding it is reported as `INVALID_RESPONSE`.
+- `floecat.delta-sharing.max-response-bytes` (system property) -- cap on a single response body,
+  default 32 MiB. A larger body is refused rather than buffered, since the endpoint is named by
+  tenant configuration.
+- `floecat.delta-sharing.max-listing-bytes` (system property) -- cap on everything one client
+  lists, across pages and across listings, default 32 MiB. The other two bounds do not compose into
+  a memory bound: ten thousand pages of thirty-two mebibytes is past any heap, and a reconcile pass
+  keeps each schema's tables for the whole of its life, so a per-listing cap would not bound the
+  pass. A table entry runs roughly three hundred bytes of JSON, nearer six hundred with a deep
+  prefix, so the default admits above sixty thousand tables across a whole share where a large real
+  share holds thousands, and the decoded records cost about as much again. Raise it for a genuinely
+  larger share; exceeding it fails the reconcile as `INVALID_RESPONSE`, which is not retried and
+  ends the pass rather than being recorded as one skipped schema.
 
 ### Reconciler deployment modes
 

--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,7 @@
       <module>catalog-access/iceberg-rest</module>
       <module>catalog-access/delta-common</module>
       <module>catalog-access/unity</module>
+      <module>catalog-access/delta-sharing</module>
       
       <!-- Connectors -->
       <module>connectors/catalogs/iceberg</module>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -244,6 +244,12 @@
 
     <dependency>
       <groupId>ai.floedb.floecat</groupId>
+      <artifactId>floecat-catalog-access-delta-sharing</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>ai.floedb.floecat</groupId>
       <artifactId>floecat-flight</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/service/src/main/java/ai/floedb/floecat/service/integration/CatalogIntegrationAccess.java
+++ b/service/src/main/java/ai/floedb/floecat/service/integration/CatalogIntegrationAccess.java
@@ -121,6 +121,7 @@ public class CatalogIntegrationAccess {
         switch (integration.getType()) {
           case CIT_ICEBERG_REST -> CatalogProtocol.ICEBERG_REST;
           case CIT_UNITY -> CatalogProtocol.UNITY_CATALOG;
+          case CIT_DELTA_SHARING -> CatalogProtocol.DELTA_SHARING;
           case CIT_UNSPECIFIED, UNRECOGNIZED ->
               throw new CatalogAccessException(
                   CatalogAccessException.Code.INVALID_CONFIGURATION,
@@ -223,13 +224,25 @@ public class CatalogIntegrationAccess {
       List.of("s3.region", "region", "client.region", "aws.region");
 
   /**
-   * The integration's properties with {@code s3.region} resolved, for Unity.
+   * Protocols whose provider probes storage itself and so needs a resolved {@code s3.region}.
    *
-   * <p>Unity only. The Iceberg REST provider reads the same map and turns {@code s3.region} into
-   * {@code client.region}, so defaulting it there would pin a region on an integration that
-   * deliberately set none and was relying on the AWS SDK's own resolution chain -- replacing a
-   * provider-managed default with this deployment's. Unity's storage validator has no such chain:
-   * without a region it assumed {@code us-east-1} and disagreed with the read path.
+   * <p>Both run the same Delta log probe, which falls back to {@code us-east-1} when the region is
+   * absent. A share whose table lives elsewhere then has its validation read answered with
+   * PermanentRedirect while the read path, which consults the endpoint, succeeds -- an Integration
+   * permanently reporting a storage-access failure that does not exist in practice.
+   */
+  private static final java.util.Set<CatalogProtocol> RESOLVES_STORAGE_REGION =
+      java.util.EnumSet.of(CatalogProtocol.UNITY_CATALOG, CatalogProtocol.DELTA_SHARING);
+
+  /**
+   * The integration's properties with {@code s3.region} resolved.
+   *
+   * <p>Only for {@link #RESOLVES_STORAGE_REGION}. The Iceberg REST provider reads the same map and
+   * turns {@code s3.region} into {@code client.region}, so defaulting it there would pin a region
+   * on an integration that deliberately set none and was relying on the AWS SDK's own resolution
+   * chain -- replacing a provider-managed default with this deployment's. The Delta log probe those
+   * two protocols share has no such chain: without a region it assumed {@code us-east-1} and
+   * disagreed with the read path.
    *
    * <p>Resolved across every spelling, not just {@code s3.region}. The provider reads only that key
    * and the validation probe builds its S3 client from it, so a region written another way has to
@@ -248,7 +261,7 @@ public class CatalogIntegrationAccess {
   private Map<String, String> withDefaultRegion(
       CatalogIntegration integration, CatalogProtocol protocol) {
     Map<String, String> properties = integration.getPropertiesMap();
-    if (protocol != CatalogProtocol.UNITY_CATALOG) {
+    if (!RESOLVES_STORAGE_REGION.contains(protocol)) {
       return properties;
     }
     String stated = null;

--- a/service/src/main/java/ai/floedb/floecat/service/integration/CatalogIntegrationsImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/integration/CatalogIntegrationsImpl.java
@@ -900,7 +900,9 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
   }
 
   private static void validateType(CatalogIntegrationType type, String corr) {
-    if (type != CatalogIntegrationType.CIT_ICEBERG_REST && type != CatalogIntegrationType.CIT_UNITY)
+    if (type != CatalogIntegrationType.CIT_ICEBERG_REST
+        && type != CatalogIntegrationType.CIT_UNITY
+        && type != CatalogIntegrationType.CIT_DELTA_SHARING)
       throw GrpcErrors.invalidArgument(corr, FIELD, Map.of("field", "type"));
   }
 
@@ -908,6 +910,14 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
       CatalogIntegrationType integrationType, CatalogAuthentication authentication, String corr) {
     var configuration = authentication.getConfigurationCase();
     if (configuration == CatalogAuthentication.ConfigurationCase.CONFIGURATION_NOT_SET) return;
+    // A Delta Sharing recipient authenticates with the token its provider issued and nothing else.
+    // The protocol defines no other scheme, so an AWS or OAuth block on one is a configuration
+    // error rather than an unused field.
+    if (integrationType == CatalogIntegrationType.CIT_DELTA_SHARING
+        && configuration != CatalogAuthentication.ConfigurationCase.BEARER) {
+      throw GrpcErrors.invalidArgument(
+          corr, FIELD, Map.of("field", "authentication.configuration"));
+    }
     if (integrationType == CatalogIntegrationType.CIT_UNITY
         && configuration != CatalogAuthentication.ConfigurationCase.OAUTH_CLIENT_CREDENTIALS
         && configuration != CatalogAuthentication.ConfigurationCase.BEARER) {

--- a/service/src/test/java/ai/floedb/floecat/service/integration/CatalogIntegrationAccessTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/integration/CatalogIntegrationAccessTest.java
@@ -66,6 +66,20 @@ class CatalogIntegrationAccessTest {
   }
 
   /**
+   * Delta Sharing runs the same Delta log probe as Unity, which falls back to us-east-1 when the
+   * region is absent. A share whose table lives elsewhere would have its validation read answered
+   * with PermanentRedirect while the read path, which consults the endpoint, succeeds.
+   */
+  @Test
+  void fillsInTheDeploymentRegionForADeltaSharingIntegrationToo() {
+    var integration = bearerIntegration(Map.of(), CatalogIntegrationType.CIT_DELTA_SHARING);
+
+    var resolved = access.resolve(integration);
+
+    assertEquals("eu-west-1", resolved.config().properties().get("s3.region"));
+  }
+
+  /**
    * Unity only. The Iceberg REST provider reads the same map and turns s3.region into
    * client.region, so defaulting it there would pin a region on an integration that deliberately
    * set none and was relying on the AWS SDK's own resolution chain.
@@ -331,6 +345,33 @@ class CatalogIntegrationAccessTest {
         assertThrows(CatalogAccessException.class, () -> access.open(integration));
 
     assertEquals(CatalogAccessException.Code.INTERNAL, error.code());
+  }
+
+  @Test
+  void resolvesADeltaSharingRecipientOntoItsProtocolAndBearerToken() {
+    var authentication =
+        CatalogAuthentication.newBuilder()
+            .setBearer(BearerAuthentication.getDefaultInstance())
+            .setCredentialsConfigured(true)
+            .setCredentialGeneration(1L)
+            .build();
+    CatalogIntegration integration =
+        integration(authentication).toBuilder()
+            .setType(CatalogIntegrationType.CIT_DELTA_SHARING)
+            .build();
+    when(credentials.resolve(integration))
+        .thenReturn(
+            Optional.of(
+                CatalogIntegrationCredentials.newBuilder()
+                    .setBearerToken(SecretValue.newBuilder().setValue("recipient"))
+                    .build()));
+
+    var resolved = access.resolve(integration);
+
+    assertEquals(CatalogProtocol.DELTA_SHARING, resolved.config().protocol());
+    assertEquals(CatalogAuthenticationScheme.OAUTH2, resolved.config().authentication().scheme());
+    assertEquals("recipient", resolved.credentials().properties().get("token"));
+    assertFalse(resolved.config().properties().containsKey("token"));
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/integration/CatalogIntegrationsImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/integration/CatalogIntegrationsImplTest.java
@@ -557,6 +557,63 @@ class CatalogIntegrationsImplTest {
   }
 
   @Test
+  void deltaSharingAcceptsARecipientBearerToken() {
+    var response =
+        service
+            .createCatalogIntegration(
+                CreateCatalogIntegrationRequest.newBuilder()
+                    .setSpec(
+                        CatalogIntegrationSpec.newBuilder()
+                            .setDisplayName("Partner Share")
+                            .setType(CatalogIntegrationType.CIT_DELTA_SHARING)
+                            .setCatalogUri("https://sharing.example/delta-sharing")
+                            .setAuthentication(
+                                CatalogAuthentication.newBuilder()
+                                    .setBearer(BearerAuthentication.getDefaultInstance())))
+                    .setCredentials(
+                        CatalogIntegrationCredentials.newBuilder()
+                            .setBearerToken(SecretValue.newBuilder().setValue("recipient")))
+                    .build())
+            .await()
+            .indefinitely();
+
+    assertEquals(CatalogIntegrationType.CIT_DELTA_SHARING, response.getIntegration().getType());
+    verify(service.integrations).createWithMeta(any());
+  }
+
+  @Test
+  void deltaSharingRejectsEveryAuthenticationExceptBearer() {
+    var schemes =
+        List.of(
+            oauthAuthentication(),
+            CatalogAuthentication.newBuilder()
+                .setAwsSigv4(AwsSigV4Authentication.newBuilder().setRegion("us-east-1"))
+                .build());
+    for (var authentication : schemes) {
+      var error =
+          assertThrows(
+              StatusRuntimeException.class,
+              () ->
+                  service
+                      .createCatalogIntegration(
+                          CreateCatalogIntegrationRequest.newBuilder()
+                              .setSpec(
+                                  CatalogIntegrationSpec.newBuilder()
+                                      .setDisplayName("Partner Share")
+                                      .setType(CatalogIntegrationType.CIT_DELTA_SHARING)
+                                      .setCatalogUri("https://sharing.example/delta-sharing")
+                                      .setAuthentication(authentication))
+                              .setCredentials(oauthCredentials())
+                              .build())
+                      .await()
+                      .indefinitely());
+
+      assertEquals(Status.Code.INVALID_ARGUMENT, error.getStatus().getCode());
+    }
+    verify(service.integrations, never()).createWithMeta(any());
+  }
+
+  @Test
   void createRejectsBlankTopLevelAssumeRoleExternalId() {
     var error =
         assertThrows(


### PR DESCRIPTION
# feat(delta-sharing): add the catalog-access provider

Stack 5 of 6. Base branch: `kw-delta-sharing-integration-04`.

## What

- `CIT_DELTA_SHARING` and its `CatalogProtocol.DELTA_SHARING` mapping. Bearer only: the protocol
  defines no other scheme.
- A table reconciles with a storage location this provider can read, or not at all. The reconciler
  stores no location for a table that reports none and leaves the Integration's own catalog URI as
  the upstream reference, so the table exists and nothing can open it. Shapes that would land there
  are refused at the load and counted in `objects_skipped` instead.
- Three surfaces are consulted for that location -- the listing, the metaData action, then the
  credential response, which is the only one the reference server uses. Validation consults the same
  three.
- The vend refuses a credential that does not reach the table, and leaves a broader one alone.
- Identity is the share id and the listing's table id, escaped so an id carrying the delimiter
  cannot collide.

## Review focus

That the load, the vend and validation agree about a table. They see different surfaces -- the vend
has only the metaData action, since a listing would mean paging the schema per read -- and the rule
is that the load must not be more permissive than the vend. Wires `-04` into the SPI, service, CLI
and docs.

## Scope

19 files changed, 3298 insertions(+), 20 deletions(-)

- `catalog-access/delta-sharing`
- `client-cli/src`
- `core/catalog-access-spi`
- `core/proto`
- `docs/catalog-integration-design.md`
- `docs/cli-reference.md`
- `docs/operations.md`
- `pom.xml`
- `service/pom.xml`
- `service/src`

Full rationale and the review history behind these changes are in #519, which this
stack replaces.
