### PR TITLE
test: Optimize integration-test cache resets

### DIFF
--- a/service/src/main/java/ai/floedb/floecat/service/repo/cache/PointerCache.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/cache/PointerCache.java
@@ -558,6 +558,20 @@ public final class PointerCache {
     return accountCount(Readiness.COMPLETE);
   }
 
+  /**
+   * Drops every cached pointer and complete index.
+   *
+   * <p>This is intended for test fixture resets that have cleared the underlying store directly.
+   * The next cached read repopulates the required index from that now-authoritative store.
+   */
+  public void clear() {
+    partitions.clear();
+    completeBytes.set(0L);
+    completeEntries.set(0L);
+    resident.evictPartition(key -> true);
+    resident.maximumBytes(maxBytes);
+  }
+
   public long degradedAccountCount() {
     return accountCount(Readiness.DEGRADED);
   }

--- a/service/src/test/java/ai/floedb/floecat/service/it/ConnectorIT.java
+++ b/service/src/test/java/ai/floedb/floecat/service/it/ConnectorIT.java
@@ -161,6 +161,7 @@ public class ConnectorIT {
     seeder.seedData();
     seedAccountId =
         accountRepository.getByName(TestSupport.DEFAULT_SEED_ACCOUNT).orElseThrow().getResourceId();
+    resetter.warmPointerCache(seedAccountId.getId());
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/repo/cache/CachingPointerStoreTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/cache/CachingPointerStoreTest.java
@@ -645,6 +645,19 @@ class CachingPointerStoreTest {
   }
 
   @Test
+  void clearDropsTheCompleteIndexAfterAnOutOfBandFixtureReset() {
+    String key = Keys.tablePointerByName(ACCT, "cat", "ns", "orders");
+    store.compareAndSet(key, 0L, pointer(key, "s3://old", 0L));
+    assertThat(caching.get(key)).isPresent();
+    assertThat(cache.completeAccountCount()).isEqualTo(1L);
+
+    cache.clear();
+
+    assertThat(cache.entryCount()).isZero();
+    assertThat(cache.completeAccountCount()).isZero();
+  }
+
+  @Test
   void aDeleteCannotRemoveANewerRecreationFromTheCompleteIndex() throws Exception {
     BlockingDelete store = new BlockingDelete();
     PointerCache cache = cacheFor(store);

--- a/service/src/test/java/ai/floedb/floecat/service/util/TestDataResetter.java
+++ b/service/src/test/java/ai/floedb/floecat/service/util/TestDataResetter.java
@@ -18,10 +18,13 @@ package ai.floedb.floecat.service.util;
 
 import ai.floedb.floecat.service.bootstrap.impl.SeedRunner;
 import ai.floedb.floecat.service.reconciler.jobs.durable.store.MemoryReconcileJobIndexBackend;
+import ai.floedb.floecat.service.repo.cache.PointerCache;
 import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.storage.spi.BlobStore;
+import ai.floedb.floecat.storage.spi.CachedPointerStore;
 import ai.floedb.floecat.storage.spi.PointerStore;
 import ai.floedb.floecat.storage.spi.PointerStoreKeys;
+import ai.floedb.floecat.storage.spi.RawPointerStore;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
@@ -34,7 +37,9 @@ import software.amazon.awssdk.services.dynamodb.model.ScanRequest;
 
 @ApplicationScoped
 public class TestDataResetter {
-  @Inject PointerStore ptr;
+  @Inject @RawPointerStore PointerStore ptr;
+  @Inject @CachedPointerStore PointerStore cachedPointers;
+  @Inject PointerCache pointerCache;
   @Inject BlobStore blobs;
   @Inject Instance<DynamoDbClient> dynamoDb;
   @Inject Instance<MemoryReconcileJobIndexBackend> memoryReconcileJobIndexBackend;
@@ -95,11 +100,25 @@ public class TestDataResetter {
         blobs.deletePrefix("/accounts/" + tid + "/");
       }
       blobs.deletePrefix("/accounts/");
+      if (pointerCache != null) {
+        pointerCache.clear();
+      }
 
       if (!ptr.isEmpty()) {
         ptr.dump("AFTER WIPE, NON-EMPTY");
       }
     }
+  }
+
+  /** Warms the indexes that every seeded-account test uses before its first assertion. */
+  public void warmPointerCache(String accountId) {
+    if (cachedPointers == null) {
+      return;
+    }
+    cachedPointers.listPointersByPrefix(
+        Keys.accountPointerByIdPrefix(), 1, "", new StringBuilder());
+    cachedPointers.listPointersByPrefix(
+        Keys.catalogPointerByIdPrefix(accountId), 1, "", new StringBuilder());
   }
 
   List<String> listAccountIds() {


### PR DESCRIPTION
## Summary

This speeds up integration-test fixture resets while keeping the pointer cache enabled and exercised. Test cleanup now resets the authoritative store and invalidates cached indexes once, avoiding repeated cache lock/index churn; ConnectorIT then warms its commonly used indexes after seeding.

Fixes the ConnectorIT slowdown introduced by the pointer-cache work: each test fixture reset was routing broad destructive deletes through the cache, repeatedly triggering shard-lock acquisition and complete-index invalidation/rebuilds. Resets now wipe the authoritative store directly, clear cached state once, and warm the indexes used by ConnectorIT after seeding—keeping the cache enabled and exercised for normal test operations.

## Type of Change

- [ ] feat (new functionality)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [X] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [X] `make fmt`
- [X] `make verify`
- [ ] Added/updated tests for changed behavior

## Deployment and Compatibility

- [X] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [X] PR is scoped and focused
- [X] Commit messages follow conventional commit style where practical
- [X] Documentation updated where needed
- [X] No credentials, tokens, or secrets are included
- [X] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)
