### PR TITLE
storage/aws: wait for the DynamoDB endpoint before the table bootstrap

### DIFF
--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbTablesBootstrap.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbTablesBootstrap.java
@@ -26,6 +26,7 @@ import java.util.function.Function;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
 import software.amazon.awssdk.services.dynamodb.model.*;
 
@@ -43,6 +44,9 @@ public class DynamoDbTablesBootstrap implements KvAttributes {
 
   @ConfigProperty(name = "floecat.kv.bootstrap.wait-seconds", defaultValue = "20")
   int waitSeconds;
+
+  @ConfigProperty(name = "floecat.kv.bootstrap.connect-wait-seconds", defaultValue = "90")
+  int connectWaitSeconds;
 
   public void ensureTableExists(String tableName, boolean withTtl) {
     try {
@@ -171,14 +175,39 @@ public class DynamoDbTablesBootstrap implements KvAttributes {
     ddbJoin(client -> client.updateTimeToLive(update));
   }
 
+  // First DynamoDB call the process makes. Under `make start` this service comes up ~100ms
+  // after storage-local, which can take 15-20s to bind its port on a cold box, while the
+  // SDK's own connect retries give up in ~7s -- a cold start used to die right here with
+  // "Connection refused". Retry while the endpoint does not answer at all
+  // (SdkClientException) for up to connectWaitSeconds; an actual answer -- not-found, auth,
+  // throttling -- is an AwsServiceException and still surfaces immediately. 90s matches
+  // KvServiceDependency, which is how every other service waits for the same port.
   private boolean tableExists(String tableName) {
-    try {
-      ddbJoin(
-          client ->
-              client.describeTable(DescribeTableRequest.builder().tableName(tableName).build()));
-      return true;
-    } catch (Throwable t) {
-      return isResourceNotFound(t) ? false : rethrow(t);
+    long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(connectWaitSeconds);
+    while (true) {
+      try {
+        ddbJoin(
+            client ->
+                client.describeTable(DescribeTableRequest.builder().tableName(tableName).build()));
+        return true;
+      } catch (Throwable t) {
+        if (isResourceNotFound(t)) {
+          return false;
+        }
+        if (!isEndpointUnreachable(t) || System.nanoTime() >= deadline) {
+          return rethrow(t);
+        }
+        log.info(
+            "DynamoDB endpoint not reachable yet ({}); retrying for up to {}s",
+            rootCause(t).getMessage(),
+            connectWaitSeconds);
+        try {
+          Thread.sleep(1000);
+        } catch (InterruptedException ie) {
+          Thread.currentThread().interrupt();
+          return rethrow(t);
+        }
+      }
     }
   }
 
@@ -221,6 +250,23 @@ public class DynamoDbTablesBootstrap implements KvAttributes {
       cur = cur.getCause();
     }
     return false;
+  }
+
+  private static boolean isEndpointUnreachable(Throwable t) {
+    Throwable cur = t;
+    while (cur != null) {
+      if (cur instanceof SdkClientException) return true;
+      cur = cur.getCause();
+    }
+    return false;
+  }
+
+  private static Throwable rootCause(Throwable t) {
+    Throwable cur = t;
+    while (cur.getCause() != null) {
+      cur = cur.getCause();
+    }
+    return cur;
   }
 
   private static <T> T rethrow(Throwable t) {

--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbTablesBootstrap.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbTablesBootstrap.java
@@ -20,6 +20,10 @@ import ai.floedb.floecat.storage.kv.KvAttributes;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
+import java.net.ConnectException;
+import java.net.NoRouteToHostException;
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
@@ -175,13 +179,14 @@ public class DynamoDbTablesBootstrap implements KvAttributes {
     ddbJoin(client -> client.updateTimeToLive(update));
   }
 
-  // First DynamoDB call the process makes. Under `make start` this service comes up ~100ms
-  // after storage-local, which can take 15-20s to bind its port on a cold box, while the
-  // SDK's own connect retries give up in ~7s -- a cold start used to die right here with
-  // "Connection refused". Retry while the endpoint does not answer at all
-  // (SdkClientException) for up to connectWaitSeconds; an actual answer -- not-found, auth,
-  // throttling -- is an AwsServiceException and still surfaces immediately. 90s matches
-  // KvServiceDependency, which is how every other service waits for the same port.
+  // First DynamoDB call the process makes. In local and compose setups the DynamoDB endpoint
+  // is brought up alongside this service and can take 15-20s to bind its port on a cold box,
+  // while the SDK's own connect retries give up in ~7s -- a cold start used to die right here
+  // with "Connection refused". Retry only while the connect itself fails, for up to
+  // connectWaitSeconds; anything else -- a service answer such as not-found, auth or
+  // throttling, or a client-side failure with no connect-level cause such as an unresolvable
+  // credential chain -- surfaces immediately. A misconfigured endpoint still costs the full
+  // wait if it fails at connect level (a typo'd host looks exactly like one not up yet).
   private boolean tableExists(String tableName) {
     long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(connectWaitSeconds);
     while (true) {
@@ -252,11 +257,20 @@ public class DynamoDbTablesBootstrap implements KvAttributes {
     return false;
   }
 
+  // SdkClientException is the SDK's whole client-side family, and most of it is permanent:
+  // credential-chain failures, an unparseable endpoint override, TLS trust failures, call
+  // timeouts. Retrying those would only turn a fast, clearly-attributed startup failure into a
+  // connectWaitSeconds hang, so require a genuine connect-level root cause underneath it.
   private static boolean isEndpointUnreachable(Throwable t) {
-    Throwable cur = t;
-    while (cur != null) {
-      if (cur instanceof SdkClientException) return true;
-      cur = cur.getCause();
+    boolean sdkClient = false;
+    for (Throwable cur = t; cur != null; cur = cur.getCause()) {
+      if (cur instanceof SdkClientException) sdkClient = true;
+      if (cur instanceof ConnectException
+          || cur instanceof NoRouteToHostException
+          || cur instanceof UnknownHostException
+          || cur instanceof SocketTimeoutException) {
+        return sdkClient;
+      }
     }
     return false;
   }

--- a/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbTablesBootstrapTest.java
+++ b/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbTablesBootstrapTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.storage.kv.dynamodb;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.lang.reflect.Proxy;
+import java.net.ConnectException;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
+import software.amazon.awssdk.services.dynamodb.model.*;
+
+public class DynamoDbTablesBootstrapTest {
+
+  @Test
+  void retriesWhileEndpointUnreachable_thenSucceeds() {
+    SdkClientException unreachable =
+        SdkClientException.create(
+            "Unable to execute HTTP request", new ConnectException("Connection refused"));
+    DescribeTableResponse active =
+        DescribeTableResponse.builder()
+            .table(TableDescription.builder().tableStatus(TableStatus.ACTIVE).build())
+            .build();
+    AtomicInteger calls = new AtomicInteger();
+    DynamoDbTablesBootstrap bootstrap =
+        bootstrap(10, describeTableStub(calls, unreachable, unreachable, active));
+
+    bootstrap.ensureTableExists("tbl", false);
+
+    assertEquals(3, calls.get());
+  }
+
+  @Test
+  void givesUpAfterConnectWait() {
+    SdkClientException unreachable =
+        SdkClientException.create(
+            "Unable to execute HTTP request", new ConnectException("Connection refused"));
+    AtomicInteger calls = new AtomicInteger();
+    DynamoDbTablesBootstrap bootstrap = bootstrap(0, describeTableStub(calls, unreachable));
+
+    Throwable thrown =
+        assertThrows(Throwable.class, () -> bootstrap.ensureTableExists("tbl", false));
+
+    assertTrue(containsCause(thrown, SdkClientException.class));
+    assertEquals(1, calls.get());
+  }
+
+  @Test
+  void serviceErrorIsNotRetried() {
+    AwsServiceException notAuthorized =
+        DynamoDbException.builder().message("not authorized").build();
+    AtomicInteger calls = new AtomicInteger();
+    DynamoDbTablesBootstrap bootstrap = bootstrap(10, describeTableStub(calls, notAuthorized));
+
+    assertThrows(Throwable.class, () -> bootstrap.ensureTableExists("tbl", false));
+
+    assertEquals(1, calls.get());
+  }
+
+  private static DynamoDbTablesBootstrap bootstrap(
+      int connectWaitSeconds, DynamoDbAsyncClient ddb) {
+    DynamoDbTablesBootstrap bootstrap = new DynamoDbTablesBootstrap();
+    bootstrap.enabled = true;
+    bootstrap.waitSeconds = 1;
+    bootstrap.connectWaitSeconds = connectWaitSeconds;
+    bootstrap.ddb = ddb;
+    return bootstrap;
+  }
+
+  private static DynamoDbAsyncClient describeTableStub(
+      AtomicInteger calls, Object... responsesOrExceptions) {
+    List<Object> results = List.of(responsesOrExceptions);
+    return (DynamoDbAsyncClient)
+        Proxy.newProxyInstance(
+            DynamoDbAsyncClient.class.getClassLoader(),
+            new Class<?>[] {DynamoDbAsyncClient.class},
+            (proxy, method, args) -> {
+              if (!"describeTable".equals(method.getName())) {
+                return null;
+              }
+              int index = calls.getAndIncrement();
+              Object result = results.get(Math.min(index, results.size() - 1));
+              if (result instanceof Throwable t) {
+                return CompletableFuture.failedFuture(t);
+              }
+              return CompletableFuture.completedFuture(result);
+            });
+  }
+
+  private static boolean containsCause(Throwable t, Class<? extends Throwable> type) {
+    Throwable cur = t;
+    while (cur != null) {
+      if (type.isInstance(cur)) return true;
+      cur = cur.getCause();
+    }
+    return false;
+  }
+}

--- a/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbTablesBootstrapTest.java
+++ b/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbTablesBootstrapTest.java
@@ -64,6 +64,21 @@ public class DynamoDbTablesBootstrapTest {
   }
 
   @Test
+  void permanentClientErrorIsNotRetried() {
+    SdkClientException noCredentials =
+        SdkClientException.create(
+            "Unable to load credentials from any of the providers in the chain");
+    AtomicInteger calls = new AtomicInteger();
+    DynamoDbTablesBootstrap bootstrap = bootstrap(10, describeTableStub(calls, noCredentials));
+
+    Throwable thrown =
+        assertThrows(Throwable.class, () -> bootstrap.ensureTableExists("tbl", false));
+
+    assertTrue(containsCause(thrown, SdkClientException.class));
+    assertEquals(1, calls.get());
+  }
+
+  @Test
   void serviceErrorIsNotRetried() {
     AwsServiceException notAuthorized =
         DynamoDbException.builder().message("not authorized").build();


### PR DESCRIPTION
tableExists() is the first DynamoDB call the process makes. Under `make start` floecat-runtime is launched ~100ms after storage-local, whose emulator can take 15-20s to bind :4566 on a cold box, while the SDK's built-in connect retries give up after ~7s -- so the service died at startup with "Connection refused ... :4566 (SDK Attempt Count: 9)", the account service could then never create the control account, and the SQL suite timed out on the planner port.

Retry only while the endpoint does not answer at all (SdkClientException) for up to floecat.kv.bootstrap.connect-wait-seconds (default 90s, matching core's KvServiceDependency). A real service answer -- not-found, auth, throttling -- is an AwsServiceException and still surfaces immediately.

## Summary

Describe what this PR changes and why.

## Type of Change

- [ ] feat (new functionality)
- [x] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [ ] `make fmt`
- [] `make verify`
- [x] Added/updated tests for changed behavior

## Deployment and Compatibility

- [x] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [ ] PR is scoped and focused
- [ ] Commit messages follow conventional commit style where practical
- [ ] Documentation updated where needed
- [ ] No credentials, tokens, or secrets are included
- [ ] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

## Additional Notes

Include any follow-ups, risks, or reviewer guidance.
