### PR TITLE
fix: preserve incomplete bounds during statistics rollup

### DIFF
--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/FileGroupTargetStatsRollup.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/FileGroupTargetStatsRollup.java
@@ -397,6 +397,8 @@ public final class FileGroupTargetStatsRollup {
     private Long nanCount;
     private String min;
     private String max;
+    private boolean minComplete = true;
+    private boolean maxComplete = true;
     private final ColumnNdv ndv = new ColumnNdv();
     private org.apache.datasketches.hll.Union hllUnion;
     private Integer hllLgK;
@@ -433,6 +435,8 @@ public final class FileGroupTargetStatsRollup {
       if (decodedLogicalType == null && !logicalType.isBlank()) {
         decodedLogicalType = LogicalTypeProtoAdapter.decodeLogicalType(logicalType);
       }
+      minComplete &= scalar.hasMin() && !scalar.getMin().isBlank();
+      maxComplete &= scalar.hasMax() && !scalar.getMax().isBlank();
       min = pickEncoded(decodedLogicalType, min, scalar.hasMin() ? scalar.getMin() : null, true);
       max = pickEncoded(decodedLogicalType, max, scalar.hasMax() ? scalar.getMax() : null, false);
       mergeNdv(scalar);
@@ -471,10 +475,10 @@ public final class FileGroupTargetStatsRollup {
       if (nanCount != null) {
         builder.setNanCount(nanCount);
       }
-      if (min != null) {
+      if (minComplete && min != null) {
         builder.setMin(min);
       }
-      if (max != null) {
+      if (maxComplete && max != null) {
         builder.setMax(max);
       }
       Ndv aggregatedNdv = aggregateNdv();

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/FileGroupTargetStatsRollupSketchTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/FileGroupTargetStatsRollupSketchTest.java
@@ -53,6 +53,64 @@ class FileGroupTargetStatsRollupSketchTest {
           .build();
 
   @Test
+  void fileRecordRollup_keepsMissingBoundsUnknown() {
+    ScalarStats complete =
+        ScalarStats.newBuilder()
+            .setDisplayName("col")
+            .setLogicalType("STRING")
+            .setRowCount(10)
+            .setMin("a")
+            .setMax("m")
+            .build();
+    ScalarStats missingUpper =
+        ScalarStats.newBuilder()
+            .setDisplayName("col")
+            .setLogicalType("STRING")
+            .setRowCount(10)
+            .setMin("n")
+            .build();
+
+    ScalarStats merged =
+        onlyScalar(
+            FileGroupTargetStatsRollup.completeSnapshotFromFileRecords(
+                TABLE,
+                1L,
+                Set.of(FloecatConnector.StatsTargetKind.COLUMN),
+                List.of(fileRecord(1L, complete), fileRecord(1L, missingUpper))));
+
+    assertTrue(merged.hasMin());
+    assertEquals("a", merged.getMin());
+    assertFalse(merged.hasMax(), "an unknown contributor maximum must remain unknown");
+
+    ScalarStats reversed =
+        onlyScalar(
+            FileGroupTargetStatsRollup.completeSnapshotFromFileRecords(
+                TABLE,
+                1L,
+                Set.of(FloecatConnector.StatsTargetKind.COLUMN),
+                List.of(fileRecord(1L, missingUpper), fileRecord(1L, complete))));
+    assertFalse(reversed.hasMax(), "bound completeness must not depend on contributor order");
+
+    ScalarStats missingLower =
+        ScalarStats.newBuilder()
+            .setDisplayName("col")
+            .setLogicalType("STRING")
+            .setRowCount(10)
+            .setMax("z")
+            .build();
+    ScalarStats lowerUnknown =
+        onlyScalar(
+            FileGroupTargetStatsRollup.completeSnapshotFromFileRecords(
+                TABLE,
+                1L,
+                Set.of(FloecatConnector.StatsTargetKind.COLUMN),
+                List.of(fileRecord(1L, complete), fileRecord(1L, missingLower))));
+    assertFalse(lowerUnknown.hasMin(), "an unknown contributor minimum must remain unknown");
+    assertTrue(lowerUnknown.hasMax());
+    assertEquals("z", lowerUnknown.getMax());
+  }
+
+  @Test
   void fileRecordRollup_mergesScalarAndThetaOnly() {
     ScalarStats s1 =
         scalarWithSketches(


### PR DESCRIPTION
## Summary

Ensures file-group statistics rollups preserve unknown lower or upper bounds when any contributing file lacks that bound. This prevents another file’s finite bound from being presented as complete and potentially causing unsafe pruning. Regression coverage verifies both lower and upper bounds and confirms the result is independent of contributor order.

## Type of Change

- [ ] feat (new functionality)
- [X] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [X] `make fmt`
- [X] `make verify`
- [X] Added/updated tests for changed behavior

## Deployment and Compatibility

- [X] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [X] PR is scoped and focused
- [X] Commit messages follow conventional commit style where practical
- [X] Documentation updated where needed
- [X] No credentials, tokens, or secrets are included
- [X] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)
